### PR TITLE
Check sound driver before enabling audio

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2729,7 +2729,7 @@ void CursesLoop(struct CMDLINE *cmdline)
                     LogMessage, NULL);
 
   SoundOpen(cmdline->plugin);
-  SoundEnable(UseSounds);
+  UseSounds = SoundEnable(UseSounds);
 
   display_intro();
 

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -283,7 +283,9 @@ void ToggleSound(GtkWidget *widget, gpointer data)
                                           "<main>/Game/Enable sound");
   if (widget) {
     enable = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget));
-    SoundEnable(enable);
+    enable = SoundEnable(enable);
+    UseSounds = enable;
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widget), enable);
   }
 }
 
@@ -2189,7 +2191,7 @@ gboolean GtkLoop(int *argc, char **argv[],
   gtk_box_pack_start(GTK_BOX(vbox2), menubar, FALSE, FALSE, 0);
   gtk_widget_show_all(menubar);
   UpdateMenus();
-  SoundEnable(UseSounds);
+  UseSounds = SoundEnable(UseSounds);
   widget = dp_gtk_item_factory_get_widget(ClientData.Menu,
                                           "<main>/Game/Enable sound");
   gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widget), UseSounds);

--- a/src/sound.c
+++ b/src/sound.c
@@ -263,9 +263,15 @@ void SoundPlay(const gchar *snd)
   }
 }
 
-void SoundEnable(gboolean enable)
+gboolean SoundEnable(gboolean enable)
 {
+  if (enable && driver == NULL) {
+    sound_enabled = FALSE;
+    return FALSE;
+  }
+
   sound_enabled = enable;
+  return sound_enabled;
 }
 
 gboolean IsSoundEnabled(void)

--- a/src/sound.h
+++ b/src/sound.h
@@ -44,7 +44,7 @@ void SoundInit(void);
 void SoundOpen(gchar *drivername);
 void SoundClose(void);
 void SoundPlay(const gchar *snd);
-void SoundEnable(gboolean enable);
+gboolean SoundEnable(gboolean enable);
 gboolean IsSoundEnabled(void);
 
 #endif /* __DP_SOUND_H__ */


### PR DESCRIPTION
## Summary
- Avoid enabling sound when no driver is active
- Report actual sound state to curses and GTK clients

## Testing
- `gcc tests/test_sound.c src/sound.c src/log.c /tmp/test_stubs.c -DPLUGINS -I src -ldl $(pkg-config --cflags --libs glib-2.0) -o /tmp/test_sound && /tmp/test_sound` *(failed: Package glib-2.0 was not found)*
- `apt-get update -y` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a6b99da588326877e322984c1f5ba