### PR TITLE
Fix tab indentation in doc uninstall rule

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -17,6 +17,6 @@ install-data-local:
 
 uninstall-local:
 	for doc in ${DOCS}; do \
-          /bin/rm -f ${DOCPATH}/$${doc}; \
+	/bin/rm -f ${DOCPATH}/$${doc}; \
 	done
 	/bin/rm -f ${DOCPATH}/LICENCE


### PR DESCRIPTION
## Summary
- ensure doc uninstall script uses a tab for rm command

## Testing
- `./autogen.sh --prefix=$(pwd)/build/install` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `make uninstall` *(fails: No rule to make target 'uninstall')*


------
https://chatgpt.com/codex/tasks/task_e_68990ed967f8832693b62b4f130dc216