### PR TITLE
Disable curses client chat message handling

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -1096,15 +1096,7 @@ void HandleClientMessage(char *Message, Player *Play)
     print_status(Play, TRUE);
     break;
   case C_MSG:
-    text = g_strdup_printf("%s: %s", GetPlayerName(From), Data);
-    display_message(text);
-    g_free(text);
-    break;
   case C_MSGTO:
-    text = g_strdup_printf("%s->%s: %s", GetPlayerName(From),
-                           GetPlayerName(Play), Data);
-    display_message(text);
-    g_free(text);
     break;
   case C_JOIN:
     text = g_strdup_printf(_("%s joins the game!"), Data);


### PR DESCRIPTION
## Summary
- ignore incoming `C_MSG` and `C_MSGTO` messages in `curses_client.c`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f2dadb8083268e29a73b36fd1dae