### PR TITLE
Handle ExpandWriteBuffer failure in QueueMessageForSend

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -888,7 +888,7 @@ void CommitWriteBuffer(NetworkBuffer *NetBuf, ConnBuf *conn,
  * error if the buffer reaches its maximum size (although this error will
  * be detected when an attempt is made to write the buffer to the wire).
  */
-void QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data)
+gboolean QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data)
 {
   gchar *addpt;
   guint addlen;
@@ -897,16 +897,19 @@ void QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data)
   conn = &NetBuf->WriteBuf;
 
   if (!data)
-    return;
+    return FALSE;
   addlen = strlen(data) + 1;
-  addpt = ExpandWriteBuffer(conn, addlen, NULL);
-  if (!addpt)
-    return;
+  addpt = ExpandWriteBuffer(conn, addlen, &NetBuf->error);
+  if (!addpt) {
+    g_warning("Failed to expand write buffer for outgoing message");
+    return FALSE;
+  }
 
   memcpy(addpt, data, addlen);
   addpt[addlen - 1] = NetBuf->Terminator;
 
   CommitWriteBuffer(NetBuf, conn, addpt, addlen);
+  return TRUE;
 }
 
 static void SetNetworkError(LastError **error) {

--- a/src/network.h
+++ b/src/network.h
@@ -183,7 +183,7 @@ gboolean NetBufHandleNetwork(NetworkBuffer *NetBuf, gboolean ReadReady,
                              gboolean *DoneOK);
 gboolean ReadDataFromWire(NetworkBuffer *NetBuf);
 gboolean WriteDataToWire(NetworkBuffer *NetBuf);
-void QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data);
+gboolean QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data);
 gint CountWaitingMessages(NetworkBuffer *NetBuf);
 gchar *GetWaitingMessage(NetworkBuffer *NetBuf);
 void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,


### PR DESCRIPTION
## Summary
- check result of `ExpandWriteBuffer` in `QueueMessageForSend`
- return boolean status and log warning when write buffer expansion fails

## Testing
- `gcc -c src/network.c -I src -I . -DHAVE_CONFIG_H` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a7639208326bc7acfb0c7df6b78