### PR TITLE
Handle ESD connection failures gracefully

### DIFF
--- a/src/plugins/sound_esd.c
+++ b/src/plugins/sound_esd.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <esd.h>
 #include <glib.h>
+#include "../nls.h"
 #include "../sound.h"
 
 #define MAXCACHE 6
@@ -46,6 +47,10 @@ static gboolean SoundOpen_ESD(void)
   int i;
 
   sock = esd_open_sound(NULL);
+  if (sock == -1) {
+    g_warning(_("Cannot connect to ESD sound server"));
+    return FALSE;
+  }
   for (i = 0; i < MAXCACHE; i++) {
     cache[i].esdid = -1;
     cache[i].name = NULL;

--- a/src/sound.c
+++ b/src/sound.c
@@ -203,19 +203,21 @@ SoundDriver *SoundGetPlugin(const gchar *drivername)
 
 void SoundOpen(gchar *drivername)
 {
+  sound_enabled = FALSE;
   if (!drivername || strcmp(drivername, NOPLUGIN) != 0) {
     driver = GetPlugin(drivername);
     if (driver) {
+      gboolean opened = TRUE;
       if (driver->open) {
         dopelog(3, 0, "Using plugin %s", driver->name);
-        /* Only enable sound if the driver opens successfully. */
-        gboolean opened = driver->open();
+        opened = driver->open();
         if (!opened) {
           g_log(NULL, G_LOG_LEVEL_CRITICAL,
                 _("Failed to open sound driver \"%s\"."), driver->name);
           driver = NULL;
         }
       }
+      sound_enabled = opened && (driver != NULL);
     } else if (drivername) {
       gchar *plugins, *err;
 
@@ -228,8 +230,6 @@ void SoundOpen(gchar *drivername)
       g_free(err);
     }
   }
-  /* Only report sound as enabled if a driver was successfully loaded. */
-  sound_enabled = (driver != NULL);
 }
 
 void SoundClose(void)


### PR DESCRIPTION
## Summary
- Warn and abort ESD sound driver initialization when the ESD server cannot be opened
- Only enable sound after a driver successfully opens

## Testing
- `gcc tests/test_sound.c src/sound.c src/log.c /tmp/stub.c -I src -I src/plugins $(pkg-config --cflags --libs glib-2.0) -o /tmp/test_sound && /tmp/test_sound` *(fails: Package 'glib-2.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a6b9e4fa883268bd0d93f882b0af8