### PR TITLE
Fix SOCKS5 connect buffer sizing

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -472,7 +472,7 @@ static gboolean Socks5Connect(NetworkBuffer *NetBuf)
   netport = htons(NetBuf->port);
   g_assert(sizeof(netport) == 2);
 
-  addlen = hostlen + 7;
+  addlen = hostlen + 8;
   addpt = ExpandWriteBuffer(conn, addlen, &NetBuf->error);
   if (!addpt)
     return FALSE;
@@ -481,8 +481,9 @@ static gboolean Socks5Connect(NetworkBuffer *NetBuf)
   addpt[2] = 0;                 /* reserved - must be zero */
   addpt[3] = 3;                 /* Address type - FQDN */
   addpt[4] = hostlen;           /* Length of address */
-  strcpy(&addpt[5], NetBuf->host);
+  memcpy(&addpt[5], NetBuf->host, hostlen);
   memcpy(&addpt[5 + hostlen], &netport, sizeof(netport));
+  addpt[5 + hostlen + sizeof(netport)] = '\0';
 
   NetBuf->sockstat = NBSS_CONNECT;
 


### PR DESCRIPTION
## Summary
- Allocate SOCKS5 connect buffer with space for hostname without null terminator
- Use memcpy for hostname copy and adjust port placement

## Testing
- `./autogen.sh` *(fails: automake missing)*
- `gcc -DNETWORKING -I src -I . tests/test_socks5.c src/network.c src/error.c src/util.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0)` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897a36460a483268d3f55a459842cf2