### PR TITLE
Remove Talk menu and dialog translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1945,16 +1945,6 @@ msgstr "Zeige S>pieler oder P>unkte? "
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Wem möchtest du etwas zuflüstern ? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Sprich: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Möchtest du noch mal spielen? "
@@ -1983,18 +1973,6 @@ msgstr "/Spiel/Sound"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Spiel/_Ende..."
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Mitteilung"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Mitteilung/An _Alle..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Mitteilung/An _Spieler..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2460,16 +2438,6 @@ msgstr "Bezahle alles"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Spieler Liste"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Rede mit Spieler(n)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Rede mit allen Spielern"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -1852,16 +1852,6 @@ msgstr ""
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr ""
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr ""
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr ""
@@ -1889,18 +1879,6 @@ msgstr ""
 
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr ""
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
 msgstr ""
 
 #: src/gui_client/gtk_client.c:171
@@ -2345,16 +2323,6 @@ msgstr ""
 #. Title of player list dialog
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
-msgstr ""
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr ""
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1919,16 +1919,6 @@ msgstr ""
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr ""
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr ""
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr ""
@@ -1956,18 +1946,6 @@ msgstr ""
 
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr ""
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr ""
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
 msgstr ""
 
 #: src/gui_client/gtk_client.c:171
@@ -2414,16 +2392,6 @@ msgstr ""
 #. Title of player list dialog
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
-msgstr ""
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr ""
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players

--- a/po/es.po
+++ b/po/es.po
@@ -1991,16 +1991,6 @@ msgstr "¿Qué lista quiere? ¿J>ugadores o P>untuaciones? "
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "¿Con quién quiere hablar en privado?"
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Decir: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
@@ -2029,18 +2019,6 @@ msgstr "/Juego/Activar_sonido"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Juego/_Salir..."
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Hablar"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Hablar/_Hablar a todos..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Hablar/Hablar al _Jugador..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2503,16 +2481,6 @@ msgstr "Pagar todo"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Lista de jugadores"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Hablar al jugador (o jugadores)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -1991,16 +1991,6 @@ msgstr "¿Qué lista quieres? ¿J>ugadores o P>untuaciones? "
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "¿Con quién quieres hablar en privado?"
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Decir: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
@@ -2029,18 +2019,6 @@ msgstr "/Juego/Habilitar _sonido"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Juego/_Salir..."
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Hablar"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Hablar/_Hablar a todos..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Hablar/Hablar al _Jugador..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2503,16 +2481,6 @@ msgstr "Pagar todo"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Lista de jugadores"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Hablar al jugador (o jugadores)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/fr.po
+++ b/po/fr.po
@@ -1929,16 +1929,6 @@ msgstr "Lister quoi? J>oueurs ou S>cores? "
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "A qui tu veux parler en prive ? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Parler: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Rejouer? "
@@ -1967,18 +1957,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Jeu/_Quitter"
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Parler"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Parler/A _Tous..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Parler/A _joueur..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2434,16 +2412,6 @@ msgstr "Tout payer"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Liste des joueurs"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Parler au joueur(s)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Parler a tout les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -1973,16 +1973,6 @@ msgstr "Lister quoi? J>oueurs ou S>cores? "
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "À qui que tu veux parler en privé ? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Parler: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Jouer à nouveau? "
@@ -2011,18 +2001,6 @@ msgstr "/Jeu/Activer les _sons"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Jeu/_Quitter"
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Parler"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Parler/Avec _tout le monde..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Parler/Avec un _joueur..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2479,16 +2457,6 @@ msgstr "Tout payer"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Liste des joueurs"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Parler au(x) joueur(s)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Parler à tous les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/nn.po
+++ b/po/nn.po
@@ -1961,16 +1961,6 @@ msgstr "Lista opp kva? S>pelarar eller P>oeng? "
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Kven vil du snakka privat med? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Snakk: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Spela igjen? "
@@ -1999,18 +1989,6 @@ msgstr "/Spel/Slå på _lyd"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Spel/_Avslutt"
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Snakk"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Snakk/Til _alle ..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Snakk/Til _spelar ..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2472,16 +2450,6 @@ msgstr "Betal alt"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Spelarliste"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Snakk med spelar(ar)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Snakk med alle spelarane"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/pl.po
+++ b/po/pl.po
@@ -1919,16 +1919,6 @@ msgstr "Co chcesz zobaczyć? G>raczy W>yniki"
 msgid "PS"
 msgstr "GW"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Do kogo prywatnie zagadujesz ? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Nawijaj: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Grasz jeszcze raz? "
@@ -1957,18 +1947,6 @@ msgstr ""
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Gra/_Wyjście..."
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Rozmowa"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Rozmowa/Ze _Wszystkimi..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Rozmowa/Z _Graczem..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2425,16 +2403,6 @@ msgstr "Spłać wszystko"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Lista graczy"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Mów do gracza(y)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Mów do wszystkich graczy"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1943,16 +1943,6 @@ msgstr "Listar o que? J>ogadores ou P>ontuações? "
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2686
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Quem você quer pagear (falar privadamente) ? "
-
-#. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2692
-#: src/curses_client/curses_client.c:2706
-msgid "Talk: "
-msgstr "Fale: "
-
 #: src/curses_client/curses_client.c:2832
 msgid "Play again? "
 msgstr "Jogar novamente? "
@@ -1981,18 +1971,6 @@ msgstr "/Jogo/_Habilitar som"
 #: src/gui_client/gtk_client.c:167
 msgid "/Game/_Quit..."
 msgstr "/Jogo/_Sair..."
-
-#: src/gui_client/gtk_client.c:168
-msgid "/_Talk"
-msgstr "/_Falar"
-
-#: src/gui_client/gtk_client.c:169
-msgid "/Talk/To _All..."
-msgstr "/Falar/Para _Todos..."
-
-#: src/gui_client/gtk_client.c:170
-msgid "/Talk/To _Player..."
-msgstr "/Falar/Para um _Jogador..."
 
 #: src/gui_client/gtk_client.c:171
 msgid "/_List"
@@ -2454,16 +2432,6 @@ msgstr "Pagar tudo"
 #: src/gui_client/gtk_client.c:2663
 msgid "Player List"
 msgstr "Lista de jogadores"
-
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2775
-msgid "Talk to player(s)"
-msgstr "Falar com jogador(es)"
-
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2797
-msgid "Talk to all players"
-msgstr "Falar com todos os jogadores"
 
 #. Prompt for you to enter the message to be sent to other players
 #: src/gui_client/gtk_client.c:2803


### PR DESCRIPTION
## Summary
- remove Talk-related menu entries and dialog strings from translation template and all locale files

## Testing
- `msgfmt po/*.po -o po/*.mo`
- `ls po/*.mo`
- `make clean` *(fails: No rule to make target 'clean')*
- `make install` *(fails: No rule to make target 'install')*
- `./autogen.sh` *(fails: You must have automake installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897b14c1d1c83269c3a48d89ed2231a