### PR TITLE
Expose sound plugin helpers for tests

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -86,6 +86,15 @@ static void AddPlugin(InitFunc ifunc, void *module)
   }
 }
 
+/*
+ * Public wrappers for unit tests to register and query plugins without
+ * exposing the internal static helpers.
+ */
+void SoundAddPlugin(SoundDriver *(*ifunc)(void), void *module)
+{
+  AddPlugin(ifunc, module);
+}
+
 #ifdef PLUGINS
 static void OpenModule(const gchar *modname, const gchar *fullname)
 {
@@ -172,7 +181,7 @@ void SoundInit(void)
   driver = NULL;
 }
 
-static SoundDriver *GetPlugin(gchar *drivername)
+static SoundDriver *GetPlugin(const gchar *drivername)
 {
   GSList *listpt;
 
@@ -185,6 +194,11 @@ static SoundDriver *GetPlugin(gchar *drivername)
     }
   }
   return NULL;
+}
+
+SoundDriver *SoundGetPlugin(const gchar *drivername)
+{
+  return GetPlugin(drivername);
 }
 
 void SoundOpen(gchar *drivername)

--- a/src/sound.h
+++ b/src/sound.h
@@ -38,6 +38,8 @@ struct _SoundDriver {
 typedef struct _SoundDriver SoundDriver;
 
 gchar *GetPluginList(void);
+void SoundAddPlugin(SoundDriver *(*ifunc)(void), void *module);
+SoundDriver *SoundGetPlugin(const gchar *drivername);
 void SoundInit(void);
 void SoundOpen(gchar *drivername);
 void SoundClose(void);

--- a/tests/test_sound.c
+++ b/tests/test_sound.c
@@ -1,11 +1,6 @@
 #include "sound.h"
 #include <assert.h>
 
-/* Prototype for internal plugin lookup so we can check whether a driver
- * was found before calling SoundOpen. */
-SoundDriver *GetPlugin(const gchar *drivername);
-void AddPlugin(SoundDriver *(*ifunc)(void), void *module);
-
 /* A dummy sound driver whose open routine always fails. */
 static gboolean failing_open(void) {
   return FALSE;
@@ -22,7 +17,7 @@ int main(void) {
   assert(IsSoundEnabled() == FALSE);
 
   /* Opening with no name uses the first available driver, if any. */
-  SoundDriver *drv = GetPlugin(NULL);
+  SoundDriver *drv = SoundGetPlugin(NULL);
   SoundOpen(NULL);
   assert(IsSoundEnabled() == (drv != NULL));
 
@@ -37,7 +32,7 @@ int main(void) {
   /* Register a driver that fails to open and ensure sound stays disabled. */
   SoundInit();
   assert(IsSoundEnabled() == FALSE);
-  AddPlugin(failing_init, NULL);
+  SoundAddPlugin(failing_init, NULL);
   SoundOpen("failing-driver");
   assert(IsSoundEnabled() == FALSE);
 


### PR DESCRIPTION
## Summary
- expose `SoundAddPlugin` and `SoundGetPlugin` to allow unit tests to register and query sound plugins
- update sound test to use new public wrappers

## Testing
- `gcc tests/test_sound.c src/sound.c src/log.c src/nls.c src/tstring.c -I src -I . $(pkg-config --cflags --libs glib-2.0) -o tests/test_sound` *(fails: Package glib-2.0 was not found)*
- `apt-get install -y libglib2.0-dev` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689a5f0564d083269e3c6d7184b60c35