### PR TITLE
Refine coat size handling and adjust bitch capacity

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -112,6 +112,7 @@ int DrugSortMethod = DS_ATOZ;
 int FightTimeout = 5, IdleTimeout = 14400, ConnectTimeout = 300;
 int MaxClients = 20, AITurnPause = 5;
 price_t StartCash = 2000, StartDebt = 5500;
+int BaseCoatSize = 40;
 GSList *ServerList = NULL;
 
 GScannerConfig ScannerConfig = {
@@ -872,7 +873,7 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
   NewPlayer->Bitches.Carried = 3;
   NewPlayer->CopIndex = 0;
   NewPlayer->Health = 100;
-  NewPlayer->CoatSize = 100;
+  NewPlayer->CoatSize = BaseCoatSize + NewPlayer->Bitches.Carried * 20;
   NewPlayer->Flags = 0;
 #ifdef NETWORKING
   InitNetworkBuffer(&NewPlayer->NetBuf, '\n', '\r',

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3382,7 +3382,7 @@ void ClearPrices(Player *Play)
  */
 void GainBitch(Player *Play)
 {
-  Play->CoatSize += 10;
+  Play->CoatSize += 20;
   Play->Bitches.Carried++;
 }
 
@@ -3398,7 +3398,7 @@ int LoseBitch(Player *Play, Inventory *Guns, Inventory *Drugs)
   GunIndex = g_new(int, NumGun);
 
   ClearInventory(Guns, Drugs);
-  Play->CoatSize -= 10;
+  Play->CoatSize -= 20;
   if (TotalGunsCarried(Play) > 0) {
     if (brandom(0, 100) <
         TotalGunsCarried(Play) * 100 / (Play->Bitches.Carried + 2)) {


### PR DESCRIPTION
## Summary
- Introduce `BaseCoatSize` and compute trench coat capacity from base size plus 20 per assistant
- Increase coat size gain and loss in `GainBitch`/`LoseBitch` to 20 to match new capacity formula

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689b0812d1c08326a4d01d5950acd0ac