### PR TITLE
Reduce starting clerics for smaller coat capacity

### DIFF
--- a/doc/clientplay.html
+++ b/doc/clientplay.html
@@ -56,25 +56,25 @@ game and version and licensing information. Press any key to clear this.</li>
 
 <p>The game screen is your interface with the dopewars world. At the top of the
 screen, from left to right, is displayed the game date, the game location
-(you start in the Bronx), the number of bitches working for you, and the
+(you start in the Bronx), the number of clerics working for you, and the
 space you have available for drugs. Note that each drug uses up one "space",
-but some guns may take up more.
-Your "bitches" are your subordinates - each bitch increases your "space"
-by 10 (you yourself start with a space of 20) and can carry one gun (you can
-carry two). Your bitches also take damage for you when in firefights, so it
-is advantageous to acquire extra bitches during the game.</p>
+but some guns may take up more. Your "clerics" are your subordinates - each
+cleric increases your "space" by 20 (you yourself start with a space of 40)
+and can carry one gun (you can carry two). With two clerics you begin with 80
+spaces. Your clerics also take damage for you when in firefights, so it is
+advantageous to acquire extra clerics during the game.</p>
 
 <p>Below the top line of the screen are three large windows. The one in
 the top left lists your statistics - your finances, the health of yourself
-or your bitches, and the number of guns you are carrying. Notice that you
+or your clerics, and the number of guns you are carrying. Notice that you
 start the game with a debt - this will increase, turn by turn, until you
 pay it off to the Loan Shark. The top right window lists the drugs that you
 are currently carrying (you start off with none). Below this is a window in
 which messages from other players (if any) will appear.</p>
 
 <p>Please note that if you are playing in <a href="commandline.html#antique">
-"antique"</a> mode, you do not have "bitches" but instead have a large
-trenchcoat which can carry 100 drugs. Antique mode also disables the
+"antique"</a> mode, you do not have clerics but instead have a large
+trenchcoat which can carry 80 drugs. Antique mode also disables the
 messages window.</p>
 
 <h2><a id="server">Connecting to a dopewars server (or not)</a></h2>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -870,7 +870,7 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
   NewPlayer->Cash = StartCash;
   NewPlayer->Debt = StartDebt;
   NewPlayer->Bank = 0;
-  NewPlayer->Bitches.Carried = 3;
+  NewPlayer->Bitches.Carried = 2;
   NewPlayer->CopIndex = 0;
   NewPlayer->Health = 100;
   NewPlayer->CoatSize = BaseCoatSize + NewPlayer->Bitches.Carried * 20;


### PR DESCRIPTION
## Summary
- Start players with two clerics instead of three and recalculate coat capacity accordingly
- Describe the new starting cleric count and 80-space coat in the client play guide

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689b0dac0a848326b397a86d6a0cf95e