### PR TITLE
Guard Talk menu item sensitivity

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -1980,9 +1980,10 @@ static gint DrugSortByPrice(GtkTreeModel *model, GtkTreeIter *a,
 
 void UpdateMenus(void)
 {
-  gtk_widget_set_sensitive(dp_gtk_item_factory_get_widget(ClientData.Menu,
-                                                          "<main>/Talk"),
-                           InGame && Network);
+  GtkWidget *talk_widget =
+      dp_gtk_item_factory_get_widget(ClientData.Menu, "<main>/Talk");
+  if (talk_widget != NULL)
+    gtk_widget_set_sensitive(talk_widget, InGame && Network);
   //gtk_widget_set_sensitive(dp_gtk_item_factory_get_widget
   //                         (ClientData.Menu, "<main>/Game/Options..."),
   //                         !InGame);


### PR DESCRIPTION
## Summary
- Guard Talk menu item sensitivity from null widget in `UpdateMenus`

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a5aeab8148326847589eecbc39d00