### PR TITLE
Remove talk menu feature

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2334,7 +2334,7 @@ static void DisplayDrugsHere(Player *Play)
  */
 static void Curses_DoGame(Player *Play)
 {
-  gchar *buf, *OldName, *TalkMsg;
+  gchar *buf, *OldName;
   GString *text;
   int i, c;
   char IsCarrying;
@@ -2596,37 +2596,6 @@ static void Curses_DoGame(Player *Play)
           DisplayMode = DM_NONE;
           SendClientMessage(Play, C_NONE, C_REQUESTSCORE, NULL, NULL);
         }
-      } else if (c == 'P' && Network) {
-        tmp = ListPlayers(Play, TRUE,
-                          _("Whom do you want to page "
-                            "(talk privately to) ? "));
-        if (tmp) {
-          attrset(TextAttr);
-          clear_line(get_prompt_line());
-          /* Prompt for sending player-player messages */
-          TalkMsg = nice_input(_("Talk: "), get_prompt_line(), 0, FALSE,
-                               NULL, '\0');
-          if (TalkMsg[0]) {
-            SendClientMessage(Play, C_NONE, C_MSGTO, tmp, TalkMsg);
-            buf = g_strdup_printf("%s->%s: %s", GetPlayerName(Play),
-                                  GetPlayerName(tmp), TalkMsg);
-            display_message(buf);
-            g_free(buf);
-          }
-          g_free(TalkMsg);
-        }
-      } else if (c == 'T' && Client) {
-        attrset(TextAttr);
-        clear_line(get_prompt_line());
-        TalkMsg = nice_input(_("Talk: "), get_prompt_line(), 0,
-                             FALSE, NULL, '\0');
-        if (TalkMsg[0]) {
-          SendClientMessage(Play, C_NONE, C_MSG, NULL, TalkMsg);
-          buf = g_strdup_printf("%s: %s", GetPlayerName(Play), TalkMsg);
-          display_message(buf);
-          g_free(buf);
-        }
-        g_free(TalkMsg);
       }
     } else if (DisplayMode == DM_FIGHT) {
       switch (c) {

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -67,7 +67,7 @@ struct ClientDataStruct {
   DPGtkItemFactory *Menu;
   struct StatusWidgets Status;
   struct InventoryWidgets Drug, Gun, InvenDrug, InvenGun;
-  GtkWidget *JetButton, *vbox, *PlayerList, *TalkList;
+  GtkWidget *JetButton, *vbox, *PlayerList;
   guint JetAccel;
   struct CMDLINE *cmdline;
 };
@@ -85,7 +85,7 @@ static struct ClientDataStruct ClientData;
 static gboolean InGame = FALSE;
 
 static GtkWidget *FightDialog = NULL, *SpyReportsDialog;
-static gboolean IsShowingPlayerList = FALSE, IsShowingTalkList = FALSE;
+static gboolean IsShowingPlayerList = FALSE;
 static gboolean IsShowingInventory = FALSE, IsShowingGunShop = FALSE;
 static gboolean IsShowingDealDrugs = FALSE;
 
@@ -130,9 +130,6 @@ static void DealGuns(GtkWidget *widget, gpointer data);
 static void QuestionDialog(char *Data, Player *From);
 static void TransferDialog(gboolean Debt);
 static void ListPlayers(GtkWidget *widget, gpointer data);
-static void TalkToAll(GtkWidget *widget, gpointer data);
-static void TalkToPlayers(GtkWidget *widget, gpointer data);
-static void TalkDialog(gboolean TalkToAll);
 static GtkWidget *CreatePlayerList(void);
 static void UpdatePlayerList(GtkWidget *clist, gboolean IncludeSelf);
 static void DestroyShowing(GtkWidget *widget, gpointer data);
@@ -157,9 +154,6 @@ static DPGtkItemFactoryEntry menu_items[] = {
   //{N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
   {N_("/Game/Enable _sound"), NULL, ToggleSound, 0, "<CheckItem>"},
   {N_("/Game/_Quit..."), "<control>Q", QuitGame, 0, NULL},
-  {N_("/_Talk"), NULL, NULL, 0, "<Branch>"},
-  {N_("/Talk/To _All..."), NULL, TalkToAll, 0, NULL},
-  {N_("/Talk/To _Player..."), NULL, TalkToPlayers, 0, NULL},
   {N_("/_List"), NULL, NULL, 0, "<Branch>"},
   {N_("/List/_Players..."), NULL, ListPlayers, 0, NULL},
   {N_("/List/_Scores..."), NULL, ListScores, 0, NULL},
@@ -1983,9 +1977,6 @@ static gint DrugSortByPrice(GtkTreeModel *model, GtkTreeIter *a,
 
 void UpdateMenus(void)
 {
-  gtk_widget_set_sensitive(dp_gtk_item_factory_get_widget(ClientData.Menu,
-                                                          "<main>/Talk"),
-                           InGame && Network);
   //gtk_widget_set_sensitive(dp_gtk_item_factory_get_widget
   //                         (ClientData.Menu, "<main>/Game/Options..."),
   //                         !InGame);
@@ -2640,146 +2631,12 @@ void ListPlayers(GtkWidget *widget, gpointer data)
   gtk_widget_show_all(dialog);
 }
 
-struct TalkStruct {
-  GtkWidget *dialog, *clist, *entry, *checkbutton;
-};
-
 /* Columns in player list */
 enum {
   PLAYER_COL_NAME = 0,
   PLAYER_COL_PT,
   PLAYER_NUM_COLS
 };
-
-static void TalkSendSelected(GtkTreeModel *model, GtkTreePath *path,
-                             GtkTreeIter *iter, gpointer data)
-{
-  Player *Play;
-  gchar *text = data;
-  gtk_tree_model_get(model, iter, PLAYER_COL_PT, &Play, -1);
-  if (Play) {
-    gchar *msg = g_strdup_printf(
-                     "%s->%s: %s", GetPlayerName(ClientData.Play),
-                     GetPlayerName(Play), text);
-    SendClientMessage(ClientData.Play, C_NONE, C_MSGTO, Play, text);
-    PrintMessage(msg, "page");
-    g_free(msg);
-  }
-}
-
-static void TalkSend(GtkWidget *widget, struct TalkStruct *TalkData)
-{
-  gboolean AllPlayers;
-  gchar *text;
-  GString *msg;
-
-  AllPlayers =
-      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON
-                                   (TalkData->checkbutton));
-  text = gtk_editable_get_chars(GTK_EDITABLE(TalkData->entry), 0, -1);
-  gtk_editable_delete_text(GTK_EDITABLE(TalkData->entry), 0, -1);
-  if (!text)
-    return;
-
-  msg = g_string_new("");
-
-  if (AllPlayers) {
-    SendClientMessage(ClientData.Play, C_NONE, C_MSG, NULL, text);
-    g_string_printf(msg, "%s: %s", GetPlayerName(ClientData.Play), text);
-    PrintMessage(msg->str, "talk");
-  } else {
-    GtkTreeSelection *tsel = gtk_tree_view_get_selection(
-                                        GTK_TREE_VIEW(TalkData->clist));
-    gtk_tree_selection_selected_foreach(tsel, TalkSendSelected, text);
-  }
-  g_free(text);
-  g_string_free(msg, TRUE);
-}
-
-void TalkToAll(GtkWidget *widget, gpointer data)
-{
-  TalkDialog(TRUE);
-}
-
-void TalkToPlayers(GtkWidget *widget, gpointer data)
-{
-  TalkDialog(FALSE);
-}
-
-void TalkDialog(gboolean TalkToAll)
-{
-  GtkWidget *dialog, *clist, *button, *entry, *label, *vbox, *hsep,
-      *checkbutton, *hbbox;
-  GtkAccelGroup *accel_group;
-  static struct TalkStruct TalkData;
-
-  if (IsShowingTalkList)
-    return;
-  dialog = TalkData.dialog = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  accel_group = gtk_accel_group_new();
-  gtk_window_add_accel_group(GTK_WINDOW(dialog), accel_group);
-
-  /* Title of talk dialog */
-  gtk_window_set_title(GTK_WINDOW(dialog), _("Talk to player(s)"));
-  my_set_dialog_position(GTK_WINDOW(dialog));
-
-  gtk_window_set_default_size(GTK_WINDOW(dialog), 200, 190);
-  gtk_container_set_border_width(GTK_CONTAINER(dialog), 7);
-
-  gtk_window_set_modal(GTK_WINDOW(dialog), FALSE);
-  gtk_window_set_transient_for(GTK_WINDOW(dialog),
-                               GTK_WINDOW(ClientData.window));
-  SetShowing(dialog, &IsShowingTalkList);
-
-  vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 7);
-
-  clist = TalkData.clist = ClientData.TalkList = CreatePlayerList();
-  UpdatePlayerList(clist, FALSE);
-  gtk_tree_selection_set_mode(
-          gtk_tree_view_get_selection(GTK_TREE_VIEW(clist)),
-          GTK_SELECTION_MULTIPLE);
-  gtk_box_pack_start(GTK_BOX(vbox), clist, TRUE, TRUE, 0);
-
-  checkbutton = TalkData.checkbutton =
-      /* Checkbutton set if you want to talk to all players */
-      gtk_check_button_new_with_label(_("Talk to all players"));
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton), TalkToAll);
-  gtk_box_pack_start(GTK_BOX(vbox), checkbutton, FALSE, FALSE, 0);
-
-  /* Prompt for you to enter the message to be sent to other players */
-  label = gtk_label_new(_("Message:-"));
-
-  gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
-
-  entry = TalkData.entry = gtk_entry_new();
-  g_signal_connect(G_OBJECT(entry), "activate",
-                   G_CALLBACK(TalkSend), (gpointer)&TalkData);
-  gtk_box_pack_start(GTK_BOX(vbox), entry, FALSE, FALSE, 0);
-
-  hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-  gtk_box_pack_start(GTK_BOX(vbox), hsep, FALSE, FALSE, 0);
-
-  hbbox = my_hbbox_new();
-
-  /* Button to send a message to other players */
-  button = gtk_button_new_with_label(_("Send"));
-
-  g_signal_connect(G_OBJECT(button), "clicked",
-                   G_CALLBACK(TalkSend), (gpointer)&TalkData);
-  my_gtk_box_pack_start_defaults(GTK_BOX(hbbox), button);
-
-  button = gtk_button_new_with_mnemonic(_("_Close"));
-  g_signal_connect_swapped(G_OBJECT(button), "clicked",
-                           G_CALLBACK(gtk_widget_destroy),
-                           G_OBJECT(dialog));
-  my_gtk_box_pack_start_defaults(GTK_BOX(hbbox), button);
-
-  gtk_box_pack_start(GTK_BOX(vbox), hbbox, FALSE, FALSE, 0);
-
-  gtk_container_add(GTK_CONTAINER(dialog), vbox);
-  gtk_widget_show_all(dialog);
-}
 
 GtkWidget *CreatePlayerList(void)
 {
@@ -3081,9 +2938,6 @@ void UpdatePlayerLists(void)
 {
   if (IsShowingPlayerList) {
     UpdatePlayerList(ClientData.PlayerList, FALSE);
-  }
-  if (IsShowingTalkList) {
-    UpdatePlayerList(ClientData.TalkList, FALSE);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove Talk menu from GTK client and associated code
- strip Talk commands from curses client

## Testing
- `./runindent.sh src/gui_client/gtk_client.c src/curses_client/curses_client.c` *(fails: indent not found)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_6897aa5c22cc8326a136a59ba9e7eaad