### PR TITLE
Remove Talk menu from GTK client

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2093,7 +2093,7 @@ gboolean GtkLoop(int *argc, char **argv[],
 #endif
 {
   GtkWidget *window, *vbox, *vbox2, *hbox, *frame, *grid, *menubar, *text,
-      *vpaned, *button, *tv, *widget, *talk_item;
+      *vpaned, *button, *tv, *widget, *talk_menu, *talk_item;
   GtkAccelGroup *accel_group;
   GtkTreeSortable *sortable;
   int i;
@@ -2160,8 +2160,9 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   dp_gtk_item_factory_create_items(item_factory, nmenu_items, menu_items,
                                    NULL);
-  talk_item =
+  talk_menu =
     dp_gtk_item_factory_get_widget(item_factory, "<main>/Talk");
+  talk_item = talk_menu ? gtk_widget_get_parent(talk_menu) : NULL;
   gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
   menubar = dp_gtk_item_factory_get_widget(item_factory, "<main>");
 


### PR DESCRIPTION
## Summary
- Remove leftover Talk menu by retrieving its submenu, finding the parent item, and removing it from the menubar

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `apt-get update` *(fails: repository InRelease is not signed)*
- `apt-get install -y automake` *(fails: Package 'automake' has no installation candidate)*
- `gcc -c src/gui_client/gtk_client.c -Isrc -I/usr/include/gtk-3.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/pixman-1` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a178712dc83269b549d9e0031e79a