### PR TITLE
Remove obsolete spy acceptance message from translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3484,13 +3484,6 @@ msgstr "YN^Willst Du eine %tde für %P kaufen?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: Angebot war im Interesse von %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr ""
-"%s hat deine %tde angenommen !^Benutz die Taste G um deinen Spion zu "
-"kontaktieren."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -3318,11 +3318,6 @@ msgstr ""
 msgid "%s: offer was on behalf of %s"
 msgstr ""
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr ""
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3387,11 +3387,6 @@ msgstr ""
 msgid "%s: offer was on behalf of %s"
 msgstr ""
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr ""
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/es.po
+++ b/po/es.po
@@ -3558,11 +3558,6 @@ msgstr "YN^¿Quiere comprar un %tde por %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: la oferta era en nombre de %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "¡%s ha aceptado su %tde!^Use la tecla G para contactar con su espía."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -3556,11 +3556,6 @@ msgstr "YN^¿Quieres comprar un %tde por %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: la oferta era en nombre de %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "¡%s ha aceptado tu %tde!^Usa la tecla G para contactar con tu espía."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/fr.po
+++ b/po/fr.po
@@ -3448,11 +3448,6 @@ msgstr "YN^Tu veux acheter un %tde pour %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: l'offre etait au nom de %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "%s a accepte votre %tde!^Tape G pour contacter ton espion."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -3521,11 +3521,6 @@ msgstr "YN^Veux-tu acheter un %tde pour %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: l'offre etait au nom de %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "%s a accepté votre %tde!^Tape G pour contacter ton espion."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/nn.po
+++ b/po/nn.po
@@ -3511,11 +3511,6 @@ msgstr "YN^Vil du kjøpa ein %tue for %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: Tilbodet var på vegne av %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "%s har godteke %tbe di! Bruk G-knappen for å kontakta spionen din."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/pl.po
+++ b/po/pl.po
@@ -3433,12 +3433,6 @@ msgstr "YN^Chciałbyś kupić %tde za %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: propozycja była na rachunek %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr ""
-"%s zaakceptował twój %tde!^Użyj klawisza G, aby skontaktować się ze szpiegiem"
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3467,11 +3467,6 @@ msgstr "YN^Você gostaria de comprar %tde por %P?"
 msgid "%s: offer was on behalf of %s"
 msgstr "%s: oferta foi %s"
 
-#: src/serverside.c:3329
-#, c-format
-msgid "%s has accepted your %tde!^Use the G key to contact your spy."
-msgstr "%s aceitou seu %tde!^Use a tecla G para contactar seu espião."
-
 #: src/serverside.c:3381
 msgid ""
 "You hallucinated for three days on the wildest trip you ever imagined!^Then "


### PR DESCRIPTION
## Summary
- drop unused spy acceptance string from message template
- strip the same translation entry from all locale files

## Testing
- `make -C po update-po` *(fails: No rule to make target 'update-po')*
- `msgfmt -c -o /dev/null po/de.po`
- `msgfmt -c -o /dev/null po/en_GB.po`
- `msgfmt -c -o /dev/null po/es.po` *(fails: format specifications mismatch)*
- `msgfmt -c -o /dev/null po/es_ES.po` *(fails: format specifications mismatch)*
- `msgfmt -c -o /dev/null po/fr.po`
- `msgfmt -c -o /dev/null po/fr_CA.po`
- `msgfmt -c -o /dev/null po/nn.po` *(fails: invalid format strings)*
- `msgfmt -c -o /dev/null po/pl.po`
- `msgfmt -c -o /dev/null po/pt_BR.po`


------
https://chatgpt.com/codex/tasks/task_e_6897a696ff848326a8912c6c0d1d14f1