### PR TITLE
Disable AI chat messages

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -341,13 +341,13 @@ int HandleAIMessage(char *Message, Player *AIPlay)
       AIJet(AIPlay);
     }
     break;
-  case C_MSG:
-    g_print("%s: %s\n", GetPlayerName(From), Data);
-    break;
-  case C_MSGTO:
-    g_print("%s->%s: %s\n", GetPlayerName(From), GetPlayerName(AIPlay),
-            Data);
-    break;
+  /* case C_MSG: */
+  /*   g_print("%s: %s\n", GetPlayerName(From), Data); */
+  /*   break; */
+  /* case C_MSGTO: */
+  /*   g_print("%s->%s: %s\n", GetPlayerName(From), GetPlayerName(AIPlay), */
+  /*           Data); */
+  /*   break; */
   case C_JOIN:
     g_print(_("%s joins the game.\n"), Data);
     break;
@@ -675,8 +675,9 @@ void AISendRandomMessage(Player *AIPlay)
     N_("Reckon I'll just have to kill you for your own good.")
   };
 
-  SendClientMessage(AIPlay, C_NONE, C_MSG, NULL,
-                    _(RandomInsult[brandom(0, 5)]));
+  /* AI players should not send chat messages */
+  /* SendClientMessage(AIPlay, C_NONE, C_MSG, NULL, */
+  /*                   _(RandomInsult[brandom(0, 5)])); */
 }
 
 #else /* NETWORKING */


### PR DESCRIPTION
## Summary
- Prevent AI message handler from reacting to C_MSG and C_MSGTO commands
- Stop AI players from attempting to send chat insults

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_6899f4948c0483268e00a65dd5ed3766