### PR TITLE
Adjust starting cash and street gun prices

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -362,7 +362,7 @@ players.)</dd>
 <dt><b>Gun[<i>3</i>].Price=<i>2900</i></b></dt>
 <dd>Sets the price in the gun shop of the <i>3rd</i> gun to <i>$2,900</i>.
 Guns offered "on the street" (i.e. by random events) will be priced at about
-one third of the value set here.</dd>
+one half of the value set here.</dd>
 
 <dt><b>Gun[<i>3</i>].Space=<i>4</i></b></dt>
 <dd>Tells dopewars that gun number <i>3</i> uses <i>4</i> spaces in the 
@@ -514,8 +514,8 @@ necessarily AI players that connect to a server run on this machine) wait
 <i>5</i> seconds between moving from location to location - i.e. a turn
 takes at least 5 seconds.</dd>
 
-<dt><b>StartCash=<i>2000</i></b></dt>
-<dd>Each player will start the game with <i>$2,000</i> in cash.</dd>
+<dt><b>StartCash=<i>4000</i></b></dt>
+<dd>Each player will start the game with <i>$4,000</i> in cash.</dd>
 
 <dt><b>StartDebt=<i>5000</i></b></dt>
 <dd>Each player will start the game with a debt to the loan shark of

--- a/doc/help/guns.html
+++ b/doc/help/guns.html
@@ -26,7 +26,7 @@ sections in this window to be filled in.<p /></li>
 
 <li><b>Price</b>: The cost of the gun, if you buy it from the Gun Shop. (If
 you are offered it during the course of the game on the street, then it is
-offered at about a third of this price).
+offered at about half of this price).
 <p /></li>
 
 <li><b>Inventory space</b>: The amount of space that this gun takes up in

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -111,7 +111,7 @@ int LoanSharkLoc, BankLoc, GunShopLoc, RoughPubLoc;
 int DrugSortMethod = DS_ATOZ;
 int FightTimeout = 5, IdleTimeout = 14400, ConnectTimeout = 300;
 int MaxClients = 20, AITurnPause = 5;
-price_t StartCash = 2000, StartDebt = 5500;
+price_t StartCash = 4000, StartDebt = 5500;
 int BaseCoatSize = 40;
 GSList *ServerList = NULL;
 

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3034,7 +3034,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
-      /* Street price is one-tenth of the pub price range (8k–24k by default). */
+      /* Street price is one-third of the pub price range (8k–24k by default). */
       To->Bitches.Price =
           prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)3;
       text =
@@ -3049,7 +3049,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
   } else if (!Sanitized && NumGun > 0
              && (TotalGunsCarried(To) < To->Bitches.Carried + 2)) {
     ObjNum = brandom(0, NumGun);
-    To->Guns[ObjNum].Price = Gun[ObjNum].Price / 3;
+    To->Guns[ObjNum].Price = Gun[ObjNum].Price / 2;
     if (Gun[ObjNum].Space > To->CoatSize)
       return 0;
     text = dpg_strdup_printf(_("YN^Would you like to buy a %tde for %P?"),


### PR DESCRIPTION
## Summary
- Increase default starting cash to $4000 so players can afford early gear
- Halve street gun discount to keep the gun shop relevant
- Document new starting cash and street pricing

## Testing
- `make -C po dopewars.pot`
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689b0db80d708326b248414a1a2cb5c8