### PR TITLE
Adjust street offer discount

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -361,8 +361,8 @@ players.)</dd>
 
 <dt><b>Gun[<i>3</i>].Price=<i>2900</i></b></dt>
 <dd>Sets the price in the gun shop of the <i>3rd</i> gun to <i>$2,900</i>.
-Guns offered "on the street" (i.e. by random events) will be priced at 10%
-of the value set here.</dd>
+Guns offered "on the street" (i.e. by random events) will be priced at about
+one third of the value set here.</dd>
 
 <dt><b>Gun[<i>3</i>].Space=<i>4</i></b></dt>
 <dd>Tells dopewars that gun number <i>3</i> uses <i>4</i> spaces in the 
@@ -571,7 +571,7 @@ current game turn.</dd>
 <dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$50,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
-distribution by 10.</dd>
+distribution by 3.</dd>
 
 <dt><b>Bitch.MaxPrice=<i>150000</i></b></dt>
 <dd>Sets the maximum price for a bitch to <i>$150,000</i>.</dd>

--- a/doc/help/guns.html
+++ b/doc/help/guns.html
@@ -26,7 +26,7 @@ sections in this window to be filled in.<p /></li>
 
 <li><b>Price</b>: The cost of the gun, if you buy it from the Gun Shop. (If
 you are offered it during the course of the game on the street, then it is
-offered at 10% of this price).
+offered at about a third of this price).
 <p /></li>
 
 <li><b>Inventory space</b>: The amount of space that this gun takes up in

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3035,7 +3035,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
       To->Bitches.Price =
-          prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)10;
+          prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)3;
       text =
           dpg_strdup_printf(_
                             ("YN^Hey trader! I'll help carry your %tde for a "
@@ -3048,7 +3048,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
   } else if (!Sanitized && NumGun > 0
              && (TotalGunsCarried(To) < To->Bitches.Carried + 2)) {
     ObjNum = brandom(0, NumGun);
-    To->Guns[ObjNum].Price = Gun[ObjNum].Price / 10;
+    To->Guns[ObjNum].Price = Gun[ObjNum].Price / 3;
     if (Gun[ObjNum].Space > To->CoatSize)
       return 0;
     text = dpg_strdup_printf(_("YN^Would you like to buy a %tde for %P?"),


### PR DESCRIPTION
## Summary
- Tweak street offer pricing so guns and carriers cost roughly one third of normal price
- Document new one-third pricing for street gun and carrier offers

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689b081feed48326bb3e45cad4a5a7e0