### PR TITLE
Add top-level update-po target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,4 +20,7 @@ install-data-local:
 	${INSTALL} -m 0644 ${srcdir}/${DESKTOP} ${DESKTOPDIR}
 
 uninstall-local:
-	/bin/rm -f ${SCORE} ${DESKTOPDIR}/${DESKTOP}
+        /bin/rm -f ${SCORE} ${DESKTOPDIR}/${DESKTOP}
+
+.PHONY: update-po
+update-po: ; $(MAKE) -C po update-po


### PR DESCRIPTION
## Summary
- Add a phony `update-po` target in the root `Makefile.am` to delegate catalog updates to the `po` directory.

## Testing
- `autoreconf -fvi` *(failed: aclocal missing)*
- `make update-po` *(failed: No rule to make target `update-po`)*


------
https://chatgpt.com/codex/tasks/task_e_6897a8a9b4808326a40ca99c57db9bdd