### PR TITLE
Remove legacy spy and tipoff commands

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -869,8 +869,6 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
       NewPlayer->IdleTimeout = 0;
   NewPlayer->Guns = (Inventory *)g_malloc0(NumGun * sizeof(Inventory));
   NewPlayer->Drugs = (Inventory *)g_malloc0(NumDrug * sizeof(Inventory));
-  InitList(&(NewPlayer->SpyList));
-  InitList(&(NewPlayer->TipList));
   NewPlayer->Turn = 1;
   NewPlayer->date = g_date_new_dmy(StartDate.day, StartDate.month,
                                    StartDate.year);
@@ -929,8 +927,6 @@ GSList *RemovePlayer(Player *Play, GSList *First)
   if (!IsCop(Play))
     ShutdownNetworkBuffer(&Play->NetBuf);
 #endif
-  ClearList(&(Play->SpyList));
-  ClearList(&(Play->TipList));
   g_date_free(Play->date);
   g_free(Play->Name);
   g_free(Play->Guns);
@@ -1413,100 +1409,6 @@ int GetNextDrugIndex(int OldIndex, Player *Play)
     }
   }
   return MaxIndex;
-}
-
-/* 
- * A DopeList is akin to a Vector class; it is a list of DopeEntry
- * structures, which can be dynamically extended or compressed. This
- * function initializes the newly-created list pointed to by "List"
- * (A DopeEntry contains a Player pointer and a counter, and is used
- * by the server to keep track of tipoffs and spies.)
- */
-void InitList(DopeList *List)
-{
-  List->Data = NULL;
-  List->Number = 0;
-}
-
-/* 
- * Clears the list pointed to by "List".
- */
-void ClearList(DopeList *List)
-{
-  g_free(List->Data);
-  InitList(List);
-}
-
-/* 
- * Adds a new DopeEntry (pointed to by "NewEntry") to the list "List".
- * A copy of NewEntry is placed into the list, so the original
- * structure pointed to by NewEntry can be reused.
- */
-void AddListEntry(DopeList *List, DopeEntry *NewEntry)
-{
-  if (!NewEntry || !List)
-    return;
-  List->Number++;
-  List->Data = (DopeEntry *)g_realloc(List->Data, List->Number *
-                                      sizeof(DopeEntry));
-  memmove(&(List->Data[List->Number - 1]), NewEntry, sizeof(DopeEntry));
-}
-
-/* 
- * Removes the DopeEntry at index "Index" from list "List".
- */
-void RemoveListEntry(DopeList *List, int Index)
-{
-  if (!List || Index < 0 || Index >= List->Number)
-    return;
-
-  if (Index < List->Number - 1) {
-    memmove(&(List->Data[Index]), &(List->Data[Index + 1]),
-              (List->Number - 1 - Index) * sizeof(DopeEntry));
-  }
-  List->Number--;
-  List->Data = (DopeEntry *)g_realloc(List->Data, List->Number *
-                                      sizeof(DopeEntry));
-  if (List->Number == 0)
-    List->Data = NULL;
-}
-
-/* 
- * Returns the index of the DopeEntry matching "Play" in list "List"
- * or -1 if this is not found.
- */
-int GetListEntry(DopeList *List, Player *Play)
-{
-  int i;
-
-  for (i = List->Number - 1; i >= 0; i--) {
-    if (List->Data[i].Play == Play)
-      return i;
-  }
-  return -1;
-}
-
-/* 
- * Removes (if it exists) the DopeEntry in list "List" matching "Play".
- */
-void RemoveListPlayer(DopeList *List, Player *Play)
-{
-  RemoveListEntry(List, GetListEntry(List, Play));
-}
-
-/* 
- * Similar to RemoveListPlayer, except that if the list contains "Play" more
- * than once, all the matching entries are removed, not just the first.
- */
-void RemoveAllEntries(DopeList *List, Player *Play)
-{
-  int i;
-
-  do {
-    i = GetListEntry(List, Play);
-    if (i >= 0)
-      RemoveListEntry(List, i);
-  } while (i >= 0);
 }
 
 void ResizeLocations(int NewNum)

--- a/src/dopewars.h
+++ b/src/dopewars.h
@@ -142,9 +142,6 @@ typedef enum {
 typedef enum {
   FIRSTTURN   = 1 << 0,
   DEADHARDASS = 1 << 1,
-  TIPPEDOFF   = 1 << 2,
-  SPIEDON     = 1 << 3,
-  SPYINGON    = 1 << 4,
   FIGHTING    = 1 << 5,
   CANSHOOT    = 1 << 6,
   TRADING     = 1 << 7
@@ -275,18 +272,6 @@ typedef struct INVENTORY Inventory;
 struct PLAYER_T;
 typedef struct PLAYER_T Player;
 
-struct TDopeEntry {
-  Player *Play;
-  int Turns;
-};
-typedef struct TDopeEntry DopeEntry;
-
-struct TDopeList {
-  DopeEntry *Data;
-  int Number;
-};
-typedef struct TDopeList DopeList;
-
 struct PLAYER_T {
   guint ID;
   int Turn;
@@ -302,7 +287,6 @@ struct PLAYER_T {
   time_t FightTimeout, IdleTimeout, ConnectTimeout;
   guint tiebreak;
   price_t DocPrice;
-  DopeList SpyList, TipList;
   Player *OnBehalfOf;
 #ifdef NETWORKING
   NetworkBuffer NetBuf;
@@ -384,13 +368,6 @@ void ClearInventory(Inventory *Guns, Inventory *Drugs);
 int IsCarryingRandom(Player *Play, int amount);
 void ChangeSpaceForInventory(Inventory *Guns, Inventory *Drugs,
                              Player *Play);
-void InitList(DopeList *List);
-void AddListEntry(DopeList *List, DopeEntry *NewEntry);
-void RemoveListEntry(DopeList *List, int Entry);
-int GetListEntry(DopeList *List, Player *Play);
-void RemoveListPlayer(DopeList *List, Player *Play);
-void RemoveAllEntries(DopeList *List, Player *Play);
-void ClearList(DopeList *List);
 int TotalGunsCarried(Player *Play);
 int read_string(FILE *fp, char **buf);
 int brandom(int bot, int top);

--- a/src/message.c
+++ b/src/message.c
@@ -598,52 +598,40 @@ void ReceiveInventory(char *Data, Inventory *Guns, Inventory *Drugs)
  */
 void SendPlayerData(Player *To)
 {
-  SendSpyReport(To, To);
-}
-
-/* 
- * Sends pertinent data about player "SpiedOn" from the server
- * to player "To".
- */
-void SendSpyReport(Player *To, Player *SpiedOn)
-{
   gchar *cashstr, *debtstr, *bankstr;
   GString *text;
   int i;
 
   text = g_string_new(NULL);
   g_string_printf(text, "%s^%s^%s^%d^%d^%d^%d^%d^",
-                   (cashstr = pricetostr(SpiedOn->Cash)),
-                   (debtstr = pricetostr(SpiedOn->Debt)),
-                   (bankstr = pricetostr(SpiedOn->Bank)),
-                   SpiedOn->Health, SpiedOn->CoatSize,
-                   SpiedOn->IsAt, SpiedOn->Turn, SpiedOn->Flags);
+                   (cashstr = pricetostr(To->Cash)),
+                   (debtstr = pricetostr(To->Debt)),
+                   (bankstr = pricetostr(To->Bank)),
+                   To->Health, To->CoatSize,
+                   To->IsAt, To->Turn, To->Flags);
   g_free(cashstr);
   g_free(debtstr);
   g_free(bankstr);
-  if (HaveAbility(SpiedOn, A_DATE)) {
-    g_string_append_printf(text, "%d^%d^%d^", g_date_get_day(SpiedOn->date),
-                      g_date_get_month(SpiedOn->date),
-                      g_date_get_year(SpiedOn->date));
+  if (HaveAbility(To, A_DATE)) {
+    g_string_append_printf(text, "%d^%d^%d^", g_date_get_day(To->date),
+                      g_date_get_month(To->date),
+                      g_date_get_year(To->date));
   }
   for (i = 0; i < NumGun; i++) {
-    g_string_append_printf(text, "%d^", SpiedOn->Guns[i].Carried);
+    g_string_append_printf(text, "%d^", To->Guns[i].Carried);
   }
   for (i = 0; i < NumDrug; i++) {
-    g_string_append_printf(text, "%d^", SpiedOn->Drugs[i].Carried);
+    g_string_append_printf(text, "%d^", To->Drugs[i].Carried);
   }
   if (HaveAbility(To, A_DRUGVALUE))
     for (i = 0; i < NumDrug; i++) {
       g_string_append_printf(text, "%s^",
                         (cashstr =
-                         pricetostr(SpiedOn->Drugs[i].TotalValue)));
+                         pricetostr(To->Drugs[i].TotalValue)));
       g_free(cashstr);
     }
-  g_string_append_printf(text, "%d", SpiedOn->Bitches.Carried);
-  if (To != SpiedOn)
-    SendServerMessage(SpiedOn, C_NONE, C_UPDATE, To, text->str);
-  else
-    SendServerMessage(NULL, C_NONE, C_UPDATE, To, text->str);
+  g_string_append_printf(text, "%d", To->Bitches.Carried);
+  SendServerMessage(NULL, C_NONE, C_UPDATE, To, text->str);
   g_string_free(text, TRUE);
 }
 

--- a/src/message.h
+++ b/src/message.h
@@ -39,8 +39,8 @@ typedef enum {
   C_BANK, C_QUESTION, C_UNUSED, C_HISCORE, C_STARTHISCORE, C_ENDHISCORE,
   C_BUYOBJECT, C_DONE, C_REQUESTJET, C_PAYLOAN, C_ANSWER, C_DEPOSIT, C_PUSH,
   C_QUIT = 'a',
-  C_RENAME, C_NAME, C_SACKBITCH, C_TIPOFF, C_SPYON, C_WANTQUIT,
-  C_CONTACTSPY, C_KILL, C_REQUESTSCORE, C_INIT, C_DATA,
+  C_RENAME, C_NAME, C_SACKBITCH, C_WANTQUIT,
+  C_KILL, C_REQUESTSCORE, C_INIT, C_DATA,
   C_FIGHTPRINT, C_FIGHTACT, C_TRADE, C_CHANGEDISP,
   C_NETMESSAGE, C_ABILITIES
 } MsgCode;
@@ -113,7 +113,6 @@ void SendInventory(Player *From, AICode AI, MsgCode Code, Player *To,
                    Inventory *Guns, Inventory *Drugs);
 void ReceiveInventory(char *Data, Inventory *Guns, Inventory *Drugs);
 void SendPlayerData(Player *To);
-void SendSpyReport(Player *To, Player *SpiedOn);
 void ReceivePlayerData(Player *Play, char *text, Player *From);
 void SendInitialData(Player *To);
 void ReceiveInitialData(Player *Play, char *data);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -326,7 +326,6 @@ void HandleServerMessage(gchar *buf, Player *Play)
   AICode AI;
   MsgCode Code;
   gchar *text;
-  DopeEntry NewEntry;
   int i;
   price_t money;
 
@@ -479,15 +478,6 @@ void HandleServerMessage(gchar *buf, Player *Play)
   case C_REQUESTSCORE:
     SendHighScores(Play, FALSE, NULL);
     break;
-  case C_CONTACTSPY:
-    for (list = FirstServer; list; list = g_slist_next(list)) {
-      tmp = (Player *)list->data;
-      i = GetListEntry(&(tmp->SpyList), Play);
-      if (tmp != Play && i >= 0 && tmp->SpyList.Data[i].Turns >= 0) {
-        SendSpyReport(Play, tmp);
-      }
-    }
-    break;
   case C_DEPOSIT:
     money = strtoprice(Data);
     if (Play->EventNum == E_BANK && Play->Bank + money >= 0
@@ -528,36 +518,6 @@ void HandleServerMessage(gchar *buf, Player *Play)
       SendEvent(Play);
     }
     break;
-  case C_SPYON:
-    if (Play->Cash >= Prices.Spy) {
-      dopelog(3, LF_SERVER, _("%s now spying on %s"), GetPlayerName(Play),
-              GetPlayerName(To));
-      Play->Cash -= Prices.Spy;
-      LoseBitch(Play, NULL, NULL);
-      NewEntry.Play = Play;
-      NewEntry.Turns = -1;
-      AddListEntry(&(To->SpyList), &NewEntry);
-      SendPlayerData(Play);
-    } else {
-      dopelog(2, LF_SERVER, _("%s spy on %s: DENIED"), GetPlayerName(Play),
-                GetPlayerName(To));
-    }
-    break;
-  case C_TIPOFF:
-    if (Play->Cash >= Prices.Tipoff) {
-      dopelog(3, LF_SERVER, _("%s tipped off the Amirs to %s"),
-              GetPlayerName(Play), GetPlayerName(To));
-      Play->Cash -= Prices.Tipoff;
-      LoseBitch(Play, NULL, NULL);
-      NewEntry.Play = Play;
-      NewEntry.Turns = 0;
-      AddListEntry(&(To->TipList), &NewEntry);
-      SendPlayerData(Play);
-    } else {
-      g_warning(_("%s tipoff about %s: DENIED"), GetPlayerName(Play),
-                GetPlayerName(To));
-    }
-    break;
   case C_SACKBITCH:
     if (Play->Bitches.Carried > 0) {
       LoseBitch(Play, NULL, NULL);
@@ -582,21 +542,11 @@ void HandleServerMessage(gchar *buf, Player *Play)
  */
 void ClientLeftServer(Player *Play)
 {
-  Player *tmp;
-  GSList *list;
-
   if (!IsConnectedPlayer(Play))
     return;
 
   if (Play->EventNum == E_FIGHT || Play->EventNum == E_FIGHTASK) {
     WithdrawFromCombat(Play);
-  }
-  for (list = FirstServer; list; list = g_slist_next(list)) {
-    tmp = (Player *)list->data;
-    if (tmp != Play) {
-      RemoveAllEntries(&(tmp->TipList), Play);
-      RemoveAllEntries(&(tmp->SpyList), Play);
-    }
   }
   BroadcastToClients(C_NONE, C_LEAVE, GetPlayerName(Play), Play, Play);
 }
@@ -2263,52 +2213,6 @@ void SendEvent(Player *To)
       SendServerMessage(NULL, C_NONE, C_SUBWAYFLASH, To, NULL);
       break;
     case E_OFFOBJECT:
-      To->OnBehalfOf = NULL;
-      for (i = 0; i < To->TipList.Number; i++) {
-        dopelog(3, LF_SERVER, _("%s: Tipoff from %s"), GetPlayerName(To),
-                GetPlayerName(To->TipList.Data[i].Play));
-        To->OnBehalfOf = To->TipList.Data[i].Play;
-        SendCopOffer(To, FORCECOPS);
-        return;
-      }
-      for (i = 0; i < To->SpyList.Number; i++) {
-        if (To->SpyList.Data[i].Turns < 0) {
-          dopelog(3, LF_SERVER, _("%s: Spy offered by %s"), GetPlayerName(To),
-                  GetPlayerName(To->SpyList.Data[i].Play));
-          To->OnBehalfOf = To->SpyList.Data[i].Play;
-          SendCopOffer(To, FORCEBITCH);
-          return;
-        }
-        To->SpyList.Data[i].Turns++;
-        if (To->SpyList.Data[i].Turns > 3 &&
-            brandom(0, 100) < 10 + To->SpyList.Data[i].Turns) {
-          if (TotalGunsCarried(To) > 0)
-            j = brandom(0, NUMDISCOVER);
-          else
-            j = brandom(0, NUMDISCOVER - 1);
-          text =
-              dpg_strdup_printf(_("One of your %tde was spying for %s."
-                                  "^The spy %s!"), Names.Bitches,
-                                GetPlayerName(To->SpyList.Data[i].Play),
-                                _(Discover[j]));
-          if (j != DEFECT)
-            LoseBitch(To, NULL, NULL);
-          SendPlayerData(To);
-          SendPrintMessage(NULL, C_NONE, To, text);
-          g_free(text);
-          text = g_strdup_printf(_("Your spy working with %s has "
-                                   "been discovered!^The spy %s!"),
-                                 GetPlayerName(To), _(Discover[j]));
-          if (j == ESCAPE)
-            GainBitch(To->SpyList.Data[i].Play);
-          To->SpyList.Data[i].Play->Flags &= ~SPYINGON;
-          SendPlayerData(To->SpyList.Data[i].Play);
-          SendPrintMessage(NULL, C_NONE, To->SpyList.Data[i].Play, text);
-          g_free(text);
-          RemoveListEntry(&(To->SpyList), i);
-          i--;
-        }
-      }
       if (Money > 3000000)
         i = 130;
       else if (Money > 1000000)
@@ -2443,8 +2347,6 @@ int SendCopOffer(Player *To, OfferForce Force)
     i = 100;
   else if (Force == FORCEBITCH)
     i = 0;
-  else
-    To->OnBehalfOf = NULL;
   if (i < 33) {
     return (OfferObject(To, Force == FORCEBITCH));
   } else if (i < 50) {
@@ -2938,36 +2840,6 @@ Player *GetNextShooter(Player *Play)
   return MinPlay;
 }
 
-void ResolveTipoff(Player *Play)
-{
-  GString *text;
-
-  if (IsCop(Play) || !CanRunHere(Play))
-    return;
-
-  if (g_slist_find(FirstServer, (gpointer)Play->OnBehalfOf)) {
-    dopelog(4, LF_SERVER, _("%s: tipoff by %s finished OK."),
-            GetPlayerName(Play), GetPlayerName(Play->OnBehalfOf));
-    RemoveListPlayer(&(Play->TipList), Play->OnBehalfOf);
-    text = g_string_new("");
-    if (Play->Health == 0) {
-      g_string_printf(text,
-                       _("Following your tipoff, the Seljuk Amirs ambushed %s, "
-                         "who was speared to death!"), GetPlayerName(Play));
-    } else {
-      dpg_string_printf(text,
-                         _("Following your tipoff, the Seljuk Amirs ambushed %s, "
-                           "who escaped with %d %tde. "), GetPlayerName(Play),
-                         Play->Bitches.Carried, Names.Bitches);
-    }
-    GainBitch(Play->OnBehalfOf);
-    SendPlayerData(Play->OnBehalfOf);
-    SendPrintMessage(NULL, C_NONE, Play->OnBehalfOf, text->str);
-    g_string_free(text, TRUE);
-  }
-  Play->OnBehalfOf = NULL;
-}
-
 /* 
  * Cleans up combat after player "Play" has left.
  */
@@ -2988,7 +2860,6 @@ void WithdrawFromCombat(Player *Play)
   if (!Play->FightArray)
     return;
 
-  ResolveTipoff(Play);
   FightDone = TRUE;
   for (AttackInd = 0; AttackInd < Play->FightArray->len; AttackInd++) {
     Attack = (Player *)g_ptr_array_index(Play->FightArray, AttackInd);
@@ -3010,7 +2881,6 @@ void WithdrawFromCombat(Player *Play)
     for (DefendInd = 0; DefendInd < Play->FightArray->len; DefendInd++) {
       Defend = (Player *)g_ptr_array_index(Play->FightArray, DefendInd);
       Defend->FightArray = NULL;
-      ResolveTipoff(Defend);
       if (IsCop(Defend)) {
         FirstServer = RemovePlayer(Defend, FirstServer);
       } else if (Defend->Health == 0) {
@@ -3323,22 +3193,6 @@ void HandleAnswer(Player *From, Player *To, char *answer)
   } else if (answer[0] == 'Y')
     switch (From->EventNum) {
     case E_OFFOBJECT:
-      if (g_slist_find(FirstServer, (gpointer)From->OnBehalfOf)) {
-        dopelog(3, LF_SERVER, _("%s: offer was on behalf of %s"),
-                GetPlayerName(From), GetPlayerName(From->OnBehalfOf));
-        if (From->Bitches.Price) {
-          text = dpg_strdup_printf(_("%s has accepted your %tde!"
-                                     "^Use the G key to contact your spy."),
-                                   GetPlayerName(From), Names.Bitch);
-          From->OnBehalfOf->Flags |= SPYINGON;
-          SendPlayerData(From->OnBehalfOf);
-          SendPrintMessage(NULL, C_NONE, From->OnBehalfOf, text);
-          g_free(text);
-          i = GetListEntry(&(From->SpyList), From->OnBehalfOf);
-          if (i >= 0)
-            From->SpyList.Data[i].Turns = 0;
-        }
-      }
       if (From->Bitches.Price) {
         text = g_strdup_printf("bitch^0^1");
         BuyObject(From, text);
@@ -3433,19 +3287,6 @@ void HandleAnswer(Player *From, Player *To, char *answer)
     case E_LOANSHARK:
     case E_OFFOBJECT:
     case E_WEED:
-      if (g_slist_find(FirstServer, (gpointer)From->OnBehalfOf)) {
-        dopelog(3, LF_SERVER, _("%s: offer was on behalf of %s"),
-                GetPlayerName(From), GetPlayerName(From->OnBehalfOf));
-        if (From->Bitches.Price && From->EventNum == E_OFFOBJECT) {
-          text = dpg_strdup_printf(_("%s has rejected your %tde!"),
-                                   GetPlayerName(From), Names.Bitch);
-          GainBitch(From->OnBehalfOf);
-          SendPlayerData(From->OnBehalfOf);
-          SendPrintMessage(NULL, C_NONE, From->OnBehalfOf, text);
-          g_free(text);
-          RemoveListPlayer(&(From->SpyList), From->OnBehalfOf);
-        }
-      }
       From->EventNum++;
       SendEvent(From);
       break;


### PR DESCRIPTION
## Summary
- Drop support for legacy C_SPYON and C_TIPOFF server commands
- Remove spy/tipoff bookkeeping and list management from player data
- Streamline player data updates now that spy reports are gone

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get install -y automake` *(fails: Package 'automake' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689798fb36b48326a5707a05be0964f6