### PR TITLE
Handle sound plugin errors safely

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -26,6 +26,7 @@
 
 #include <glib.h>
 #include <string.h>
+#include <errno.h>
 
 #ifdef PLUGINS
 #include <sys/types.h>
@@ -95,8 +96,10 @@ static void OpenModule(const gchar *modname, const gchar *fullname)
 
     soundmodule = dlopen(fullname, RTLD_NOW);
     if (!soundmodule) {
-      /* FIXME: using dlerror() here causes a segfault later in the program */
-      dopelog(3, 0, "dlopen of %s failed: %s", fullname, dlerror());
+      /* Avoid calling dlerror() directly as it has been associated with
+       * crashes on some platforms.  Use strerror on errno instead so we still
+       * get a useful message without risking a segfault. */
+      dopelog(3, 0, "dlopen of %s failed: %s", fullname, g_strerror(errno));
       return;
     }
 
@@ -108,7 +111,8 @@ static void OpenModule(const gchar *modname, const gchar *fullname)
     if (ifunc) {
       AddPlugin(ifunc, soundmodule);
     } else {
-      dopelog(3, 0, "dlsym (%s) failed: %s", funcname->str, dlerror());
+      dopelog(3, 0, "dlsym (%s) failed: %s", funcname->str,
+              g_strerror(errno));
       dlclose(soundmodule);
     }
     g_string_free(funcname, TRUE);
@@ -201,7 +205,8 @@ void SoundOpen(gchar *drivername)
       g_free(err);
     }
   }
-  sound_enabled = TRUE;
+  /* Only report sound as enabled if a driver was successfully loaded. */
+  sound_enabled = (driver != NULL);
 }
 
 void SoundClose(void)
@@ -225,6 +230,7 @@ void SoundClose(void)
 #endif
   g_slist_free(driverlist);
   driverlist = NULL;
+  sound_enabled = FALSE;
 }
 
 void SoundPlay(const gchar *snd)

--- a/tests/test_sound.c
+++ b/tests/test_sound.c
@@ -1,0 +1,25 @@
+#include "sound.h"
+#include <assert.h>
+
+/* Prototype for internal plugin lookup so we can check whether a driver
+ * was found before calling SoundOpen. */
+SoundDriver *GetPlugin(const gchar *drivername);
+
+int main(void) {
+  SoundInit();
+
+  /* Opening with no name uses the first available driver, if any. */
+  SoundDriver *drv = GetPlugin(NULL);
+  SoundOpen(NULL);
+  assert(IsSoundEnabled() == (drv != NULL));
+
+  /* Closing should always disable sound. */
+  SoundClose();
+  assert(IsSoundEnabled() == FALSE);
+
+  /* Explicitly requesting a bad driver leaves sound disabled. */
+  SoundOpen("nonexistent-driver");
+  assert(IsSoundEnabled() == FALSE);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- avoid potential segfaults during plugin loading by not calling dlerror and reporting errno instead
- mark sound disabled when no plugin driver was loaded
- disable sound flag after closing all drivers
- add stub tests to verify sound_enabled and IsSoundEnabled behavior

## Testing
- `gcc tests/test_sound.c src/sound.c -I./src -o tests/test_sound` *(fails: glib.h: No such file or directory)*
- `sudo apt-get update && sudo apt-get install -y libglib2.0-dev` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68974ae0e6448326ab72ce34c48cb35d