### PR TITLE
Disable sound by default

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -51,7 +51,10 @@ SoundDriver *sound_cocoa_init(void);
 static SoundDriver *driver = NULL;
 static GSList *driverlist = NULL;
 typedef SoundDriver *(*InitFunc)(void);
-static gboolean sound_enabled = TRUE;
+/*
+ * Sound is disabled by default until a driver is explicitly opened.
+ */
+static gboolean sound_enabled = FALSE;
 
 gchar *GetPluginList(void)
 {

--- a/tests/test_sound.c
+++ b/tests/test_sound.c
@@ -18,6 +18,8 @@ static SoundDriver *failing_init(void) {
 
 int main(void) {
   SoundInit();
+  /* Sound should start disabled until a driver is opened. */
+  assert(IsSoundEnabled() == FALSE);
 
   /* Opening with no name uses the first available driver, if any. */
   SoundDriver *drv = GetPlugin(NULL);
@@ -34,6 +36,7 @@ int main(void) {
 
   /* Register a driver that fails to open and ensure sound stays disabled. */
   SoundInit();
+  assert(IsSoundEnabled() == FALSE);
   AddPlugin(failing_init, NULL);
   SoundOpen("failing-driver");
   assert(IsSoundEnabled() == FALSE);


### PR DESCRIPTION
## Summary
- Disable sound by default until a driver successfully opens
- Update sound tests for new default disabled state

## Testing
- `gcc tests/test_sound.c src/sound.c -Dstatic= -I./src $(pkg-config --cflags --libs glib-2.0) -ldl -o tests/test_sound` *(fails: Package glib-2.0 was not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897564d7f1c8326b6dd68b5cfd1ee66