### PR TITLE
docs: remove talk sound references

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -621,8 +621,7 @@ any drugs, and clients will display this information if available.</dd>
 target. The sound must be installed on your system, and you must be using
 a functioning sound system, in order to hear anything. Other sounds that
 can be configured in the same way are: <b>FightMiss</b>, <b>FightReload</b>,
-<b>Jet</b>, <b>CoinBuy</b>, <b>TalkToAll</b>, <b>TalkPrivate</b>, <b>JoinGame</b>,
-and <b>LeaveGame</b>.</dd>
+<b>Jet</b>, <b>CoinBuy</b>, <b>JoinGame</b>, and <b>LeaveGame</b>.</dd>
 
 </dl>
 


### PR DESCRIPTION
## Summary
- remove outdated TalkToAll and TalkPrivate sound references from config documentation

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `sudo apt-get install -y automake` *(fails: Package 'automake' has no installation candidate)*
- `make -C doc` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd488bb48326a2f062e5499dec33