### PR TITLE
Clarify street price discount

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -571,7 +571,7 @@ current game turn.</dd>
 <dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$80,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
-distribution by 3.</dd>
+distribution by 3, i.e. about one-third of the pub price range.</dd>
 
 <dt><b>Bitch.MaxPrice=<i>240000</i></b></dt>
 <dd>Sets the maximum price for a bitch to <i>$240,000</i>.</dd>

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3034,7 +3034,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
-      /* Street price is one-tenth of the pub price range (8k–24k by default). */
+      /* Street price is one-third of the pub price range (8k–24k by default). */
       To->Bitches.Price =
           prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)3;
       text =


### PR DESCRIPTION
## Summary
- Fix comment in `OfferObject` to note street price is one-third of pub range.
- Update config docs to note bitches offered on the street cost about one-third of pub price.

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `apt-get update` *(fails: repository not signed)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689b0db9bc708326a9b0c057cc30facf