### PR TITLE
Handle failed sound driver initialization

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -191,7 +191,13 @@ void SoundOpen(gchar *drivername)
     if (driver) {
       if (driver->open) {
         dopelog(3, 0, "Using plugin %s", driver->name);
-        driver->open();
+        /* Only enable sound if the driver opens successfully. */
+        gboolean opened = driver->open();
+        if (!opened) {
+          g_log(NULL, G_LOG_LEVEL_CRITICAL,
+                _("Failed to open sound driver \"%s\"."), driver->name);
+          driver = NULL;
+        }
       }
     } else if (drivername) {
       gchar *plugins, *err;

--- a/tests/test_sound.c
+++ b/tests/test_sound.c
@@ -4,6 +4,17 @@
 /* Prototype for internal plugin lookup so we can check whether a driver
  * was found before calling SoundOpen. */
 SoundDriver *GetPlugin(const gchar *drivername);
+void AddPlugin(SoundDriver *(*ifunc)(void), void *module);
+
+/* A dummy sound driver whose open routine always fails. */
+static gboolean failing_open(void) {
+  return FALSE;
+}
+
+static SoundDriver *failing_init(void) {
+  static SoundDriver drv = { NULL, "failing-driver", failing_open, NULL, NULL };
+  return &drv;
+}
 
 int main(void) {
   SoundInit();
@@ -19,6 +30,12 @@ int main(void) {
 
   /* Explicitly requesting a bad driver leaves sound disabled. */
   SoundOpen("nonexistent-driver");
+  assert(IsSoundEnabled() == FALSE);
+
+  /* Register a driver that fails to open and ensure sound stays disabled. */
+  SoundInit();
+  AddPlugin(failing_init, NULL);
+  SoundOpen("failing-driver");
   assert(IsSoundEnabled() == FALSE);
 
   return 0;


### PR DESCRIPTION
## Summary
- Prevent sound from being enabled when driver initialization fails and log a critical error
- Add unit test that registers a failing driver and verifies sound remains disabled

## Testing
- `gcc -Dstatic= -I src tests/test_sound.c src/sound.c src/log.c -o test_sound $(pkg-config --cflags --libs glib-2.0)` *(failed: glib-2.0 headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897549c49f88326b070434037558ae4