### PR TITLE
Hide Talk menu option in GTK client

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2160,6 +2160,9 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   dp_gtk_item_factory_create_items(item_factory, nmenu_items, menu_items,
                                    NULL);
+  GtkWidget *talk_menu =
+    dp_gtk_item_factory_get_widget(item_factory, "<main>/Talk");
+  gtk_widget_hide(talk_menu);
   gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
   menubar = dp_gtk_item_factory_get_widget(item_factory, "<main>");
 


### PR DESCRIPTION
## Summary
- Hide the Talk menu by fetching its widget and hiding it after menu creation

## Testing
- `./runindent.sh src/gui_client/gtk_client.c` *(fails: indent: not found)*
- `make` *(fails: No targets specified and no makefile found)*
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*

------
https://chatgpt.com/codex/tasks/task_e_689a10d23c44832691d4bd0ce685c5ba