### PR TITLE
Fix memory management in Cocoa sound driver

### DIFF
--- a/src/plugins/sound_cocoa.m
+++ b/src/plugins/sound_cocoa.m
@@ -53,9 +53,14 @@ static void SoundPlay_Cocoa(const gchar *snd)
   if (!p) {
     p = [[NSSound alloc] initWithContentsOfFile:sound byReference:YES];
     /* If the sound file doesn't exist, do nothing */
-    if (!p) return;
+    if (!p) {
+      [sound release];
+      return;
+    }
     [play_by_name setObject:p forKey:sound];
+    [p release];
   }
+  [sound release];
   /* First, stop any currently playing sound */
   [p stop];
   [p play];


### PR DESCRIPTION
## Summary
- Release temporary NSString key after sound lookup/creation in SoundPlay_Cocoa
- Drop extra retain on new NSSound objects stored in play_by_name

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689a5e0b99908326876da29e1776eef0