### PR TITLE
Hide Talk menu after showing menubar

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2162,13 +2162,13 @@ gboolean GtkLoop(int *argc, char **argv[],
                                    NULL);
   GtkWidget *talk_menu =
     dp_gtk_item_factory_get_widget(item_factory, "<main>/Talk");
-  gtk_widget_hide(talk_menu);
   gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
   menubar = dp_gtk_item_factory_get_widget(item_factory, "<main>");
 
   vbox2 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox2), menubar, FALSE, FALSE, 0);
   gtk_widget_show_all(menubar);
+  gtk_widget_hide(talk_menu);
   UpdateMenus();
   SoundEnable(UseSounds);
   widget = dp_gtk_item_factory_get_widget(ClientData.Menu,


### PR DESCRIPTION
## Summary
- ensure Talk menu stays hidden by hiding it after the menubar is displayed

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `sudo apt-get update` *(fails: repository is not signed)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689a12a1d08c8326b788724bbfd517f5