### PR TITLE
Remove errands references

### DIFF
--- a/doc/clientplay.html
+++ b/doc/clientplay.html
@@ -199,22 +199,6 @@ player instead. These messages will appear in the Messages window also.</p>
 will either list the other players in the game, or the list of high scores
 maintained by the server which you're connected to.</p>
 
-<p>The "G" key activates the "give errand" command. With this you can sack one
-of your bitches (with the "G" key again), pay one to tip off the cops to one
-of the other players, or pay one to leave your employment and to join another
-player and spy on them for you. In any case, if you lose a bitch you may
-also lose any drugs or guns which they were carrying (remember that each
-bitch can carry one gun, and increases your inventory - your available space - 
-by 10).</p>
-
-<p>A tip-off means that Officer Hardass or Bob will attack your chosen
-enemy when they jet to their next location (and then you will get to hear
-the result of the encounter). A spy, on the other hand, will present himself to
-the enemy as a bargain bitch (in the same way as normal "bargain bitches"
-appear). If your enemy accepts the bitch, you will then be able to see
-everything about the enemy whenever you like, by pressing the "C" key from the
-main drug prices screen. Unfortunately, there is a chance that your spy may be
-discovered by your opponent later on...</p>
 
 <p>If, in the course of normal play, you are carrying one or more guns, and you
 jet to the a location where another player already is, you will be informed of

--- a/po/de.po
+++ b/po/de.po
@@ -535,15 +535,6 @@ msgstr "Wie sollen zwei oder mehrere Drogen bezeichnet werden?"
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() Format-String für das Anzeigen der Spielrunden"
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Kosten für das Ausspionieren eines Feindes mit einer Hure"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-"Kosten um einen Spieler mit Hilfe einer Hure an die Polizei zu verraten"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Minimaler Geldbetrag für das Anheuern einer Hure"
@@ -1235,8 +1226,8 @@ msgstr ""
 "  -h       Zeige diese Hilfe an\n"
 "  -v       Zeige Version und beende\n"
 "\n"
-"dopewars steht unter dem Copyright (C) von Ben Webb 1998-2022 und ist verö"
-"ffentlicht unter der GNU GPL\n"
+"dopewars steht unter dem Copyright (C) von Ben Webb 1998-2022 und ist "
+"veröffentlicht unter der GNU GPL\n"
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
@@ -1571,45 +1562,9 @@ msgstr "Du hast %d. "
 msgid "How many do you sell? "
 msgstr "Wieviel verkaufst du? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Wähle einen Auftrag für eine deiner %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "     S>chicke Spion zu einem anderem Dealer   (Kosten: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "     V>erpfeife ein anderen Dealer an die Cops (Kosten: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "     D>röhn dich voll"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "oder K>ontaktiere deine Spione um Meldung zu erhalten"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "oder mach N>ichts ? "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "SVDKN"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Wen willst du bespitzeln? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Wen möchtest du verpfeifen? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1875,22 +1830,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Spion berichtet für %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Spion: Drogen/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Spion: Waffen/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Tja, Du bist alleine auf der Welt!"
@@ -1940,10 +1879,6 @@ msgstr ", S>prechen, F>lüstern"
 msgid ", L>ist"
 msgstr ", L>iste"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", A>ktion"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", K>ämpfen"
@@ -1990,7 +1925,6 @@ msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "EVWSFLAKRB"
@@ -2078,22 +2012,6 @@ msgstr "/Anzeigen/der _Punkte..."
 msgid "/List/_Inventory..."
 msgstr "/Anzeigen/des _Inventars..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Aktionen"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Aktionen/_Spionieren..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Aktionen/_Verpfeifen..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Aktionen/_Spionagebericht lesen..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Hilfe"
@@ -2176,22 +2094,6 @@ msgstr ""
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Reise zu %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr ""
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Spion (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Verpfeife (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2579,28 +2481,6 @@ msgstr "Nachricht:-"
 msgid "Send"
 msgstr "Senden"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Spioniere anderen Spieler aus"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Bitte wähle einen Spieler aus den Du ausspionieren m?chtest.\n"
-"Deine %tde wird dann dem anderen Spieler ihre Dienste anbieten,\n"
-"und wenn sie erfolgreich ist, kannst du Dir die Statistik deines\n"
-"Kontrahenten im \"Spion Report\" Menu anschauen\n"
-"Aber Vorsicht %tde wird dich verlassen und %tde oder %tde mitnehmen."
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2692,11 +2572,6 @@ msgstr "Leider benutzt schon jemand anders \"deinen\" Namen, ändere Ihn bitte."
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Waffenladen Fenstertitel/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Spion berichtet"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3060,16 +2935,6 @@ msgstr "Dopewars Server"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "dopewars AI"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "entkommen"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "erwischt"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3480,26 +3345,6 @@ msgstr "Kann Bestenliste-Datei %s nicht schreiben."
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Verpfiffen von %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Spion angeboten von %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Eine deiner %tde hat für %s spioniert.^Der Spion %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Dein Spion der für %s arbeitete wurde enttarnt!^Der Spion %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3564,13 +3409,6 @@ msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr ""
 "Deinem Tipp folgend haben die Cops %s in einen Hinterhalt gelockt und "
 "abgeknallt."
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Deinem Tipp folgend haben die Cops %s in einen Hinterhalt gelockt; leider, "
-"konnte %d mit %tde entkommen."
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -528,14 +528,6 @@ msgstr ""
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr ""
@@ -1479,44 +1471,8 @@ msgstr ""
 msgid "How many do you sell? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr ""
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr ""
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr ""
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr ""
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
 msgstr ""
 
 #. Prompt for confirmation of sacking a bitch
@@ -1782,22 +1738,6 @@ msgstr ""
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr ""
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr ""
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr ""
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr ""
@@ -1847,10 +1787,6 @@ msgstr ""
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ""
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ""
@@ -1896,7 +1832,6 @@ msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr ""
@@ -1984,22 +1919,6 @@ msgstr ""
 msgid "/List/_Inventory..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr ""
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr ""
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr ""
@@ -2077,22 +1996,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:545
 #, c-format
 msgid "Jetting to %tde"
-msgstr ""
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr ""
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr ""
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
 msgstr ""
 
 #. Title of the GTK+ high score dialog
@@ -2464,23 +2367,6 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr ""
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2566,11 +2452,6 @@ msgstr ""
 #. by default)
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
-msgstr ""
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
 msgstr ""
 
 #: src/gui_client/optdialog.c:420
@@ -2933,16 +2814,6 @@ msgstr ""
 #. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
-msgstr ""
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr ""
-
-#: src/serverside.c:73
-msgid "defected"
 msgstr ""
 
 #: src/serverside.c:73
@@ -3315,26 +3186,6 @@ msgstr ""
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr ""
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr ""
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr ""
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr ""
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3396,11 +3247,6 @@ msgstr ""
 #: src/serverside.c:2954
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
-msgstr ""
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
 msgstr ""
 
 #: src/serverside.c:3024

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -526,14 +526,6 @@ msgstr ""
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr ""
@@ -1546,44 +1538,8 @@ msgstr ""
 msgid "How many do you sell? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr ""
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr ""
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr ""
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr ""
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr ""
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
 msgstr ""
 
 #. Prompt for confirmation of sacking a bitch
@@ -1849,22 +1805,6 @@ msgstr ""
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr ""
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr ""
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr ""
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr ""
@@ -1914,10 +1854,6 @@ msgstr ""
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ""
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ""
@@ -1963,7 +1899,6 @@ msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr ""
@@ -2051,22 +1986,6 @@ msgstr ""
 msgid "/List/_Inventory..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr ""
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr ""
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr ""
@@ -2144,22 +2063,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:545
 #, c-format
 msgid "Jetting to %tde"
-msgstr ""
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr ""
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr ""
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
 msgstr ""
 
 #. Title of the GTK+ high score dialog
@@ -2533,23 +2436,6 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr ""
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2635,11 +2521,6 @@ msgstr ""
 #. by default)
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
-msgstr ""
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
 msgstr ""
 
 #: src/gui_client/optdialog.c:420
@@ -3002,16 +2883,6 @@ msgstr ""
 #. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
-msgstr ""
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr ""
-
-#: src/serverside.c:73
-msgid "defected"
 msgstr ""
 
 #: src/serverside.c:73
@@ -3384,26 +3255,6 @@ msgstr ""
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr ""
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr ""
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr ""
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr ""
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3465,11 +3316,6 @@ msgstr ""
 #: src/serverside.c:2954
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
-msgstr ""
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
 msgstr ""
 
 #: src/serverside.c:3024

--- a/po/es.po
+++ b/po/es.po
@@ -544,15 +544,6 @@ msgstr "Palabra usada para designar dos o más drogas"
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar la ronda del juego"
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Coste de enviar a una puta a espiar al enemigo"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-"Coste de enviar a una puta a dar información sobre el enemigo a la policía"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Precio mínimo de contratar una puta"
@@ -1274,8 +1265,8 @@ msgstr ""
 "  -t       obligar al uso de un cliente en modo texto (curses) (por\n"
 "              omisión se usa un cliente gráfico si es posible)\n"
 "  -P nombre  establecer el nombre del jugador a \"nombre\"\n"
-"  -C FICHERO  convertir un fichero de puntuaciones en el \"formato antiguo"
-"\"               al nuevo formato\n"
+"  -C FICHERO  convertir un fichero de puntuaciones en el \"formato "
+"antiguo\"               al nuevo formato\n"
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
@@ -1619,45 +1610,9 @@ msgstr "Tiene %d. "
 msgid "How many do you sell? "
 msgstr "¿Cuánto quiere vender? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Elija un recado que encargar a una de sus %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   E>spiar a otro traficante             (precio: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   D>elatar a la policía otro traficante (precio: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   I>rse a consumir sus drogas"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "o C>ontactar con sus espias y recibir las informaciones"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "o N>o mandar ningún encargo "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "EDICN"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "¿A quién quiere espiar? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "¿A quién quiere delatar a la policía? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1922,22 +1877,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Información sobre %s de las espías"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Espía: Drogas/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Espía: Armas/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
@@ -1987,10 +1926,6 @@ msgstr ", H>ablar a todos, hablar a un J>ugador"
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", M>andar recado"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", E>nfrentarse"
@@ -2036,7 +1971,6 @@ msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "CVTHJLMEIS"
@@ -2124,22 +2058,6 @@ msgstr "/Listar/_Puntuaciones..."
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventario..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Recados"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Recados/_Espiar..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Recados/_Delatar..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Recados/_Obtener información de las espías..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Ayuda"
@@ -2222,22 +2140,6 @@ msgstr ""
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Yendo %tal"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr "%/Elemento de menú echar a una puta/E_char a una %Tde..."
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Espiar (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Delatar (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2622,28 +2524,6 @@ msgstr "Mensaje:-"
 msgid "Send"
 msgstr "Enviar"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Espiar al jugador"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Por favor, elija al jugador al quiere espiar. Su %tde ofrecerá\n"
-"sus servicios a ese jugador, y si tiene éxito, podrá ver la\n"
-"situación del jugador con el menú \"Obtener informes de las\n"
-"espías\" Recuerde que la %tde se va, así que puede perder\n"
-"todas las %tde o %tde que le esté guardando."
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2737,11 +2617,6 @@ msgstr "Desgraciadamente ya hay otro jugador usando «su» nombre. Elija otro"
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Información de las espías"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3109,16 +2984,6 @@ msgstr "servidor dopewars"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Jugador automático de dopewars"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "se escapó"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "desertó"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3556,26 +3421,6 @@ msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Delación de %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Oferta de espionaje de %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Una de sus %tde estaba espiando para %s. ^¡La espía %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "¡Su espía trabajando con %s ha sido descubierta!^¡La espía %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3639,12 +3484,6 @@ msgstr "%s: la delación de %s acabó bien."
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr ""
 "Siguiendo su delación, la policía va a por %s, ¡le disparan y es abatido!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Siguiendo su delación , la policía va a por %s, que escapa con %d %tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -542,15 +542,6 @@ msgstr "Palabra usada para designar dos o más drogas"
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar el turno del juego"
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Coste de enviar a una puta a espiar al enemigo"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-"Coste de enviar a una puta a dar información sobre el enemigo a la poli"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Precio mínimo de contratar una puta"
@@ -1274,8 +1265,8 @@ msgstr ""
 "  -t       obligar al uso de un cliente en modo texto (curses) (por\n"
 "              omisión se usa un cliente gráfico si es posible)\n"
 "  -P nombre  establecer el nombre del jugador a \"nombre\"\n"
-"  -C FICHERO  convertir un fichero de puntuaciones en el \"formato antiguo"
-"\"               al nuevo formato\n"
+"  -C FICHERO  convertir un fichero de puntuaciones en el \"formato "
+"antiguo\"               al nuevo formato\n"
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
@@ -1619,45 +1610,9 @@ msgstr "Tienes %d. "
 msgid "How many do you sell? "
 msgstr "¿Cuánto quieres vender? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Elige un recado que encargar a una de tus %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   E>spiar a otro camello                (precio: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   S>oplarse a la bofia de otro camello  (precio: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   I>rse a tomar por culo"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "o C>ontactar con tus espias y recibir las informaciones"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "o N>o mandar ningún encargo "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "ESICN"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "¿A quién quieres espiar? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "¿De quién quieres chivarte a la pasma? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1922,22 +1877,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Información sobre %s de las espías"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Espía: Drogas/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Espía: Armas/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
@@ -1987,10 +1926,6 @@ msgstr ", H>ablar a todos, hablar a un J>ugador"
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", M>andar recado"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", E>nfrentarte"
@@ -2036,7 +1971,6 @@ msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "CPTHJLMEDS"
@@ -2124,22 +2058,6 @@ msgstr "/Listar/_Puntuaciones..."
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventario..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Recados"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Recados/_Espiar..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Recados/_Chivarse a la policía..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Recados/_Obtener información de las espías..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Ayuda"
@@ -2222,22 +2140,6 @@ msgstr ""
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Yendo %tal"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr "%/Elemento de menú echar a una puta/E_char a una %Tde..."
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Espiar (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Chivarse (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2622,28 +2524,6 @@ msgstr "Mensaje:-"
 msgid "Send"
 msgstr "Enviar"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Espiar al jugador"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Por favor, elige al jugador al quieres espiar. Tu %tde ofrecerá\n"
-"sus servicios a ese jugador, y si tiene éxito, podrás ver la\n"
-"situación del jugador con el menú \"Obtener informes de las\n"
-"espías\" Recuerda que la %tde se va, así que puedes perder\n"
-"todas las %tde o %tde que te esté guardando."
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2737,11 +2617,6 @@ msgstr "Desgraciadamente ya hay otro jugador usando «tu» nombre. Elije otro"
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Información de las espías"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3109,16 +2984,6 @@ msgstr "servidor dopewars"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Jugador automático de dopewars"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "se escapó"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "desertó"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3555,26 +3420,6 @@ msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Chivatazo de %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Oferta de espionaje de %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Una de tus %tde estaba espiando para %s. ^¡La espía %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "¡Tu espía trabajando con %s ha sido descubierta!^¡La espía %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3637,11 +3482,6 @@ msgstr "%s: el chivatazo de %s acabó bien."
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr "Siguiendo tu chivatazo, la bofia va a por %s, ¡le disparan y la palma!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr "Siguiendo tu chivatazo, la pasma va a por %s, que escapa con %d %tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/fr.po
+++ b/po/fr.po
@@ -527,15 +527,6 @@ msgstr "Mot utilise pour decrire deux drogues ou plus"
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Cout pour envoyer une chienne espionner le dealer ennemi"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-"Cout pour envoyer une chienne donner des informations sur l'ennemi aux flics"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Prix minimum pour employer une salope"
@@ -1557,45 +1548,9 @@ msgstr "Tu as %d. "
 msgid "How many do you sell? "
 msgstr "Combien tu en vends? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Choisir un boulot a donner a une de tes %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   E>spionner un autre dealer              (cout: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   D>onner un autre dealer aux flics       (cout: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   A>ller se faire foutre"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "ou C>ontacter vos espions et recevoir des rapports"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "ou P>as de boulot ? "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "EDACP"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Qui tu veux espionner ?"
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Qui tu veux donner aux flics ?"
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1860,22 +1815,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Rapport des espions pour %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Esprion: Drogues/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Esprion: Flingues/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
@@ -1925,10 +1864,6 @@ msgstr ", P>arler, R>reveiller"
 msgid ", L>ist"
 msgstr ", L>lister"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", D>onner"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", C>ombattre"
@@ -1974,7 +1909,6 @@ msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "AVLPRLDCEQ"
@@ -2062,22 +1996,6 @@ msgstr "/Liste/_Scores..."
 msgid "/List/_Inventory..."
 msgstr "/Liste/_Inventaire..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Taches"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Taches/_Espionner..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Taches/_Balancer..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Taches/_Rapports des espions..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Aide"
@@ -2156,22 +2074,6 @@ msgstr "Le serveur est mort. Devient solo"
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Bouger vers %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr ""
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Espionner (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Balancer (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2553,28 +2455,6 @@ msgstr "Message:-"
 msgid "Send"
 msgstr "Envoyer"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Espionner le joueur"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Merci de choisir le joueur a espionner. Votre %tde va\n"
-"ensuite offrir ses services aux joueur, et si elle a du\n"
-"succes, vous aurez ensuite acces aux stats du joueur avec\n"
-"le menu \"Rapport des Espions\". La %tde va partir, donc\n"
-"toutes les %tde ou %tde qu'elle porte seront peut etre perdus!"
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2668,11 +2548,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Armurerie window title/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Rapport des espions"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3040,16 +2915,6 @@ msgstr "serveur dopewars"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "dopewars AI"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "enfui"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "passe a l'ennemi"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3447,26 +3312,6 @@ msgstr "Impossible d'ecrire le fichier des high scores %s"
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Balance de %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Espion offert par %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Une de tes %tde etait un espion pour %s.^L'espion %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Votre espion travaillant pour %s a ete decouvert!^L'espion %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3529,13 +3374,6 @@ msgstr "%s: balance par %s finit OK."
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr "Suivant votre balance, les flics ont pecho %s, qui est mort par balle!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Suivant votre balance, les flics ont pecho %s, qui s'est echappe avec %d "
-"%tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -532,15 +532,6 @@ msgstr "Mot utilisé pour décrire deux drogues ou plus"
 msgid "strftime() format string for displaying the game turn"
 msgstr "Chaîne de formattage strftime() pour l'affichage du tour"
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Coût pour envoyer une pute espionner le pusher ennemi"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
-"Coût pour envoyer une pute donner des informations sur l'ennemi à la police"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Prix minimum pour employer une pute"
@@ -1600,45 +1591,9 @@ msgstr "T'as %d. "
 msgid "How many do you sell? "
 msgstr "Combien que tu en vends? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Choisir une job à donner à une de tes %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   E>spionner un autre pusher              (cout: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   D>onner un autre pusher aux boeufs       (cout: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   A>ller se faire foutre"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "ou C>ontacter vos espions et recevoir leur rapports"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "ou P>as de job ? "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "EDACP"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Qui c'est que tu veux espionner ? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Qui c'est que tu veux donner aux flics ? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1904,22 +1859,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Rapports des espions pour %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Espion: Drogues/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Espion: Guns/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
@@ -1969,10 +1908,6 @@ msgstr ", P>lacotter, R>éveiller"
 msgid ", L>ist"
 msgstr ", L>ister"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", D>onner"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", C>ombattre"
@@ -2018,7 +1953,6 @@ msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "AVLPRLDCSQ"
@@ -2106,22 +2040,6 @@ msgstr "/Liste/_Scores..."
 msgid "/List/_Inventory..."
 msgstr "/Liste/_Inventaire..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Tâches"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Tâches/_Espionner..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Tâches/_Rapporter un joueur à la police..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Tâches/R_apports des espions..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Aide"
@@ -2200,22 +2118,6 @@ msgstr "Le serveur est mort. Mode solo"
 #, c-format
 msgid "Jetting to %tde"
 msgstr "S'en aller vers %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr "%/Sack Bitch menu item/_Renvoyer une pute..."
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Espionner (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Rapporter un joueur à la police (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2598,28 +2500,6 @@ msgstr "Message:-"
 msgid "Send"
 msgstr "Envoyer"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Espionner le joueur"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Merci de choisir le joueur a espionner. Votre %tde va\n"
-"ensuite offrir ses services aux joueur, et si elle a du\n"
-"succes, vous aurez ensuite acces aux stats du joueur avec\n"
-"le menu \"Rapport des Espions\". La %tde va partir, donc\n"
-"toutes les %tde ou %tde qu'elle porte seront peut etre perdus!"
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2713,11 +2593,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Marchand d'armes window title/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Rapports des espions"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3085,16 +2960,6 @@ msgstr "Serveur dopewars"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "IA dopewars"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "enfui"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "passé à l'ennemi"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3518,26 +3383,6 @@ msgstr "Impossible d'écrire le fichier des meilleurs scores %s"
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Indice de %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Espion offert par %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Une de tes %tde était un espion pour %s.^L'espion %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Votre espion travaillant pour %s a été découvert!^L'espion %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3600,13 +3445,6 @@ msgstr "%s: indice par %s finit OK."
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr "Suivant votre indice, les boeufs ont pogné %s, qui est mort par balle!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Suivant votre indice, les boeufs ont attaqué %s, qui s'est échappé avec %d "
-"%tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/nn.po
+++ b/po/nn.po
@@ -542,14 +542,6 @@ msgstr "Ord for to eller fleire slag dop"
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() formatstreng for å visa tida i spelet"
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Prisen for at ei hore skal spionera på fienden"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr "Prisen for at ei hore skal tipsa politiet om ein fiende"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Minstepris for å tilsetja ei hore"
@@ -1588,45 +1580,9 @@ msgstr "Du har %d. "
 msgid "How many do you sell? "
 msgstr "Kor mange vil du selja? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Vel eit ærend å gje ei av %tbf dine ..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   S>pionér på ein annan pushar           (pris: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   T>ipsa politiet om ein annan pushar     (pris: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   H>a seg vekk"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "eller K>ontakta spionane dine og få rapportar"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "eller I>ngenting?"
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "STHKI"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Kven vil du spionera på?"
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Kven vil du tipsa purken om?"
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1891,22 +1847,6 @@ msgstr "%-7tde  %3d"
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Spionrapportar for %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr "%/Spion: Dop/%Tde..."
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr "%/Spion: Våpen/%Tde..."
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Ingen andre spelarar er logga på no."
@@ -1956,10 +1896,6 @@ msgstr ", sN>akka med alle, snakka med E>in"
 msgid ", L>ist"
 msgstr ", sjå L>ister"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", G>je oppdrag"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", kJ>empa"
@@ -2005,7 +1941,6 @@ msgstr "Mista sambandet til tenaren! Går tilbake til einspelar-modus."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "KSHNELGJRA"
@@ -2093,22 +2028,6 @@ msgstr "/Lister/_Poeng..."
 msgid "/List/_Inventory..."
 msgstr "/Lister/_Eignelutar..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Oppdrag"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Oppdrag/_Spioner ..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Oppdrag/_Tips politiet ..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Oppdrag/_Hent spionrapportar ..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Hjelp"
@@ -2191,22 +2110,6 @@ msgstr ""
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Reiser til %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr "%/Spark hore menyval/S_park %tue..."
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Spioner (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Tips (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2590,28 +2493,6 @@ msgstr "Melding:-"
 msgid "Send"
 msgstr "Send"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Spionér på spelar"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Vel ein spelar du vil spionera på. %Tbe di vil så\n"
-"tilby tenestane sine til spelarane, og viss ho lukkast,\n"
-"vil du kunna sjå den spelaren sin status med\n"
-"«Hent spionrapportar»-menyen. Hugs at %tbe vil forlata\n"
-"deg, så %tuf eller %tuf som ho har på seg kan gå tapt!"
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2704,11 +2585,6 @@ msgstr "Diverre, nokon andre bruker «ditt» namn. Ver snill og byt det:-"
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Våpenforretning-tittel/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Spionrapportar"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3076,16 +2952,6 @@ msgstr "dopewars-tenar"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Datastyrt dopewars-spelar"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "slapp unna"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "hoppa av"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3510,26 +3376,6 @@ msgstr "Kan ikkje skriva til poengtavlefila %s"
 msgid "(R.I.P.)"
 msgstr "(Kvil i fred.)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Tips frå %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: Fekk tilbod om spion frå %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Ei av %tbf dine spionerte for %s. ^Spionen %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Spionen din hjå %s har blitt oppdaga!^Spionen %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3592,12 +3438,6 @@ msgstr "%s: Tips frå %s avslutta OK."
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr "Ut frå tipset ditt gjekk politiet mot %s, som vart skoten og drepen!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Ut frå tipset ditt rykka politiet ut mot %s, som kom seg unna med %d %tde."
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/pl.po
+++ b/po/pl.po
@@ -527,14 +527,6 @@ msgstr "Słowo określające więcej dragów"
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Koszt szpiegowania wroga przez dziwkę"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr "Koszt napuszczenia na wroga glin przez dziwkę"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Minimalna cena wynajęcia dziwki"
@@ -1546,45 +1538,9 @@ msgstr "Posiadasz %d. "
 msgid "How many do you sell? "
 msgstr "Ile sprzedajesz? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Wybierz zadanie dla jednej ze swoich %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   S>zpieguj innego dilera                 (koszt: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   Z>akapuj glinom na innego dilera        (koszt: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   W>ypieprz ją z roboty"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "albo K>ontakt ze szpiegami i raporcik"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "   N>ie ma być żadnego zlecenia ? "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "SZWKN"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Kogo chcesz szpiegować? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Na kogo chcesz nasłać gliny? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1849,22 +1805,6 @@ msgstr ""
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Szpieg złożył raport o %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr ""
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr ""
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Nie ma aktualnie innych zalogowanych graczy!"
@@ -1914,10 +1854,6 @@ msgstr " G>adaj P>owiedz "
 msgid ", L>ist"
 msgstr " Z>obacz"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr " D>aj zlecenie"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr " A>takuj"
@@ -1963,7 +1899,6 @@ msgstr "Połączenie z serwerem zerwane! Włączenie trybu dla jednego gracza"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "KSUGPZDAJW"
@@ -2051,22 +1986,6 @@ msgstr "/Zobacz/_Wynik..."
 msgid "/List/_Inventory..."
 msgstr "/Zobacz/_Plecak..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Zlecenia"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Zlecenia/_Szpiegowanie..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Zlecenia/_Zasadzka..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Zlecenia/_Raport szpiegowski..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Pomoc"
@@ -2145,22 +2064,6 @@ msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Podróż do miasta %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr ""
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Szpiegowanie (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Zasadzka (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2543,28 +2446,6 @@ msgstr "Wiadomość:-"
 msgid "Send"
 msgstr "Wyślij"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Szpieguj gracza"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Wybierz gracza, którego chcesz szpiegować. Twoja %tde\n"
-"zaoferuje wtedy swoje usługi temu graczowi, i jeżeli on się zgodzi,\n"
-"będziesz w stanie zobaczyć jego statystyki poprzez opcję\n"
-"\"Raport szpiegowski\" w menu. Pamiętaj, że %tde cię opuści\n"
-"i jakikolwiek %tde albo %tde, którą niesie, może stracić!"
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2657,11 +2538,6 @@ msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Raport szpiega"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3025,16 +2901,6 @@ msgstr ""
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr ""
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "usciekł"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "uszkodził"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3430,26 +3296,6 @@ msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Zasadzkę zrobił %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr ""
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Jeden z twoich %tde chodził za %s.^Szpieg %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Twój szpieg pracujący nad %s został odkryty!^Szpieg %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3513,12 +3359,6 @@ msgstr "%s: kablowanie %s zakończone OK."
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr ""
 "Dzięki twoim wskazówkom gliny zasadziły się na %s, który został zastrzelony"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Dzięki twoim wskazówkom gliny zasadziły się na %s, który uciekł z %d %tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -527,14 +527,6 @@ msgstr "Palavra usada para denominar duas ou mais drogas"
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:623
-msgid "Cost for a bitch to spy on the enemy"
-msgstr "Custo para as putas espionarem o inimigo"
-
-#: src/dopewars.c:626
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr "Custo para as putas atraírem os policiais ao inimigo"
-
 #: src/dopewars.c:629
 msgid "Minimum price to hire a bitch"
 msgstr "Preço mínimo para contratar uma puta"
@@ -1140,8 +1132,8 @@ msgstr ""
 "  -o addr    especifica o nome do host do server dopewars para jogar em "
 "modo\n"
 "                multiplayer (legível - ex. nenhumlugar.com - formato)\n"
-"  -s         roda em modo servidor (nota: para um servidor \"não interativo"
-"\", \n"
+"  -s         roda em modo servidor (nota: para um servidor \"não "
+"interativo\", \n"
 "                rode dopewars -s < /dev/null >> logfile & )\n"
 "  -S         roda um servidor \"privado\" (não modifica o servidor meta)\n"
 "  -p         especifica uma porta de rede para usar (padrão: 7902)\n"
@@ -1218,8 +1210,8 @@ msgstr ""
 "  -o addr    especifica o nome do host do server dopewars para jogar em "
 "modo\n"
 "                multiplayer (legível - ex. nenhumlugar.com - formato)\n"
-"  -s         roda em modo servidor (nota: para um servidor \"não interativo"
-"\", \n"
+"  -s         roda em modo servidor (nota: para um servidor \"não "
+"interativo\", \n"
 "                rode dopewars -s < /dev/null >> logfile & )\n"
 "  -S         roda um servidor \"privado\" (não modifica o servidor meta)\n"
 "  -p         especifica uma porta de rede para usar (padrão: 7902)\n"
@@ -1570,45 +1562,9 @@ msgstr "Você tem %d. "
 msgid "How many do you sell? "
 msgstr "Quantos você vai vender? "
 
-#: src/curses_client/curses_client.c:1012
-#, c-format
-msgid "Choose an errand to give one of your %tde..."
-msgstr "Escolha um trabalho para dar a uma de suas %tde..."
-
-#: src/curses_client/curses_client.c:1018
-msgid "   S>py on another dealer                  (cost: %P)"
-msgstr "   E>spionar um outro traficante           (custo: %P)"
-
-#: src/curses_client/curses_client.c:1022
-msgid "   T>ip off the cops to another dealer     (cost: %P)"
-msgstr "   A>trair policiais para outro traficante  (custo: %P)"
-
-#: src/curses_client/curses_client.c:1025
-msgid "   G>et stuffed"
-msgstr "   D>espedir"
-
 #: src/curses_client/curses_client.c:1028
 msgid "or C>ontact your spies and receive reports"
 msgstr "ou C>ontactar suas espiãs e receber informações"
-
-#: src/curses_client/curses_client.c:1030
-msgid "or N>o errand ? "
-msgstr "ou N>enhum trabalho ? "
-
-#. Translate these 5 keys to match the above options, keeping the
-#. original order the same (S>py, T>ip off, G>et stuffed, C>ontact spy,
-#. N>o errand)
-#: src/curses_client/curses_client.c:1037
-msgid "STGCN"
-msgstr "EADCN"
-
-#: src/curses_client/curses_client.c:1042
-msgid "Whom do you want to spy on? "
-msgstr "Quem você quer espiar? "
-
-#: src/curses_client/curses_client.c:1048
-msgid "Whom do you want to tip the cops off to? "
-msgstr "Para quem você quer que os policiais sejam atraídos? "
 
 #. Prompt for confirmation of sacking a bitch
 #: src/curses_client/curses_client.c:1055
@@ -1873,22 +1829,6 @@ msgstr ""
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2163
-#, c-format
-msgid "Spy reports for %s"
-msgstr "Informações de espionagem de %s"
-
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
-#: src/curses_client/curses_client.c:2169
-msgid "%/Spy: Drugs/%Tde..."
-msgstr ""
-
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2177
-msgid "%/Spy: Guns/%Tde..."
-msgstr ""
-
 #: src/curses_client/curses_client.c:2205
 msgid "No other players are currently logged on!"
 msgstr "Nenhum outro jogador está atualmente logado!"
@@ -1938,10 +1878,6 @@ msgstr ", F>alar, P>agear"
 msgid ", L>ist"
 msgstr ", J>ogadores"
 
-#: src/curses_client/curses_client.c:2514
-msgid ", G>ive"
-msgstr ", D>ar"
-
 #: src/curses_client/curses_client.c:2517
 msgid ", F>ight"
 msgstr ", L>utar"
@@ -1987,7 +1923,6 @@ msgstr "Conexão com o servidor perdida! Revertendo para o modo de um jogador"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, G>ive errand, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2633
 msgid "BSDTPLGFJQ"
 msgstr "CVLFPJDLIS"
@@ -2075,22 +2010,6 @@ msgstr "/Listar/_Pontuações..."
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventário..."
 
-#: src/gui_client/gtk_client.c:175
-msgid "/_Errands"
-msgstr "/_Trabalhos"
-
-#: src/gui_client/gtk_client.c:176
-msgid "/Errands/_Spy..."
-msgstr "/Trabalhos/_Espionar..."
-
-#: src/gui_client/gtk_client.c:177
-msgid "/Errands/_Tipoff..."
-msgstr "/Trabalhos/_Atrair..."
-
-#: src/gui_client/gtk_client.c:181
-msgid "/Errands/_Get spy reports..."
-msgstr "/Trabalhos/_Pegar informações de espionagem..."
-
 #: src/gui_client/gtk_client.c:182
 msgid "/_Help"
 msgstr "/_Ajuda"
@@ -2169,22 +2088,6 @@ msgstr "O servidor foi terminado. Revertendo para modo de um jogador."
 #, c-format
 msgid "Jetting to %tde"
 msgstr "Indo para %tde"
-
-#. Text for the Errands/Sack Bitch menu item
-#: src/gui_client/gtk_client.c:556
-msgid "%/Sack Bitch menu item/S_ack %Tde..."
-msgstr "%/Despedir puta menu item/_Despedir %Tde..."
-
-#. Text to update the Errands/Spy menu item with the price for spying
-#: src/gui_client/gtk_client.c:565
-msgid "_Spy (%P)"
-msgstr "_Espionar (%P)"
-
-#. Text to update the Errands/Tipoff menu item with the price for a
-#. tipoff
-#: src/gui_client/gtk_client.c:571
-msgid "_Tipoff (%P)"
-msgstr "_Subornar (%P)"
 
 #. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:629
@@ -2572,29 +2475,6 @@ msgstr "Mensagem:-"
 msgid "Send"
 msgstr "Mandar"
 
-#. Title of dialog to select a player to spy on
-#: src/gui_client/gtk_client.c:2937
-msgid "Spy On Player"
-msgstr "Espionar Jogador"
-
-#. Informative text for "spy on player" dialog. (%tde = "bitch",
-#. "bitch", "guns", "drugs", respectively, by default)
-#: src/gui_client/gtk_client.c:2941
-#, c-format
-msgid ""
-"Please choose the player to spy on. Your %tde will\n"
-"then offer his services to the player, and if successful,\n"
-"you will be able to view the player's stats with the\n"
-"\"Get spy reports\" menu. Remember that the %tde will leave\n"
-"you, so any %tde or %tde that he's carrying may be lost!"
-msgstr ""
-"Por favor escolha o jogador para espionar. Sua %tde irá\n"
-"então oferecer seus serviços para o jogador, e se conseguido,\n"
-"você poderá ver as estatísticas do jogador com o menu\n"
-"\"Obter Informações de Espionagem\". Lembre-se que a %tde irá\n"
-"deixar você, então qualquer %tde ou %tde que ela está carregandoirá ser "
-"perdido!"
-
 #. Title of dialog to select a player to tip the cops off to
 #: src/gui_client/gtk_client.c:2956
 msgid "Tip Off The Cops"
@@ -2687,11 +2567,6 @@ msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o:
 #: src/gui_client/gtk_client.c:3244
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/Título da janela da LojaDeArmas/%Tde"
-
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3311
-msgid "Spy reports"
-msgstr "Informações de Espionagem"
 
 #: src/gui_client/optdialog.c:420
 #, c-format
@@ -3054,16 +2929,6 @@ msgstr "servidor dopewars"
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "IA dopewars"
-
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
-msgid "escaped"
-msgstr "escapou"
-
-#: src/serverside.c:73
-msgid "defected"
-msgstr "derrotado"
 
 #: src/serverside.c:73
 msgid "was shot"
@@ -3466,26 +3331,6 @@ msgstr "Não foi possível escrever no arquivo de pontuação %s"
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2267
-#, c-format
-msgid "%s: Tipoff from %s"
-msgstr "%s: Atrair de %s"
-
-#: src/serverside.c:2275
-#, c-format
-msgid "%s: Spy offered by %s"
-msgstr "%s: espião oferecido por %s"
-
-#: src/serverside.c:2289
-#, c-format
-msgid "One of your %tde was spying for %s.^The spy %s!"
-msgstr "Um de suas %tde estava espionando para %s.^O espião %s!"
-
-#: src/serverside.c:2298
-#, c-format
-msgid "Your spy working with %s has been discovered!^The spy %s!"
-msgstr "Seu espião trabalhando com %s foi descobrido!^O espião %s!"
-
 #: src/serverside.c:2332
 #, c-format
 msgid "The lady next to you on the subway said,^ \"%s\"%s"
@@ -3548,12 +3393,6 @@ msgstr "%s: atração de %s terminada OK."
 #, c-format
 msgid "Following your tipoff, the cops ambushed %s, who was shot dead!"
 msgstr "Seguindo suas pistas, os policiais cercaram %s, que foi morto!"
-
-#: src/serverside.c:2958
-#, c-format
-msgid "Following your tipoff, the cops ambushed %s, who escaped with %d %tde. "
-msgstr ""
-"Seguindo suas pistas, os policiais cercara %s, que escapou com %d %tde. "
 
 #: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"


### PR DESCRIPTION
## Summary
- strip errand, spy, and tipoff strings from translation templates and catalogs
- drop G-key errand instructions from multiplayer documentation

## Testing
- `make update-po` *(fails: No rule to make target 'update-po')*
- `msgfmt -c po/*.po` *(fails: format specification mismatches in existing catalogs)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_68979c5692488326b3caabf6185d1be7