### PR TITLE
Fix Makefile uninstall-local rule indentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ install-data-local:
 	${INSTALL} -m 0644 ${srcdir}/${DESKTOP} ${DESKTOPDIR}
 
 uninstall-local:
-        /bin/rm -f ${SCORE} ${DESKTOPDIR}/${DESKTOP}
+	/bin/rm -f ${SCORE} ${DESKTOPDIR}/${DESKTOP}
 
 .PHONY: update-po
 update-po: ; $(MAKE) -C po update-po


### PR DESCRIPTION
## Summary
- Replace spaces with a tab in `uninstall-local` to ensure the remove command is interpreted correctly.

## Testing
- `autoreconf -fi && ./configure` *(fails: Can't exec "aclocal": No such file or directory)*
- `apt-get update` *(fails: The repository is not signed)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68990db15e5083268d52ebb12fdba91f