### PR TITLE
Raise default hire price range for bitches

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -567,14 +567,14 @@ current game turn.</dd>
 <dd>Sets the price to pay a bitch to tip off the cops to another player to be
 <i>$10,000</i>.</dd>
 
-<dt><b>Bitch.MinPrice=<i>50000</i></b></dt>
-<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$50,000</i>.
+<dt><b>Bitch.MinPrice=<i>80000</i></b></dt>
+<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$80,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
 distribution by 10.</dd>
 
-<dt><b>Bitch.MaxPrice=<i>150000</i></b></dt>
-<dd>Sets the maximum price for a bitch to <i>$150,000</i>.</dd>
+<dt><b>Bitch.MaxPrice=<i>240000</i></b></dt>
+<dd>Sets the maximum price for a bitch to <i>$240,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -207,7 +207,7 @@ struct PRICES Prices = {
 };
 
 struct BITCH Bitch = {
-  50000, 150000
+  80000, 240000
 };
 
 #ifdef NETWORKING

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3034,6 +3034,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
+      /* Street price is one-tenth of the pub price range (8k–24k by default). */
       To->Bitches.Price =
           prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)10;
       text =


### PR DESCRIPTION
## Summary
- raise default Bitch hire price range to 80k–240k
- document new price range and note street price ratio
- clarify server offer logic with street price comment

## Testing
- `./autogen.sh` *(fails: automake missing)*
- `apt-get update` *(fails: repository not signed)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689b081a7f788326a06ef37ab350300a