### PR TITLE
docs: clarify bitch price ranges

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -571,7 +571,7 @@ current game turn.</dd>
 <dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$40,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
-distribution by 3, i.e. about one-third of the pub price range.</dd>
+distribution by 3, i.e. about one-third of the shop price range (~$13,000–$40,000 by default).</dd>
 
 <dt><b>Bitch.MaxPrice=<i>120000</i></b></dt>
 <dd>Sets the maximum price for a bitch to <i>$120,000</i>.</dd>

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3036,7 +3036,7 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
-/* Street price is one-third of the pub price range (~26k–80k by default). */
+/* Street price is one-third of the shop price range (~13k–40k by default). */
       To->Bitches.Price =
           prandom(Bitch.MinPrice, Bitch.MaxPrice) / (price_t)3;
       text =


### PR DESCRIPTION
## Summary
- Correct street price comment to match 40k–120k shop range and ~13k–40k street range
- Update config documentation to describe street and shop price ranges consistently

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689b125a9b2c8326949b00b7a26d9383