### PR TITLE
Remove chat message sound options

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -621,7 +621,7 @@ any drugs, and clients will display this information if available.</dd>
 target. The sound must be installed on your system, and you must be using
 a functioning sound system, in order to hear anything. Other sounds that
 can be configured in the same way are: <b>FightMiss</b>, <b>FightReload</b>,
-<b>Jet</b>, <b>TalkToAll</b>, <b>TalkPrivate</b>, <b>JoinGame</b>, and
+<b>Jet</b>, <b>JoinGame</b>, and
 <b>LeaveGame</b>.</dd>
 
 </dl>

--- a/po/de.po
+++ b/po/de.po
@@ -322,14 +322,6 @@ msgstr "Sound-Datei für eine gelungene Flucht von dir"
 msgid "Sound file played on arriving at a new location"
 msgstr "Sound-Datei für die Ankunft an einem neuen Ort"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr "Sound-Datei für eine Öffentliche Chat-Nachricht"
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr "Sound-Datei für eine private Chat-Nachricht"
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr "Sound-Datei für den Beitritt eines Spielers zu einem Spiel"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -316,14 +316,6 @@ msgstr ""
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr ""
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr ""
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -314,14 +314,6 @@ msgstr ""
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr ""
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr ""
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -333,14 +333,6 @@ msgstr "Fichero de sonido reproducido cuando usted logra escapar"
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr "Sonido que se oye cuando un jugador envía un mensaje público al chat"
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr "Sonido que se oye cuando un jugador envía un mensaje privado al chat"
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -332,14 +332,6 @@ msgstr "Fichero de sonido reproducido cuando tú logras escapar"
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr "Sonido que se oye cuando un jugador envía un mensaje público al chat"
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr "Sonido que se oye cuando un jugador envía un mensaje privado al chat"
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"

--- a/po/fr.po
+++ b/po/fr.po
@@ -317,14 +317,6 @@ msgstr ""
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr ""
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr ""
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr ""

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -316,14 +316,6 @@ msgstr "Son accompagnant votre fuite réussie"
 msgid "Sound file played on arriving at a new location"
 msgstr "Son d'arrivée dans un nouvel endroit"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr "Son d'un message publique envoyé par un joueur"
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr "Son d'un message privé envoyé par un joueur"
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr "Son à faire jouer lorsqu'un joueur se joint à la partie"

--- a/po/nn.po
+++ b/po/nn.po
@@ -332,14 +332,6 @@ msgstr "Lyd som blir spelt når du klarer å koma deg unna"
 msgid "Sound file played on arriving at a new location"
 msgstr "Lyd som blir spelt når du kjem til ein ny stad"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr "Lyd som blir spelt når du sender ei offentleg melding"
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr "Lyd som blir spelt når du sender ei privat melding"
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr "Lyd som blir spelt når ein annan blir med i spelet"

--- a/po/pl.po
+++ b/po/pl.po
@@ -317,14 +317,6 @@ msgstr ""
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr ""
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr ""
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -317,14 +317,6 @@ msgstr ""
 msgid "Sound file played on arriving at a new location"
 msgstr "Arquivo de som tocado ao chegar em um novo local"
 
-#: src/dopewars.c:423
-msgid "Sound file played when a player sends a public chat message"
-msgstr ""
-
-#: src/dopewars.c:426
-msgid "Sound file played when a player sends a private chat message"
-msgstr ""
-
 #: src/dopewars.c:429
 msgid "Sound file played when a player joins the game"
 msgstr ""

--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -1099,14 +1099,12 @@ void HandleClientMessage(char *Message, Player *Play)
     text = g_strdup_printf("%s: %s", GetPlayerName(From), Data);
     display_message(text);
     g_free(text);
-    SoundPlay(Sounds.TalkToAll);
     break;
   case C_MSGTO:
     text = g_strdup_printf("%s->%s: %s", GetPlayerName(From),
                            GetPlayerName(Play), Data);
     display_message(text);
     g_free(text);
-    SoundPlay(Sounds.TalkPrivate);
     break;
   case C_JOIN:
     text = g_strdup_printf(_("%s joins the game!"), Data);

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -419,12 +419,6 @@ struct GLOBALS Globals[] = {
   {NULL, NULL, NULL, &Sounds.Jet, NULL, "Sounds.Jet",
    N_("Sound file played on arriving at a new location"), NULL, NULL, 0, "",
    NULL, NULL, FALSE, 0, 0},
-  {NULL, NULL, NULL, &Sounds.TalkToAll, NULL, "Sounds.TalkToAll",
-   N_("Sound file played when a player sends a public chat message"),
-   NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 0},
-  {NULL, NULL, NULL, &Sounds.TalkPrivate, NULL, "Sounds.TalkPrivate",
-   N_("Sound file played when a player sends a private chat message"),
-   NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 0},
   {NULL, NULL, NULL, &Sounds.JoinGame, NULL, "Sounds.JoinGame",
    N_("Sound file played when a player joins the game"),
    NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 0},
@@ -2341,8 +2335,6 @@ static void SetupParameters(GSList *extraconfigs, gboolean antique)
   AssignName(&Sounds.EnemyFlee, SNDPATH"run.wav");
   AssignName(&Sounds.Flee, SNDPATH"run.wav");
   AssignName(&Sounds.Jet, SNDPATH"train.wav");
-  AssignName(&Sounds.TalkPrivate, SNDPATH"murmur.wav");
-  AssignName(&Sounds.TalkToAll, SNDPATH"message.wav");
   AssignName(&Sounds.EndGame, SNDPATH"bye.wav");
   AssignName(&Sounds.CoinBuy, SNDPATH"coinbuy.wav");
 

--- a/src/dopewars.h
+++ b/src/dopewars.h
@@ -90,7 +90,7 @@ struct NAMES {
 };
 
 struct SOUNDS {
-  gchar *FightHit, *FightMiss, *FightReload, *Jet, *TalkToAll, *TalkPrivate, *CoinBuy;
+  gchar *FightHit, *FightMiss, *FightReload, *Jet, *CoinBuy;
   gchar *JoinGame, *LeaveGame, *StartGame, *EndGame;
   gchar *EnemyBitchKilled, *BitchKilled, *EnemyKilled, *Killed;
   gchar *EnemyFailFlee, *FailFlee, *EnemyFlee, *Flee;

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -486,14 +486,12 @@ void HandleClientMessage(char *pt, Player *Play)
     text = g_strdup_printf("%s: %s", GetPlayerName(From), Data);
     PrintMessage(text, "talk");
     g_free(text);
-    SoundPlay(Sounds.TalkToAll);
     break;
   case C_MSGTO:
     text = g_strdup_printf("%s->%s: %s", GetPlayerName(From),
                            GetPlayerName(Play), Data);
     PrintMessage(text, "page");
     g_free(text);
-    SoundPlay(Sounds.TalkPrivate);
     break;
   case C_JOIN:
     text = g_strdup_printf(_("%s joins the game!"), Data);


### PR DESCRIPTION
## Summary
- drop TalkToAll/TalkPrivate sound configuration and defaults
- remove chat sound playback hooks
- update documentation and translation templates

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689a6015e02083269d67a2490643d24d