### PR TITLE
Fix SOCKS5 auth copy and add packet tests

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -438,18 +438,20 @@ void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,
     return;
   }
   conn = &NetBuf->negbuf;
-  addlen = 3 + strlen(user) + strlen(password);
+  guint userlen = strlen(user);
+  guint passlen = strlen(password);
+  addlen = 3 + userlen + passlen;
   addpt = ExpandWriteBuffer(conn, addlen, &NetBuf->error);
-  if (!addpt || strlen(user) > 255 || strlen(password) > 255) {
+  if (!addpt || userlen > 255 || passlen > 255) {
     SetError(&NetBuf->error, ET_CUSTOM, E_FULLBUF, NULL);
     NetBufCallBack(NetBuf, TRUE);
     return;
   }
   addpt[0] = 1;                 /* Subnegotiation version code */
-  addpt[1] = strlen(user);
-  strcpy(&addpt[2], user);
-  addpt[2 + strlen(user)] = strlen(password);
-  strcpy(&addpt[3 + strlen(user)], password);
+  addpt[1] = userlen;
+  memcpy(&addpt[2], user, userlen);
+  addpt[2 + userlen] = passlen;
+  memcpy(&addpt[3 + userlen], password, passlen);
 
   CommitWriteBuffer(NetBuf, conn, addpt, addlen);
 }

--- a/tests/test_socks5.c
+++ b/tests/test_socks5.c
@@ -1,0 +1,62 @@
+#include "network.h"
+#include <assert.h>
+#include <string.h>
+
+static void dummy_cb(NetworkBuffer *NetBuf, gboolean Read, gboolean Write,
+                     gboolean Exception, gboolean CallNow) {
+  (void)NetBuf; (void)Read; (void)Write; (void)Exception; (void)CallNow;
+}
+
+static void reset_connbuf(ConnBuf *buf) {
+  if (buf->Data) g_free(buf->Data);
+  buf->Data = NULL;
+  buf->Length = 0;
+  buf->DataPresent = 0;
+}
+
+int main(void) {
+  NetworkBuffer nb;
+  InitNetworkBuffer(&nb, '\n', '\0', NULL);
+  SetNetworkBufferCallBack(&nb, dummy_cb, NULL);
+
+  /* Basic credentials */
+  reset_connbuf(&nb.negbuf);
+  SendSocks5UserPasswd(&nb, "user", "pass");
+  assert(nb.negbuf.DataPresent == 3 + 4 + 4);
+  unsigned char *b = (unsigned char *)nb.negbuf.Data;
+  assert(b[0] == 1);
+  assert(b[1] == 4);
+  assert(memcmp(b + 2, "user", 4) == 0);
+  assert(b[6] == 4);
+  assert(memcmp(b + 7, "pass", 4) == 0);
+
+  /* Long credentials of length 255 */
+  reset_connbuf(&nb.negbuf);
+  char longuser[256];
+  char longpass[256];
+  memset(longuser, 'u', 255); longuser[255] = '\0';
+  memset(longpass, 'p', 255); longpass[255] = '\0';
+  SendSocks5UserPasswd(&nb, longuser, longpass);
+  assert(nb.negbuf.DataPresent == 3 + 255 + 255);
+  b = (unsigned char *)nb.negbuf.Data;
+  assert(b[0] == 1);
+  assert(b[1] == 255);
+  assert(memcmp(b + 2, longuser, 255) == 0);
+  assert(b[2 + 255] == 255);
+  assert(memcmp(b + 3 + 255, longpass, 255) == 0);
+
+  /* Boundary: credentials too long (256 chars) */
+  reset_connbuf(&nb.negbuf);
+  char too_long[257];
+  memset(too_long, 'x', 256); too_long[256] = '\0';
+  SendSocks5UserPasswd(&nb, too_long, "p");
+  assert(nb.negbuf.DataPresent == 0);
+
+  /* Boundary: empty credentials */
+  reset_connbuf(&nb.negbuf);
+  SendSocks5UserPasswd(&nb, "", "p");
+  assert(nb.negbuf.DataPresent == 0);
+
+  reset_connbuf(&nb.negbuf);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- use explicit memcpy lengths when building SOCKS5 username/password packets
- add tests exercising basic, long, and invalid SOCKS5 credential packets

## Testing
- `gcc -DNETWORKING -Isrc tests/test_socks5.c src/network.c src/error.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0 libcurl)` *(fails: Package glib-2.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975887a6e88326b3e80a909474048c