### PR TITLE
Handle SOCKS negotiation failure

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -289,6 +289,8 @@ gboolean StartNetworkBufferConnect(NetworkBuffer *NetBuf,
 
     if (NetBuf->socks
         && !StartSocksNegotiation(NetBuf, RemoteHost, RemotePort)) {
+      /* Clean up the partial connection to prevent descriptor leaks. */
+      ShutdownNetworkBuffer(NetBuf);
       return FALSE;
     }
 


### PR DESCRIPTION
## Summary
- ensure `StartNetworkBufferConnect` cleans up the socket if SOCKS negotiation fails, preventing descriptor leaks

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689a6a728fb08326893784a45afac3d5