### PR TITLE
Fix Cygwin conditional compilation macros in network buffer code

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -234,7 +234,7 @@ void SetNetworkBufferUserPasswdFunc(NetworkBuffer *NetBuf,
 void BindNetworkBufferToSocket(NetworkBuffer *NetBuf, int fd)
 {
   NetBuf->fd = fd;
-#ifdef CYGIN
+#ifdef CYGWIN
   NetBuf->ioch = g_io_channel_win32_new_socket(fd);
 #else
   NetBuf->ioch = g_io_channel_unix_new(fd);
@@ -273,7 +273,7 @@ gboolean StartNetworkBufferConnect(NetworkBuffer *NetBuf,
 
   if (StartConnect(&NetBuf->fd, bindaddr, realhost, realport, &doneOK,
                    &NetBuf->error)) {
-#ifdef CYGIN
+#ifdef CYGWIN
     NetBuf->ioch = g_io_channel_win32_new_socket(NetBuf->fd);
 #else
     NetBuf->ioch = g_io_channel_unix_new(NetBuf->fd);
@@ -1349,7 +1349,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action, CurlConnection *g)
 {
   SockData *fdp = g_malloc0(sizeof(SockData));
 
-#ifdef CYGIN
+#ifdef CYGWIN
   fdp->ch = g_io_channel_win32_new_socket(s);
 #else
   fdp->ch = g_io_channel_unix_new(s);


### PR DESCRIPTION
## Summary
- Correct the preprocessor guard from CYGIN to CYGWIN in network buffer routines and CURL socket helper

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689a6a6acde883268d633723fed41553