### PR TITLE
Remove Talk menu from GTK client

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2093,7 +2093,7 @@ gboolean GtkLoop(int *argc, char **argv[],
 #endif
 {
   GtkWidget *window, *vbox, *vbox2, *hbox, *frame, *grid, *menubar, *text,
-      *vpaned, *button, *tv, *widget;
+      *vpaned, *button, *tv, *widget, *talk_item;
   GtkAccelGroup *accel_group;
   GtkTreeSortable *sortable;
   int i;
@@ -2160,15 +2160,16 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   dp_gtk_item_factory_create_items(item_factory, nmenu_items, menu_items,
                                    NULL);
-  GtkWidget *talk_menu =
+  talk_item =
     dp_gtk_item_factory_get_widget(item_factory, "<main>/Talk");
   gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
   menubar = dp_gtk_item_factory_get_widget(item_factory, "<main>");
 
   vbox2 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox2), menubar, FALSE, FALSE, 0);
+  if (talk_item && menubar)
+    gtk_container_remove(GTK_CONTAINER(menubar), talk_item);
   gtk_widget_show_all(menubar);
-  gtk_widget_hide(talk_menu);
   UpdateMenus();
   SoundEnable(UseSounds);
   widget = dp_gtk_item_factory_get_widget(ClientData.Menu,


### PR DESCRIPTION
## Summary
- Remove hidden Talk menu item entirely by removing it from the GTK menubar

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `gcc -fsyntax-only -Isrc -Isrc/gui_client -Isrc/gtkport src/gui_client/gtk_client.c` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a1484ba8c832682bfd4ad4c98dc0f