### PR TITLE
Handle getopt error codes explicitly

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2606,6 +2606,7 @@ struct CMDLINE *ParseCmdLine(int argc, char *argv[])
     case 'h':
     case 0:
     case '?':
+    case ':':
       cmdline->help = TRUE;
       break;
     case 'f':

--- a/src/util.c
+++ b/src/util.c
@@ -54,6 +54,8 @@ int getopt(int argc, char *const argv[], const char *str)
   int i, c;
   char *pt;
 
+  optarg = NULL;
+
   while (apos < argc && argv[apos]) {
     if (argv[apos][0] != '-') {
       apos++;
@@ -61,6 +63,8 @@ int getopt(int argc, char *const argv[], const char *str)
     }
     for (i = 1; i < strlen(argv[apos]); i++) {
       c = argv[apos][i];
+      if (c == '-')
+        continue;
       pt = strchr(str, c);
       if (pt) {
         argv[apos][i] = '-';
@@ -69,10 +73,17 @@ int getopt(int argc, char *const argv[], const char *str)
             apos++;
             optarg = argv[apos];
             apos++;
-          } else
-            return 0;
+          } else {
+            optarg = NULL;
+            apos++;
+            return ':';
+          }
         }
         return c;
+      } else {
+        argv[apos][i] = '-';
+        optarg = NULL;
+        return '?';
       }
     }
     apos++;


### PR DESCRIPTION
## Summary
- Return `?` for unknown options and `:` for missing required args in fallback `getopt`
- Reset `optarg` when no argument is found
- Treat `:` as an error in command line parsing

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*
- `make` *(fails: No targets specified and no makefile found)*
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a7b24948326804476059864897d