### PR TITLE
Use bounded copy for SOCKS4 handshake username

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1018,7 +1018,7 @@ gboolean StartSocksNegotiation(NetworkBuffer *NetBuf, gchar *RemoteHost,
   addpt[1] = 1;                 /* CONNECT */
   memcpy(&addpt[2], &netport, sizeof(netport));
   memcpy(&addpt[4], haddr, sizeof(struct in_addr));
-  strcpy(&addpt[8], username);
+  g_strlcpy(&addpt[8], username, addlen - 8);
   g_free(username);
   addpt[addlen - 1] = '\0';
 


### PR DESCRIPTION
## Summary
- use `g_strlcpy` with calculated buffer length when copying SOCKS4 username

## Testing
- `gcc tests/test_socks5.c src/network.c src/error.c src/util.c src/log.c src/message.c src/tstring.c -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -lglib-2.0 -o tests/test_socks5` *(fails: network.h: No such file or directory; glib.h: No such file or directory)*
- `gcc tests/test_sound.c src/sound.c src/util.c src/log.c src/message.c src/error.c src/tstring.c -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -lglib-2.0 -o tests/test_sound` *(fails: sound.h: No such file or directory; glib.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a0d3cce688326b20dd4054432229b