### PR TITLE
Adjust bitch hire price range and update docs

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -567,14 +567,14 @@ current game turn.</dd>
 <dd>Sets the price to pay a bitch to tip off the cops to another player to be
 <i>$10,000</i>.</dd>
 
-<dt><b>Bitch.MinPrice=<i>80000</i></b></dt>
-<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$80,000</i>.
+<dt><b>Bitch.MinPrice=<i>40000</i></b></dt>
+<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$40,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
 distribution by 3.</dd>
 
-<dt><b>Bitch.MaxPrice=<i>240000</i></b></dt>
-<dd>Sets the maximum price for a bitch to <i>$240,000</i>.</dd>
+<dt><b>Bitch.MaxPrice=<i>120000</i></b></dt>
+<dd>Sets the maximum price for a bitch to <i>$120,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -208,7 +208,7 @@ struct PRICES Prices = {
 };
 
 struct BITCH Bitch = {
-  80000, 240000
+  40000, 120000
 };
 
 #ifdef NETWORKING

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2286,6 +2286,7 @@ void SendEvent(Player *To)
       break;
     case E_HIREBITCH:
       if (To->IsAt + 1 == RoughPubLoc) {
+        /* Random pub price for a bitch, defaults to 40k-120k */
         To->Bitches.Price = prandom(Bitch.MinPrice, Bitch.MaxPrice);
         text =
             dpg_strdup_printf(_
@@ -2888,6 +2889,7 @@ void WithdrawFromCombat(Player *Play)
       } else if (CanRunHere(Defend)
                  && brandom(0, 100) > Location[Defend->IsAt].PolicePresence) {
         Defend->EventNum = E_DOCTOR;
+        /* Doctor price scales from the bitch price range (40k-120k by default) */
         Defend->DocPrice = prandom(Bitch.MinPrice, Bitch.MaxPrice) *
             Defend->Health / 500;
         text =
@@ -3034,7 +3036,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
-      /* Street price is one-tenth of the pub price range (8k–24k by default). */
+      /* Street price is one-third of the pub price range (~13k-40k by default). */
       To->Bitches.Price =
           prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)3;
       text =


### PR DESCRIPTION
## Summary
- Lower default price range for hiring a bitch to 40k-120k.
- Clarify server-side price calculations and street price comment.
- Update configuration documentation to reflect new range.

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689b0db486e08326bf1d0a33148ea091