### PR TITLE
Add faith message to About dialog and update translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2001-04-08 15:48+0100\n"
 "Last-Translator: Benjamin Karaca <mister-freeze@web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -23,28 +23,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -52,596 +52,596 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "den Kredithai"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "die Bank"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Netzwerk-Port zu dem verbunden werden soll"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Name der Highscore-Datei"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Server zu dem verbunden werden soll"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Begrüßungsnachricht (MOTD) des Servers"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Netzwerkadresse für den Server"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE, wenn ein SOCKS-Server für das Netzwerkspiel genutzt werden soll"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE, wenn numerische Benutzer-IDs für SOCKS4 benutzt werden sollen"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Der Benutzername für SOCKS4, wenn nicht leer"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "Der Hostname eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "Die Port-Adresse eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Die Version des zu verwendenden SOCKS-Protokolls (4 oder 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Benutzername für die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Passwort für  die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE wenn der Server bei einem MetaServer Meldung erstatten soll"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 "Name des Metaservers, zu/von dem Server-Details gesendet/erhalten werden "
 "sollen"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Bevorzugter Hostname deines Servers"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Bestätigung für LocalName mit dem Metaserver"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Server-Beschreibung, die an den Metaserver gemeldet wird"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Wenn TRUE wird der Server zur Taskleiste minimiert"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Wenn TRUE läuft der Server im Hintergrund"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "Das Kommando, welches zum Starten deines Web-Browsers benutzt wird"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Anzahl der Spielrunden (0 = unbegrenzt)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Tag des Monats an dem das Spiel beginnt"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Monat in dem das Spiel beginnt"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Jahr in dem das Spiel beginnt"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr "Das Währungssymbol (z.B. $)"
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Wenn TRUE wird das Währungssymbol dem Preis vorangestellt"
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Datei in welche die Log-Nachrichten geschrieben werden sollen"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Kontrolliert die Anzahl der erzeugten Log-Nachrichten"
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "strftime() Format-String für Zeitstempel in den Log-Nachrichten"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Zufallsereignisse sind entschärft"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE wenn der Wert gekaufter Drogen gespeichert werden soll"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Für die Fehlersuche hilfreiche Nachrichten erzeugen"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Anzahl der Orte im Spiel"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Anzahl der Polizisten im Spiel"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Anzahl der Waffen im Spiel"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Anzahl der Drogen im Spiel"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Position des Kredithais"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Position der Bank"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Position des Waffenladens"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Position des Pubs"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Täglicher Zinssatz beim Kredithai"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Täglicher Zinssatz deines Bankguthabens"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Name des Kredithais"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Name der Bank"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Name des Waffenladens"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Name des Pubs"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE wenn Sounds aktiviert werden sollen"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Sound-Datei für einen Treffer"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Sound-Datei für einen verfehlten Schuss"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Sound-Datei für das Nachladen einer Waffe"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr "Sound-Datei für das Ableben einer/s feindlichen Hure/Hilfssheriffs"
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr "Sound-Datei für das Ableben einer eigenen Hure"
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr "Sound-Datei für das Ableben eines anderen Spielers oder Polizisten"
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Sound-Datei für DEIN Ableben"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Sound-Datei für eine erfolglose Flucht eines anderen Spielers"
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Sound-Datei für eine erfolglose Flucht von dir"
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr "Sound-Datei für eine gelungene Flucht eines anderen Spielers"
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr "Sound-Datei für eine gelungene Flucht von dir"
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Sound-Datei für die Ankunft an einem neuen Ort"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr "Sound-Datei für den Beitritt eines Spielers zu einem Spiel"
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr "Sound-Datei für den Ausstieg eines Spielers aus einem Spiel"
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr "Sound-Datei für den Start des Spieles"
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr "Sound-Datei für das Ende des Spieles"
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Taste für das Sortieren der Liste der vorhandenen Drogen"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Sekundenanzahl in denen zurückgeschossen werden muss"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Spieler werden nach Ablauf dieser Sekunden getrennt"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Sekundenanzahl um Verbindungen herzustellen oder zu beenden"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maximale Anzahl der TCP/IP-Verbindungen"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Sekundenanzahl zwischen den Runden der KI-Spieler"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Startkapital der einzelnen Spieler"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Startschulden der einzelnen Spieler"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Namen der einzelnen Orte"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Polizeipräsenz an den einzelnen Orten (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Mindestanzahl an Drogen an jedem Ort"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Maximale Anzahl an Drogen an jedem Ort"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% Trefferresistenz jedes Spielers"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% Trefferresistenz jeder Huren"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Namen der einzelnen Polizisten"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Name des Hilfssheriffs jedes einzelnen Polizisten"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Name der Hilfssheriffs jedes einzelnen Polizisten"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% Trefferresistenz jedes Polizisten"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% Trefferresistenz jedes Hilfssheriffs"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Angriffserschwernis im Verhältnis zu einem Spieler"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Verteidigungserschwernis im Verhältnis zu einem Spieler"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Minimale Anzahl der begleitenden Hilfssheriffs"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Maximale Anzahl der begleitenden Hilfssheriffs"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Index der Waffe mit der Polizisten bewaffnet sind (Null-basiert)"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Anzahl der Waffen die jeder Polizist trägt"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Anzahl der Waffen die jeder Hilfssheriff trägt"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Name jeder Droge"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Minimaler Standardpreis jeder Droge"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Maximaler Standardpreis jeder Droge"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE wenn diese Droge extrem billig sein kann"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE wenn diese Droge extrem teuer sein kann"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Nachricht die angezeigt wird wenn diese Droge extrem billig ist"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 "Format-String der mit 50%-iger Wahrscheinlichkeit für teure Drogen benutzt "
 "wird "
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 "Teiler der für den Drogenpreis benutzt wird wenn dieser extrem billig ist"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplikationsfaktor bei extrem hohen Drogenpreisen"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Namen der einzelnen Orte"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Preis jeder Waffe"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Platzverbrauch jeder Waffe"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Schaden jeder Waffe"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Wie soll eine einzelne Hure bezeichnet werden?"
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Wie sollen zwei oder mehrere Huren bezeichnet werden?"
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Wie soll eine einzelne Waffe oder Ähnliches bezeichnet werden?"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Wie sollen zwei oder mehrere Waffen bezeichnet werden?"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Wie soll eine einzelne Droge oder Ähnliches bezeichnet werden?"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Wie sollen zwei oder mehrere Drogen bezeichnet werden?"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() Format-String für das Anzeigen der Spielrunden"
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Minimaler Geldbetrag für das Anheuern einer Hure"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Minimaler Geldbetrag fuer das Anheuern einer Hure"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Liste der Dinge die du in der U-Bahn aufschnappen kannst"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Anzahl der Dinge"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Liste der Lieder die du spielen hören kannst"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Anzahl der Lieder"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Liste der Dinge die du machen kannst"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Anzahl der Dinge die du machen kannst"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -649,140 +649,140 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 "Der Markt wird mit billigem, selbst hergestelltem Acid geradezu überflutet!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -792,48 +792,48 @@ msgstr ""
 "Weed ist ins bodenlose gefallen!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Nachricht"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr ""
 "Die Polizei hat eine große Menge %tde konfisziert! Die Preise schießen in "
 "die Höhe!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Junkies kaufen %tde für horrende Summen!"
@@ -842,160 +842,160 @@ msgstr "Junkies kaufen %tde für horrende Summen!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Wäre es nicht cool, wenn alle plötzlich mal zittern würden?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "Der Papst war mal jüdisch, weißte?"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Ich möchte wetten, dass du interessante Träume hast."
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Ich glaub' ich fahr' dieses Jahr mal wieder nach Amsterdam."
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Mein Sohn, du brauchst 'nen gelben Haarschnitt."
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ich finde es wundervoll was man heutzutage mit Düften alles anstellt."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "Ich war nicht immer ne Frau, weißte?"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Weiß deine Mami, dass du'n Dealer bist"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "Bist du bekifft?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Oh, du musst aus Kalifornien kommen."
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Ich war selber mal 'n Hippie."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Es geht einfach nichts über 'nen riesen Haufen Zaster!"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "Du siehst aus wie 'n Erdferkel!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Ich glaube nicht an Ronald Reagan!"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Verbreitet die Wahrheit! Bush ist eine Nudel!"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Hab' ich dich nich' mal im Fernsehen gesehen?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Wir gewinnen den Kampf um die Drogen!"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Ein Tag ohne Drogen ist so dunkel wie die Nacht."
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Man benutzt ohnehin nur 20% seines Gehirns, warum soll man sich da nicht die "
 "restlichen 80% zudröhnen?!"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Ich erbitte Spenden für Zombies... für Jesus!"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Darf ich dir diesen hochgestylten Pudel verkaufen?"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Gewinner nehmen keine Drogen... es sei denn, sie nehmen welche!"
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus liebt dich mehr als du glaubst."
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "Magst du ein Gummibärchen?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Ausführen der Konfigurationsdatei %s in Zeile %d abgebrochen"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Fehler beim Öffnen der Datei %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -1006,40 +1006,40 @@ msgstr ""
 "oder entferne sie mit dem push oder kill Kommando und versuche es dann noch "
 "mal"
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Index in Array %s sollte zwischen 1 und %d sein"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s ist %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s ist %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s ist %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s ist \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] ist %s\n"
@@ -1047,66 +1047,66 @@ msgstr "%s[%d] ist %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s ist { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kann nicht kleiner sein als %d  ignorieren!"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kann nicht größer sein als %d  ignorieren!"
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Optimierte Struktur-Liste von %d Elementen\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Erwarteter Boolean-Wert (0, FALSE, 1, TRUE"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1179,7 +1179,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1191,7 +1191,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1251,7 +1251,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1261,7 +1261,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1271,7 +1271,7 @@ msgstr ""
 "Option \"--enable-curses-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den GTK+-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1281,7 +1281,7 @@ msgstr ""
 "Option \"--enable-gui-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den curses-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 #, fuzzy
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
@@ -1293,7 +1293,7 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben"
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1570,11 +1570,11 @@ msgid "How many do you drop? "
 msgstr "Wie viel schmeißt du weg? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Was willst du kaufen? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "Was möchtest du verscherbeln? "
 
@@ -1603,7 +1603,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Willst du wirklich aufhören? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "JN"
 
@@ -1621,51 +1621,51 @@ msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre zum Einzelspieler-Modus zurück"
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s betritt das Spiel!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s hat das Spiel verlassen."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s ist nun bekannt als %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Derzeitiger Aufenthaltsort/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Leider benutzt schon jemand anders \"deinen\" Namen. Bitte ändere Ihn"
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "B E S T E N L I S T E"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
@@ -1673,27 +1673,27 @@ msgstr "Du hast keine %tde die du verkaufen könntest!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du brauchst mehr %tde Platz um noch mehr %tde tragen zu können!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du hast nicht genug Platz um eine %tde zu tragen!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du hast nicht genug Kohle für eine %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 
@@ -1701,41 +1701,41 @@ msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "EVG"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Wieviel Geld möchtest Du zurückzahlen?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Soviel Kohle hast Du nicht!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Möchtest Du E>inzahlen, A>bheben, oder die Bank V>erlassen? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "EAV"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Wie viel Kohle?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "So viel Knete hast du gar nicht..."
 
@@ -1743,47 +1743,47 @@ msgstr "So viel Knete hast du gar nicht..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Nein"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "R:Rennen"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "K:Kämpfen"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Angriff"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "V:Verschwinden"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Drück irgend'ne Taste..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Nachrichten (-/+ zum Scrollen)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistik"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Bargeld"
 
@@ -1791,41 +1791,41 @@ msgstr "Bargeld"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Gesundheit"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Konto"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Schulden"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Platz %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Platz %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Mantel"
 
@@ -1833,134 +1833,134 @@ msgstr "Mantel"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogen/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogen/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Tja, Du bist alleine auf der Welt!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Eingeloggte Mitspieler:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hey Kleiner, die %tde Preise von hier:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kann den SIGWINCH Interrupt Handler nicht installieren"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Hey Kleiner, wie lautet dein Name? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Willst Du E>inkaufen"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", V>erkaufen"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", W>egwerfen"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", S>prechen, F>lüstern"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", L>iste"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", K>ämpfen"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", R>eisen"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", oder B>eenden? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Willst Du "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "K>ämpfen, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "S>tehen bleiben, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "R>ennen, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "mit %tde H>andeln, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "oder B>eenden? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre in den Einzelspieler-Modus zurück"
@@ -1968,7 +1968,7 @@ msgstr ""
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "EVWSFLAKRB"
@@ -1976,30 +1976,30 @@ msgstr "EVWSFLAKRB"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "HRKSE"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Zeige S>pieler oder P>unkte? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Wem möchtest du etwas zuflüstern ? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Sprich: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Möchtest du noch mal spielen? "
 
@@ -2084,24 +2084,24 @@ msgid "Abandon game"
 msgstr "Spiel Abbrechen"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventar"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Schließen"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Verbindung zum Server verloren - wechsle in Einzelspieler-Modus"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -2110,7 +2110,7 @@ msgstr ""
 "Kehre in Einzelspieler-Modus zurück."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2148,7 +2148,7 @@ msgstr "_%Tde dealen"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Kämpfen"
 
@@ -2273,16 +2273,15 @@ msgstr "Wieviel Verkaufen?"
 msgid "Drop how many?"
 msgstr "Wieviel Wegwerfen?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
@@ -2327,65 +2326,65 @@ msgid "Question"
 msgstr "Frage"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Platz"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Deutsche Übersetzung"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Symbole und Grafiken"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sounds"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Drogen Handel und Nachforschung"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testspieler"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Exzessives Testspielen"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Konstruktive Kritik"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Unkonstruktive Kritik"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2396,6 +2395,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2409,7 +2409,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2419,7 +2419,7 @@ msgstr ""
 "Dopewars wurde unter der GNU General Public License veröffentlicht.\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2431,134 +2431,134 @@ msgstr ""
 "deiner \n"
 "UNIX-shell ein. Alle verfügbaren Kommandos werden dann angezeigt.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Lokale HTML Dokumentation"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Kredithai Fenstertitel/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/BankName Fenstertitel/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Sie müßen einen positiven Geldbetrag eingeben!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Ein B?nker spricht: \"Soviel Geld haben Sie nicht.\""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Bargeld: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Schulden: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Konto: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Zurückzahlen:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Einzahlen"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Abheben"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Bezahle alles"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Spieler Liste"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Rede mit Spieler(n)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Rede mit allen Spielern"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Nachricht:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Senden"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Name"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preis"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Anzahl"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Einkaufen ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Verkaufen"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Wegwerfen <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde hier"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde dabei"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Ändere Name"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2566,12 +2566,12 @@ msgstr "Leider benutzt schon jemand anders \"deinen\" Namen, ändere Ihn bitte."
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Waffenladen Fenstertitel/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2749,7 +2749,7 @@ msgstr "Zur Taskleiste minimieren"
 msgid "Metaserver URL"
 msgstr "MetaServer"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -2757,9 +2757,7 @@ msgstr "Kommentar"
 msgid "MOTD (welcome message)"
 msgstr "Begrüßungsnachricht"
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Server"
 
@@ -2787,127 +2785,59 @@ msgstr "Abspielen"
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kannst kein Spiel starten, ohne vorher einen Namen anzugeben!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Neues Spiel"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: Warte auf Benutzereingabe"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Verbindung wurde durch remote Host geschlossen"
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Konnte keine Verbindung zu %s herstellen"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: Versuche Verbindung zu %s herzustellen..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d von %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Verbinde mit SOCKS server %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Authentifizieren mit SOCKS server"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Status: Frage SOCKS um zu %s zu verbinden..."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Port"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Version"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Spieler"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Hey Kleiner, wie heißt Du? "
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Rechnername"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Verbinde"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Starte Einzelspieler Spiel"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Einzelspieler"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "MetaServer"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "SOCKS Authentifizierung benötigt"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3355,74 +3285,74 @@ msgstr "Du hörst jemanden %s spielen"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Möchtest du %tde besuchen?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Willst Du eine %tde für %P anwerben?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s ist schon hier!^Willst du angreifen, oder dich verdrücken?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "Keine Bullen oder Waffen!"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "Polizisten können sich nicht gegenseitig angreifen."
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "Spieler kämpfen bereits!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "Spieler kämpfen bereits in verschieden Kämpfen!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kann nicht kämpfen - keine Waffen vorhanden!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 "YN^Willst du einem Doktor %P blechen, damit er dich wieder zusammenflickt?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du wurdest in der U-Bahn bestohlen!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du triffst einen Freund! Er gibt dir %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du triffst einen Freund! Du gibst ihm %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3430,17 +3360,17 @@ msgstr ""
 "Polizeihunde jagend dich %d Blocks entlang! Du hast ein wenig %tde "
 "weggeworfen! So'n Scheiß."
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du findest %d %tde bei einem toten Penner in der U-Bahn!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Deine Mama hat aus deinem %tde Brownies gemacht! Die waren super!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3449,25 +3379,25 @@ msgstr ""
 "YN^Du findest etwas Weed, das wie wie übelstes Rattengift stinkt!^Sieht aber "
 "sonst ganz gut aus! Willst Du es rauchen?"
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du machst eine kleine Pause um %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Möchtest Du einen größeren Mantel für %P kaufen?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hey Kumpel! Ich trage dir %tde für %P. Wie wär's? Ja oder Nein?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Willst Du eine %tde für %P kaufen?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3477,29 +3407,29 @@ msgstr ""
 "alles, was du bisher erlebt hast. Dann bist du abgekratzt, weil dein Gehirn "
 "in tausend Teile zersprungen ist."
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Zu spät - %s hat sich verpisst!"
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, fuzzy, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Die Cops haben dich gesehen als du %tde wegwerfen wolltest!"
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sende Update an Metaserver..."
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sende Erinnerungsnachricht an Metaserver..."
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Spieler entfernt aufgrund von Idle Timeout"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Spieler entfernt aufgrund von Timeout bei Verbindungsaufbau"
 
@@ -3779,86 +3709,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kann WinSock nicht initialisieren (%s)"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "SOCKS-Server allgemeiner Fehler"
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Verbindung von SOCKS ruleset abgelehnt"
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Netzwerk unerreichbar"
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Host unerreichbar"
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Verbindung abgelehnt"
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL abgelaufen"
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Befehl nicht unterstützt"
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Addressen-Typ nicht unterstützt"
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS: Server hat alle angebotenen Methoden abgelehnt"
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr "Unbekannter SOCKS Addressentyp zurückgekehrt"
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-Bestätigung fehlgeschlagen"
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-Bestätigung vom Benutzer abgebrochen"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Nachfrage abgelehnt oder fehlgeschlagen"
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Abgelehnt  unmöglich identd zu kontaktieren"
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Abgelehnt  identd meldet andere Benutzer-ID"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Unbekannter SOCKS Antwort-Code"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr "Unbekannter SOCKS Antwort-Version-Code"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr "Unbekannte SOCKS Server-Version"
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS Fehler Code %d"
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4046,12 +3976,12 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben"
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Fehler beim Öffnen der Datei %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4059,6 +3989,41 @@ msgid ""
 msgstr ""
 "Ungültiges Plugin \"%s\" ausgewählt.\n"
 "(%s verfügbar; verwende nun \"%s\".)"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: Versuche Verbindung zu %s herzustellen..."
+
+#~ msgid "Unknown"
+#~ msgstr "Unbekannt"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d von %d"
+
+#~ msgid "Port"
+#~ msgstr "Port"
+
+#~ msgid "Version"
+#~ msgstr "Version"
+
+#~ msgid "Players"
+#~ msgstr "Spieler"
+
+#~ msgid "Host name"
+#~ msgstr "Rechnername"
+
+#~ msgid "_Connect"
+#~ msgstr "_Verbinde"
+
+#~ msgid "Single player"
+#~ msgstr "Einzelspieler"
+
+#~ msgid "Metaserver"
+#~ msgstr "MetaServer"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "SOCKS Authentifizierung benötigt"
 
 #~ msgid "bitch"
 #~ msgstr "Hure"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars SVN\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,28 +22,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -51,584 +51,584 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr ""
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr ""
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr ""
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr ""
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr ""
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr ""
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr ""
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr ""
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr ""
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr ""
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr ""
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr ""
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr ""
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr ""
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr ""
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr ""
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr ""
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr ""
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr ""
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr ""
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr ""
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr ""
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr ""
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr ""
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr ""
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr ""
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr ""
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 msgid "Name of each weapon"
 msgstr ""
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 msgid "Price of each weapon"
 msgstr ""
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 msgid "Space taken by each weapon"
 msgstr ""
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 msgid "Damage done by each weapon"
 msgstr ""
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr ""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr ""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr ""
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr ""
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr ""
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr ""
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr ""
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr ""
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr ""
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr ""
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr ""
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr ""
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr ""
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr ""
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -636,183 +636,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr ""
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 msgid "Edessa"
 msgstr ""
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr ""
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
@@ -821,182 +821,182 @@ msgstr ""
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr ""
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr ""
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 msgid "So I think I'm going to Alexandria this year"
 msgstr ""
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 msgid "Son, you need a yellow horse"
 msgstr ""
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr ""
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr ""
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 msgid "Does your mother know you're a war monger?"
 msgstr ""
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 msgid "Are you praying something?"
 msgstr ""
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 msgid "Oh, you must be from Constantinople"
 msgstr ""
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr ""
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 msgid "I don't believe in Pope Urban II"
 msgstr ""
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 msgid "Haven't I seen you at the Tavern?"
 msgstr ""
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 msgid "We're winning the war for Empire!"
 msgstr ""
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 msgid "A day without grace is like night"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 msgid "I'd like to sell you the Holy Grail"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr ""
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 msgid "Would you like a cabbage?"
 msgstr ""
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr ""
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
@@ -1004,66 +1004,66 @@ msgstr ""
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1108,7 +1108,7 @@ msgid ""
 "format\n"
 msgstr ""
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1120,7 +1120,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1153,7 +1153,7 @@ msgid ""
 "  -A       connect to a locally-running server for administration\n"
 msgstr ""
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1163,21 +1163,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1185,7 +1185,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1443,11 +1443,11 @@ msgid "How many do you drop? "
 msgstr ""
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr ""
 
@@ -1476,7 +1476,7 @@ msgid "Are you sure you want to quit? "
 msgstr ""
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr ""
 
@@ -1493,51 +1493,51 @@ msgstr ""
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr ""
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr ""
 
@@ -1545,27 +1545,27 @@ msgstr ""
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
@@ -1573,41 +1573,41 @@ msgstr ""
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr ""
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr ""
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
@@ -1615,47 +1615,47 @@ msgstr ""
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr ""
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr ""
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr ""
 
@@ -1663,41 +1663,41 @@ msgstr ""
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr ""
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr ""
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr ""
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr ""
 
@@ -1705,168 +1705,168 @@ msgstr ""
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr ""
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 msgid "Hey there! What's your name? "
 msgstr ""
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ""
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr ""
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr ""
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr ""
 
@@ -1951,31 +1951,31 @@ msgid "Abandon game"
 msgstr ""
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr ""
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2010,7 +2010,7 @@ msgstr ""
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr ""
 
@@ -2133,16 +2133,15 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr ""
 
@@ -2187,64 +2186,64 @@ msgid "Question"
 msgstr ""
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr ""
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr ""
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2255,6 +2254,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2268,7 +2268,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2276,7 +2276,7 @@ msgid ""
 msgstr ""
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2284,134 +2284,134 @@ msgid ""
 "options.\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr ""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr ""
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr ""
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr ""
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr ""
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr ""
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr ""
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr ""
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr ""
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr ""
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr ""
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr ""
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr ""
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr ""
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr ""
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr ""
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr ""
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2419,12 +2419,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "Metaserver URL"
 msgstr ""
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr ""
 
@@ -2601,9 +2601,7 @@ msgstr ""
 msgid "MOTD (welcome message)"
 msgstr ""
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr ""
 
@@ -2631,125 +2629,57 @@ msgstr ""
 msgid "_Help"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr ""
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr ""
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr ""
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr ""
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr ""
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr ""
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr ""
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
-msgstr ""
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr ""
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
 msgstr ""
 
 #: src/gtkport/gtkport.c:5508
@@ -3157,135 +3087,135 @@ msgstr ""
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3562,86 +3492,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -3814,12 +3744,12 @@ msgid ""
 "Recompile passing --enable-networking to the configure script."
 msgstr ""
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars SVN\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2020-12-09 12:02-0800\n"
 "Last-Translator: Ben Webb <benwebb@users.sf.net>\n"
 "Language-Team: British English <en@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -49,584 +49,584 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr ""
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr ""
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr ""
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr ""
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr ""
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr ""
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr ""
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr ""
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr ""
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr ""
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr ""
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr ""
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr ""
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr ""
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr ""
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr ""
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr ""
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr ""
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr ""
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr ""
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr ""
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr ""
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr ""
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr ""
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr ""
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr ""
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr ""
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 msgid "Name of each weapon"
 msgstr ""
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 msgid "Price of each weapon"
 msgstr ""
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 msgid "Space taken by each weapon"
 msgstr ""
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 msgid "Damage done by each weapon"
 msgstr ""
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr ""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr ""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr ""
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr ""
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr ""
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr ""
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr ""
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr ""
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr ""
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr ""
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr ""
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr ""
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr ""
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr ""
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -634,183 +634,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr ""
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 msgid "Edessa"
 msgstr ""
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr ""
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
@@ -819,182 +819,182 @@ msgstr ""
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr ""
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr ""
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 msgid "So I think I'm going to Alexandria this year"
 msgstr ""
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 msgid "Son, you need a yellow horse"
 msgstr ""
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr ""
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr ""
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 msgid "Does your mother know you're a war monger?"
 msgstr ""
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 msgid "Are you praying something?"
 msgstr ""
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 msgid "Oh, you must be from Constantinople"
 msgstr ""
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr ""
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 msgid "I don't believe in Pope Urban II"
 msgstr ""
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 msgid "Haven't I seen you at the Tavern?"
 msgstr ""
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 msgid "We're winning the war for Empire!"
 msgstr ""
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 msgid "A day without grace is like night"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 msgid "I'd like to sell you the Holy Grail"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr ""
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 msgid "Would you like a cabbage?"
 msgstr ""
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr ""
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
@@ -1002,66 +1002,66 @@ msgstr ""
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1146,7 +1146,7 @@ msgstr ""
 "  -C, --convert=FILE      convert an \"old format\" score file to the new "
 "format\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1158,7 +1158,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1220,7 +1220,7 @@ msgstr ""
 "  -C file  convert an \"old format\" score file to the new format\n"
 "  -A       connect to a locally-running server for administration\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1230,21 +1230,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1252,7 +1252,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1511,11 +1511,11 @@ msgid "How many do you drop? "
 msgstr ""
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgid "Are you sure you want to quit? "
 msgstr ""
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr ""
 
@@ -1561,51 +1561,51 @@ msgstr ""
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr ""
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr ""
 
@@ -1613,27 +1613,27 @@ msgstr ""
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
@@ -1641,41 +1641,41 @@ msgstr ""
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr ""
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr ""
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
@@ -1683,47 +1683,47 @@ msgstr ""
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr ""
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr ""
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr ""
 
@@ -1731,41 +1731,41 @@ msgstr ""
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr ""
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr ""
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr ""
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr ""
 
@@ -1773,168 +1773,168 @@ msgstr ""
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr ""
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 msgid "Hey there! What's your name? "
 msgstr ""
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ""
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr ""
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr ""
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr ""
 
@@ -2019,31 +2019,31 @@ msgid "Abandon game"
 msgstr ""
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr ""
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2078,7 +2078,7 @@ msgstr ""
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr ""
 
@@ -2201,16 +2201,15 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr ""
 
@@ -2255,64 +2254,64 @@ msgid "Question"
 msgstr ""
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr ""
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr ""
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2323,6 +2322,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2336,7 +2336,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2346,7 +2346,7 @@ msgstr ""
 "dopewars is released under the GNU General Public Licence\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2354,134 +2354,134 @@ msgid ""
 "options.\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr ""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr ""
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr ""
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr ""
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr ""
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr ""
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr ""
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr ""
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr ""
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr ""
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr ""
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr ""
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr ""
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr ""
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr ""
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr ""
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr ""
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2489,12 +2489,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2664,7 +2664,7 @@ msgstr ""
 msgid "Metaserver URL"
 msgstr ""
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr ""
 
@@ -2672,9 +2672,7 @@ msgstr ""
 msgid "MOTD (welcome message)"
 msgstr ""
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr ""
 
@@ -2702,125 +2700,57 @@ msgstr ""
 msgid "_Help"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr ""
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr ""
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr ""
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr ""
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr ""
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr ""
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr ""
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr ""
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
-msgstr ""
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr ""
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
 msgstr ""
 
 #: src/gtkport/gtkport.c:5508
@@ -3228,135 +3158,135 @@ msgstr ""
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3633,86 +3563,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "Cannot initialise WinSock (%s)!"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS authentication cancelled by user"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -3885,12 +3815,12 @@ msgid ""
 "Recompile passing --enable-networking to the configure script."
 msgstr ""
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2003-12-10 09:29+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -29,28 +29,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -58,599 +58,599 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de su servidor"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "La orden usada para iniciar su navegador web"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Número de rondas de juego (si es 0, el juego nunca termina)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Día del mes en el que empieza el juego"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Mes en el que empieza el juego"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Año en el que empieza el juego"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr "El símbolo de dinero (por ejemplo, $)"
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si TRUE, el símbolo de dinero va antes que el precio"
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Fichero en el que escribir los mensajes de registro"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Controla el número de mensajes de registro producidos"
 
 # timestamps: dataciones estampilla marcas temporales
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "formato de la cadena strftime() para las marcas de tiempo"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Se limpian los eventos aleatorios"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE si se debe guardar el valor de las drogas compradas"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Ser prolijo al procesar el fichero de configuración"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Número de sitios en el juego"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de policía en el juego"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Número de armas en el juego"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Número de drogas en el juego"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Ubicación del usurero"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Ubicación del banco"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Ubicación de la armería"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Ubicación del bar"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Tasa de interés diaria de la deuda con el usurero"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Tipo de interés diario de su saldo en el banco"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nombre del usurero"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nombre del banco"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nombre de la armería"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nombre del bar"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE si se debe habilitar el sonido"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Fichero de sonido que suena cuando un disparo hace blanco"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Fichero de sonido que suena cuando un disparo yerra su objetivo"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 "Fichero de sonido que suena cuando se mata a un ayudante o a una puta enemiga"
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr "Fichero de sonido reproducido cuando muere una de sus putas"
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Fichero de sonido reproducido cuando se mata a otro jugador o a un policía"
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Fichero de sonido reproducido cuando le matan a usted"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 "Fichero de sonido reproducido cuando un jugador intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 "Fichero de sonido reproducido cuando usted intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr "Fichero de sonido reproducido cuando un jugador logra escapar"
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr "Fichero de sonido reproducido cuando usted logra escapar"
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr "Fichero de sonido que suena cuando un jugador abandona el juego"
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr "Fichero de sonido reproducido al empezar el juego"
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr "Fichero de sonido reproducido al acabar el juego"
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Orden de las drogas disponibles"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos para devolver disparos"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Los jugadores son desconectados después de este número de segundos"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tiempo en segundos para que las conexiones sean establecidas o rotas"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexiones TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre los turnos de los jugadores automáticos"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Cantidad de dinero con la que empieza cada jugador"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Importe de la deuda con la que empieza cada jugador"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Presencia policial en cada sitio (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas en cada sitio"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Máximo número de drogas en cada lugar"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% de resistencia a disparos de cada puta"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Nombre de cada policía"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Nombre del ayudante de cada policía"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Nombre de los ayudantes de cada policía"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistencia a disparos de cada policía"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistencia a disparos de cada ayudante"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Penalización de ataque relativa a un jugador"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Penalización de defensa relativa a un jugador"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ayudantes acompañantes"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ayudantes acompañantes"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 "Índice basado en cero de la pistola con la que están armados los policías"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Número de pistolas que porta cada policía"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Número de pistolas con las que carga cada ayudante"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nombre de cada droga"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Precio mínimo normal de cada droga"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Precio máximo normal de cada droga"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE si esta droga puede ser especialmente barata"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE si esta droga puede ser especiamente cara"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensaje a mostrar cuando esta droga sea especialmente barata"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Línea utilizada para drogas que sean caras el 50% de las veces"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor del precio de la droga cuando es especialmente barata"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Precio de cada arma"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Espacio que ocupa cada arma"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Palabra usada para designar una sola \"puta\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Palabra usada para designar dos o más \"putas\""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palabra usada para designar una sola arma"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Palabra usada para designar dos o más armas"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palabra usada para designar una sola droga"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Palabra usada para designar dos o más drogas"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar la ronda del juego"
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Precio mínimo de contratar una puta"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Precio máximo de contratar una puta"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de cosas que se oyen en el metro"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Número de cosas que se dicen en el metro"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Lista de canciones que se oyen tocar"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Número de canciones que se tocan"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Lista de cosas que puede dejar de hacer"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puede dejar de hacer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -658,139 +658,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "¡El mercado está inundado de LSD casero barato!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -798,47 +798,47 @@ msgid ""
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Mensaje"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr ""
 "¡Los polis han hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los adictos están comprando %tde a precios absurdos!"
@@ -847,163 +847,163 @@ msgstr "¡Los adictos están comprando %tde a precios absurdos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite!"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "De todo lo que he perdido, lo que más echo de menos es la cabeza."
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Apuesto a que tiene sueños superinteresantes"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Creo que voy a ir a Amsterdam este año"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Chico, deberías teñirte el pelo de color amarillo"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Pero ¿por qué llevas gafas de sol si es de noche?"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "Yo no he sido siempre una mujer, ¿sabes?"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "¿Su madre sabe que es un camello?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "¿Está drogado o qué?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, usted debe ser gallego"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 "Hmmm... ¡qué almuerzo! Mi madre me ha preparado unas galletas de... "
 "chocolate."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Poderoso caballero es Don Dinero"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr ""
 "Sólo usamos el 10% de nuestro cerebro. ¡Destruyamos con drogas el 90% "
 "sobrante!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "No puedo más, me voy a la cama. ¿Me acompaña?"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "¡Ánimo! El imperio estadounidense caerá como cayó el imperio romano"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Usted sale en la televisión, ¿verdad?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "¿Sabe que tiene los ojos muy enrojecidos, joven?"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "¿Se imagina como sería la vida si no hubiera drogas?"
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "En las hamburgueserías usan carne de rata. Por eso la dan picada."
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 "`Cuestionemos la autoridad; pensemos por nosotros mismos` dijo Tim Leary"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Le vendo una cámara de fotos nueva a mitad de precio"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Los triunfadores no usan drogas... salvo..."
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Espero que no le importe, pero voy a rezar por usted."
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "La telepatía existe. ¿No siente la energía del universo?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -1014,40 +1014,40 @@ msgstr ""
 "jugador conectado. Espere a que se desconecten todos los jugadores, o\n"
 "elimínelos con las órdenes echar o matar, e inténtelo otra vez."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
@@ -1055,42 +1055,42 @@ msgstr "%s[%d] es %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1098,7 +1098,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1106,19 +1106,19 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars versión %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1209,7 +1209,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 #, fuzzy
 msgid ""
 "  -h, --help              display this help information\n"
@@ -1228,7 +1228,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1291,7 +1291,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 #, fuzzy
 msgid ""
 "  -h       display this help information\n"
@@ -1308,7 +1308,7 @@ msgstr ""
 "GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1318,7 +1318,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o use una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1328,7 +1328,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o use el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1336,7 +1336,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1620,11 +1620,11 @@ msgid "How many do you drop? "
 msgstr "¿Cuántas quiere tirar? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quiere comprar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "¿Qué quiere vender? "
 
@@ -1653,7 +1653,7 @@ msgid "Are you sure you want to quit? "
 msgstr "¿Está seguro de que quiere salir? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "SN"
 
@@ -1670,51 +1670,51 @@ msgstr "Ha sido expulsado del servidor. Pasando al modo 1 jugador."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s es ahora conocido como %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Desgraciadamente ya hay alguien usando «su» nombre. Elija otro."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tiene ningún %tde que vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "¡No tiene ninguna que vender!"
 
@@ -1722,27 +1722,27 @@ msgstr "¡No tiene ninguna que vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesita más %tde para que le guarden más %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tiene suficiente espacio para llevar ese %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tiene suficiente dinero para comprar ese %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 
@@ -1750,41 +1750,41 @@ msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVI"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quiere devolver? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "¡No tiene tanto dinero!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quiere I>ngresar dinero, O>btener dinero o S>alir?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "IOS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tiene tanto dinero en el banco..."
 
@@ -1792,47 +1792,47 @@ msgstr "No tiene tanto dinero en el banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:No"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "E:Enfrentarse"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "H:Huir"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Pulse cualquier tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Situación"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Dinero"
 
@@ -1840,41 +1840,41 @@ msgstr "Dinero"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Salud"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Deuda"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
@@ -1882,141 +1882,141 @@ msgstr "Gabardina"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, oiga. Los precios de las %tde aquí son:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Eh oiga, ¿cómo se llama? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "¿Quiere C>omprar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", E>nfrentarse"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", I>r a otro sitio"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "¿Quiere "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>ender %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "CVTHJLMEIS"
@@ -2024,30 +2024,30 @@ msgstr "CVTHJLMEIS"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "VCLES"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quiere? ¿J>ugadores o P>untuaciones? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "¿Con quién quiere hablar en privado?"
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Decir: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
@@ -2132,24 +2132,24 @@ msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventario"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -2158,7 +2158,7 @@ msgstr ""
 "Pasando al modo 1 jugador."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2195,7 +2195,7 @@ msgstr "¡A _traficar!"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Luchar"
 
@@ -2319,16 +2319,15 @@ msgstr "¿Cuánto quiere vender?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quiere tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Cancelar"
 
@@ -2373,65 +2372,65 @@ msgid "Question"
 msgstr "Pregunta"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espacio"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2442,6 +2441,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2455,7 +2455,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2465,7 +2465,7 @@ msgstr ""
 "dopewars está publicado bajo la GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2477,134 +2477,134 @@ msgstr ""
 "escriba dopewars -h en su terminal Unix. Esto mostrará una pantalla\n"
 "de ayuda con las opciones disponibles.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Documentación local en HTML "
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tiene que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "No tiene tanto dinero en el banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Dinero en efectivo: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Deuda: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Saldar:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Ingresar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Sacar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar todo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jugadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Mensaje:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Enviar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde que tiene"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2612,12 +2612,12 @@ msgstr "Desgraciadamente ya hay otro jugador usando «su» nombre. Elija otro"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2795,7 +2795,7 @@ msgstr "Minimizar a la bandeja del sistema"
 msgid "Metaserver URL"
 msgstr "Metaservidor"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Comentario"
 
@@ -2803,9 +2803,7 @@ msgstr "Comentario"
 msgid "MOTD (welcome message)"
 msgstr "MOTD (mensaje de bienvenida)"
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Servidor"
 
@@ -2833,127 +2831,59 @@ msgstr "Jugar"
 msgid "_Help"
 msgstr "_Ayuda"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puede empezar la partida sin dar un nombre antes!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Situación: Esperando datos del usuario"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Situación: Intentando contactar con %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Desconocido"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Puerto"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Versión"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Jugadores"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh oiga, ¿cuál es su _nombre?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nombre del servidor"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Conectarse"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "1 jugador"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr "_Refrescar"
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Metaservidor"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "Se precisa autenticación SOCKS"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3432,73 +3362,73 @@ msgstr "Oye a alguien poner %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quiere visitar %tal?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quiere contratar a una %tde por %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quiere Atacar o Huir?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni polis!"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los polis no pueden atacar a otros polis!"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quiere pagar %P a un médico para que le cure?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Le atracan en el metro!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Se encuentra con un amigo! Le da a usted  %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Se encuentra con un amigo! Usted le da %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3506,17 +3436,17 @@ msgstr ""
 "¡Los perros de la policía le persiguen durante %d minutos! ¡Pierde algo de "
 "%tde! Maldita sea..."
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentra %d %tde en un cadáver abandonado en el metro!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Su mamacita ha hecho galletas con algo de su %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3525,25 +3455,25 @@ msgstr ""
 "YN^¡Aquí hay algo de marihuana que huele a herbicida!^¡Tiene buen aspecto! "
 "^¿Quiere fumarla? "
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Se ha parado para %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quiere comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, oiga! Le ayudo a llevar sus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quiere comprar un %tde por %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3552,29 +3482,29 @@ msgstr ""
 "¡Estuvo alucinando durante tres días en el viaje más salvaje que haya "
 "imaginado nunca!^Y entonces se murió debido a que su cerebro se derritió."
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, fuzzy, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La policía le ve tirando %tde!"
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3856,86 +3786,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4129,12 +4059,12 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompile pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "No es posible abrir el fichero %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4142,6 +4072,44 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Situación: Intentando contactar con %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Port"
+#~ msgstr "Puerto"
+
+#~ msgid "Version"
+#~ msgstr "Versión"
+
+#~ msgid "Players"
+#~ msgstr "Jugadores"
+
+#~ msgid "Host name"
+#~ msgstr "Nombre del servidor"
+
+#~ msgid "_Connect"
+#~ msgstr "_Conectarse"
+
+#~ msgid "Single player"
+#~ msgstr "1 jugador"
+
+#~ msgid "_Refresh"
+#~ msgstr "_Refrescar"
+
+#~ msgid "Metaserver"
+#~ msgstr "Metaservidor"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "Se precisa autenticación SOCKS"
 
 #~ msgid "bitch"
 #~ msgstr "puta"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es_ES\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2003-12-10 09:48+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -29,28 +29,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -58,597 +58,597 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de tu servidor"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "La orden usada para iniciar tu navegador web"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Número de rondas de juego (si es 0, el juego nunca termina)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Día del mes en el que empieza el juego"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Mes en el que empieza el juego"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Año en el que empieza el juego"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr "El símbolo de dinero (por ejemplo, $)"
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si TRUE, el símbolo de dinero va antes del precio"
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Fichero en el que escribir los mensajes de registro"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Controla el número de mensajes de registro producidos"
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "formato de la cadena strftime() para las marcas de tiempo"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Se limpian los eventos aleatorios"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE si se debe guardar el valor de las drogas compradas"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Ser prolijo al procesar el fichero de configuración"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Número de sitios en el juego"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de poli en el juego"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Número de armas en el juego"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Número de drogas en el juego"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Ubicación del usurero"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Ubicación del banco"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Ubicación de la armería"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Ubicación del bar"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Tasa de interés diaria de la deuda con el usurero"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Tipo de interés diario de tu saldo en el banco"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nombre del usurero"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nombre del banco"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nombre de la armería"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nombre del bar"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE si se debe habilitar el sonido"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Fichero de sonido que suena cuando un disparo hace blanco"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Fichero de sonido que suena cuando un disparo yerra su objetivo"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 "Fichero de sonido a reproducir cuando se mata a un ayudante o a una puta "
 "enemiga"
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr "Fichero de sonido reproducido cuando muere una de tus putas"
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Fichero de sonido reproducido cuando se mata a otro jugador o a un policía"
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Fichero de sonido reproducido cuando te matan a ti"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 "Fichero de sonido reproducido cuando un jugador intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 "Fichero de sonido reproducido cuando intentas escapar, pero no lo consigues"
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr "Fichero de sonido reproducido cuando un jugador logra escapar"
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr "Fichero de sonido reproducido cuando tú logras escapar"
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr "Fichero de sonido que suena cuando un jugador abandona el juego"
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr "Fichero de sonido reproducido al empezar el juego"
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr "Fichero de sonido reproducido al acabar el juego"
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Orden de las drogas disponibles"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos para devolver disparos"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Los jugadores son desconectados después de este número de segundos"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tiempo en segundos para que las conexiones sean establecidas o rotas"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexiones TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre los turnos de los jugadores automáticos"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Cantidad de dinero con la que empieza cada jugador"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Importe de la deuda con la que empieza cada jugador"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Presencia policial en cada sitio (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas en cada sitio"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Máximo número de drogas en cada lugar"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% de resistencia a disparos de cada puta"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Nombre de cada poli"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Nombre del ayudante de cada poli"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Nombre de los ayudantes de cada poli"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistencia a disparos de cada poli"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistencia a disparos de cada ayudante"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Penalización de ataque relativa a un jugador"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Penalización de defensa relativa a un jugador"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ayudantes acompañantes"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ayudantes acompañantes"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Índice basado en cero de la pistola con la que están armados los polis"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Número de pistolas que porta cada poli"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Número de pistolas con las que carga cada ayudante"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nombre de cada droga"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Precio mínimo normal de cada droga"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Precio máximo normal de cada droga"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE si esta droga puede ser especialmente barata"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE si esta droga puede ser especiamente cara"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensaje a mostrar cuando esta droga sea especialmente barata"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Línea utilizada para drogas que sean caras el 50% de las veces"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor del precio de la droga cuando es especialmente barata"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Precio de cada arma"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Espacio que ocupa cada arma"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Palabra usada para designar una sola \"puta\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Palabra usada para designar dos o más \"putas\""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palabra usada para designar una sola arma"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Palabra usada para designar dos o más armas"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palabra usada para designar una sola droga"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Palabra usada para designar dos o más drogas"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar el turno del juego"
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Precio mínimo de contratar una puta"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Precio máximo de contratar una puta"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de cosas que oyes en el metro"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Número de cosas que se dicen en el metro"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Lista de canciones que oyes tocar"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Número de canciones que se tocan"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Lista de cosas que puedes dejar de hacer"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puedes dejar de hacer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -656,140 +656,140 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 "¡El mercado está inundado de tripis baratos recién llegados de Amsterdam!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -797,47 +797,47 @@ msgid ""
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Mensaje"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr ""
 "¡La pestañí ha hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
@@ -846,161 +846,161 @@ msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite, co!"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "De todo lo que he perdido, lo que más echo de menos es la cabeza."
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Apuesto a que tienes sueños superinteresantes"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Este verano no sé si bajar al moro o irme a Amsterdam"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Tío, tienes que hacerte una cresta."
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Pero ¿por qué llevas gafas de sol si es de noche?"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "Yo no he sido siempre una mujer, ¿sabes?"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "¿Tu madre sabe que eres un camello?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "¿Te has metido algo?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, tú debes ser gallego"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 "Hmmm... ¡qué almuerzo! Mi madre me ha preparado unas galletas de... "
 "chocolate."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Con dinero, chufletes."
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr ""
 "Sólo usamos el 10% de nuestro cerebro. ¡Destruye con drogas el 90% sobrante!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Estoy hecha polvo, me voy a la cama. ¿Vienes?"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "El PP es lo más rancio y retrógrado que ha parido madre. ¿O no?"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Tú sales en la tele, ¿verdad?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "¿Sabe que tiene los ojos muy enrojecidos, joven?"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "¿Te imaginas como sería la vida si no hubiera drogas?"
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "En las hamburgueserías usan carne de rata. Por eso la dan picada."
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "`Cuestiona la autoridad; piensa por ti mismo` dijo Tim Leary"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Te vendo una chupa de cuero por 30 euros."
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Los triunfadores no usan drogas... salvo..."
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Espero que no te importe, pero voy a rezar por ti."
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "La telepatía existe. ¿No sientes la energía del universo?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -1011,40 +1011,40 @@ msgstr ""
 "jugador conectado. Espera a que se desconecten todos los jugadores, o\n"
 "elimínalos con las órdenes echar o matar, e inténtalo otra vez."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
@@ -1052,42 +1052,42 @@ msgstr "%s[%d] es %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1095,7 +1095,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1103,19 +1103,19 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars versión %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1206,7 +1206,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 #, fuzzy
 msgid ""
 "  -h, --help              display this help information\n"
@@ -1225,7 +1225,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1288,7 +1288,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 #, fuzzy
 msgid ""
 "  -h       display this help information\n"
@@ -1305,7 +1305,7 @@ msgstr ""
 "GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1315,7 +1315,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o usa una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1325,7 +1325,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o usa el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1333,7 +1333,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1617,11 +1617,11 @@ msgid "How many do you drop? "
 msgstr "¿Cuántas quieres tirar? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quieres pillar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "¿Qué quieres pulir? "
 
@@ -1650,7 +1650,7 @@ msgid "Are you sure you want to quit? "
 msgstr "¿Estás seguro de que quieres salir? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "SN"
 
@@ -1667,51 +1667,51 @@ msgstr "Has sido expulsado del servidor. Pasando al modo 1 jugador."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s es ahora conocido como %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Desgraciadamente ya hay alguien usando «tu» nombre. Elige otro."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tienes ningún %tde que vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "¡No tienes ninguna que vender!"
 
@@ -1719,27 +1719,27 @@ msgstr "¡No tienes ninguna que vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesitas más %tde para que te guarden más %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tienes suficiente espacio para llevar ese %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tienes suficientes pelas para comprar ese %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 
@@ -1747,41 +1747,41 @@ msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CPD"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quieres devolver? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "¡No tienes tanta pasta!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quieres I>ngresar dinero, S>acar dinero o L>argarte?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ISL"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tienes tantos dineros en el banco..."
 
@@ -1789,47 +1789,47 @@ msgstr "No tienes tantos dineros en el banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:No"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "E:Enfrentarse"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "H:Huir"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Pulsa cualquier tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Situación"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Pasta"
 
@@ -1837,41 +1837,41 @@ msgstr "Pasta"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Salud"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Pufo"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
@@ -1879,141 +1879,141 @@ msgstr "Gabardina"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, tío. Los precios de las %tde aquí son:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Eh tío, ¿cómo te llamas? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "¿Quieres C>omprar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", P>ulir"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", E>nfrentarte"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", D>arte el piro"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "¿Quieres "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "P>ulir %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "CPTHJLMEDS"
@@ -2021,30 +2021,30 @@ msgstr "CPTHJLMEDS"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "PCLES"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quieres? ¿J>ugadores o P>untuaciones? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "¿Con quién quieres hablar en privado?"
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Decir: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
@@ -2129,24 +2129,24 @@ msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventario"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -2155,7 +2155,7 @@ msgstr ""
 "Pasando al modo 1 jugador."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2192,7 +2192,7 @@ msgstr "¡A _Trapichear!"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Luchar"
 
@@ -2316,16 +2316,15 @@ msgstr "¿Cuánto quieres pulir?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quieres tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Cancelar"
 
@@ -2370,65 +2369,65 @@ msgid "Question"
 msgstr "Pregunta"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espacio"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2439,6 +2438,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2452,7 +2452,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2462,7 +2462,7 @@ msgstr ""
 "dopewars está publicado bajo la GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2474,134 +2474,134 @@ msgstr ""
 "escribe dopewars -h en tu terminal Unix. Esto mostrará una pantalla\n"
 "de ayuda con las opciones disponibles.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Documentación local en HTML "
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tienes que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "No tienes tantos dineros en el banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Pasta en efectivo: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Pufo: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Saldar:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Ingresar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Sacar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar todo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jugadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Mensaje:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Enviar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Pulir"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde que tienes"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2609,12 +2609,12 @@ msgstr "Desgraciadamente ya hay otro jugador usando «tu» nombre. Elije otro"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2792,7 +2792,7 @@ msgstr "Minimizar a la bandeja del sistema"
 msgid "Metaserver URL"
 msgstr "Metaservidor"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Comentario"
 
@@ -2800,9 +2800,7 @@ msgstr "Comentario"
 msgid "MOTD (welcome message)"
 msgstr "MOTD (mensaje de bienvenida)"
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Servidor"
 
@@ -2830,127 +2828,59 @@ msgstr "Jugar"
 msgid "_Help"
 msgstr "_Ayuda"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puedes empezar la partida sin dar un nombre antes!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Situación: Esperando input del usuario"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Situación: Intentando contactar con %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Desconocido"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Puerto"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Versión"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Jugadores"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh tío, ¿cuál es tu _nombre?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nombre del servidor"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Conectarse"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "1 jugador"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr "_Refrescar"
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Metaservidor"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "Se precisa autenticación SOCKS"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3428,73 +3358,73 @@ msgstr "Oyes a alguien poner %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quieres visitar %tal?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quieres contratar a una %tde por %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quieres Atacar o Huir?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni maderos!"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los maderos no pueden atacar a otros maderos!"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quieres pagar %P a un médico para que te cure?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Te atracan en el metro!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Te encuentras con un amigo! Te da %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Te encuentras con un amigo! Le das %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3502,17 +3432,17 @@ msgstr ""
 "¡Los perros de la bofia te persiguen durante %d manzanas! ¡Pierdes algo de "
 "%tde! Vaya mierda, macho."
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentras %d %tde en el cuerpo de un tío tirado en el metro!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Tu mami ha hecho galletas con algo de tu %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3521,25 +3451,25 @@ msgstr ""
 "YN^¡Aquí hay algo de maría que huele a herbicida!^¡Tiene buena pinta! "
 "^¿Quieres fumarla? "
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Te has parado para %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quieres comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, tío! Te ayudo a llevar tus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quieres comprar un %tde por %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3548,29 +3478,29 @@ msgstr ""
 "¡Estuviste flipando durante tres días en el cuelgue más salvaje que hayas "
 "imaginado nunca!^Y entonces la palmaste debido a que tu cerebro se derritió."
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, fuzzy, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La bofia te ve tirando %tde!"
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3852,86 +3782,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4125,12 +4055,12 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompila pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "No es posible abrir el fichero %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4138,6 +4068,44 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Situación: Intentando contactar con %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Desconocido"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Port"
+#~ msgstr "Puerto"
+
+#~ msgid "Version"
+#~ msgstr "Versión"
+
+#~ msgid "Players"
+#~ msgstr "Jugadores"
+
+#~ msgid "Host name"
+#~ msgstr "Nombre del servidor"
+
+#~ msgid "_Connect"
+#~ msgstr "_Conectarse"
+
+#~ msgid "Single player"
+#~ msgstr "1 jugador"
+
+#~ msgid "_Refresh"
+#~ msgstr "_Refrescar"
+
+#~ msgid "Metaserver"
+#~ msgstr "Metaservidor"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "Se precisa autenticación SOCKS"
 
 #~ msgid "bitch"
 #~ msgstr "puta"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2001-10-16 20:50+0100\n"
 "Last-Translator: leonard <triton@madchat.org>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -49,591 +49,591 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "Le Preteur a Gages"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "la banque"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port reseau a se connecter"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur a se connecter"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "Different de zero si le serveur doit reporter a un metaserveur"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur "
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "description du serveur, reporte au metaserveur"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr ""
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Nombre de tours de jeu (avec 0, le jeu ne se termine jamais)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Les elements aleatioires sont nettoyes"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 "Different de zero si la valeur de la camme achetee doit etre sauvegardee"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Soyez verbose en passant le config file a la moulinette"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Nombre de lieux dans le jeu"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Nombre de types de flics dans le jeu"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Nombre de revolvers dans le jeu"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Nombre de drogues dans le jeu"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "L'endroit ou se trouve le Preteur a Gages"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "L'endroit ou se trouve la banque"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "l'endroit ou se trouve l'armurerie"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "l'endroit ou se trouve le bar"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nom du Preteur a Gages"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nom de la banque"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nom de l'armurerie"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nom du bar"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr ""
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Touche de tri pour la liste des dopes disponibles"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Nombre de secondes apres lesquelles on peut retourner le feu"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Les joueurs sont deconnectes apres ce nombre de secondes"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Temps en secondes pour que les connections soient etablies ou cassees"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Nombre maximum de connections TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Secondes entre les tours des intelligences artificielles"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Fric donne en debutant la partie"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Montant des dettes en debutant la partie"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nom de chaque lieu"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Presence policiaire a chaque endroit (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Nombre minimum de potions magiques a chaque endroit"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Nombre maximum de potions magiques a chaque endroit"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistance aux coups de fusil de chaque joueur"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% de resistance aux coups de fusil de chaque chienne"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Nom de chaque flics"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Nom de chaque sous-flic"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Nom de chaques sous-flics"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistance aux coups de fusil de chaque flic"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistance aux coups de flingue de chaque sous-flic"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Penalite d'attaque relative a un joueur"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Penalite de deffence relative a un joueur"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Nombre minimum de sous-flics accompagnant"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Nombre MAX des adjoints accompagnant"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Index base sur zero du pistolet avec lequel le flic est arme"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Nombre de flingues que chaque flic porte"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Nombre de flingues que chaque sous-flic portes"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nom de chaque potion magique"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Prix minimum normal de chaque camme"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Prix MAX normal de chaque camme"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Different de zero si cette camme peut devenir vraiement pas chere"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Different de zero si cette drogue peut devenir particulierement chere"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Message affiche si cette camme est vraiement pas chere"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Ligne utilisee pour des drogues cheres 50% des fois"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Diviseur sur le prix des cammes devenues vraiement pas cheres"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicateur pour les drogues devenues cheres"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nom de chaque lieu"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Prix de chaque type de flingue"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Espace pris par chaque flingue"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Dommage inflige par chaque flingue"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Mot utilise pour decrire 1 \"chienne\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Mot utilise pour decrire 2 \"chiennes\" ou plus"
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Mot utilise pour decrire 1 flingue ou equivalent"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Mot utlise pour decrire 2 flingues ou plus"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Mot utlise pour decrire 1 drogue "
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Mot utilise pour decrire deux drogues ou plus"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Prix minimum pour employer une salope"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Prix MAX pour employer une chienne"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "liste des trucs que vous entendez dans le metro"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "nombre de choses que vous entendez dans le metro"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "liste des morceaux de zic que vous pouvez entendre de loin"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "nombre de morceaux de musique"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "liste des trucs que tu peux arreter de faire"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "nombre de trucs que tu peux arreter de faire"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -641,139 +641,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Le marche est sature de buvards"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -781,46 +781,46 @@ msgid ""
 msgstr "de la bonne herbe d'Amsterdam vient d'arriver en masse"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Message"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr "Les flics ont mis la main sur un gros stock de %tde !"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les junkies achetent %tde hors de prix !"
@@ -829,160 +829,160 @@ msgstr "Les junkies achetent %tde hors de prix !"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "`Vivons dans l'extase de l'illimité`"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "Of all the things that I've lost, I miss my mind the most."
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Je parie que vous faites des reves tres interessants"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Je pense que je vais aller a Amsterdam cette annee"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "je suis un cheval, en fait"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ca vous arrive de conduire la nuit avec des lunettes de soleil ?"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "J'ai pas toujours ete une femme, tu sais"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Ta mere sait que tu est un dealer ?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "T'est defonce a quoi, la ?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Vous venez de Tunisie ?"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Ta mere vient de faire des bons gateaux avec un peu de ton Hash."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "In dust, we trust"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "On utilise 10% de nos cerveaux, alors pourquoi ne pas en crammer 90% ?"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Bon je suis trop defait, je vais me coucher."
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 "Les vrais leaders de ce monde sont george bush, keanu reeves et sandra "
 "Bullock"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "C'est vous que j'ai vu a la tele ?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Vous avez les yeux rouges, jeune homme."
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Un jour sans camme, c'est la nuit."
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "Sauvez des arbres, mangez des castors !"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "`Question authority; think for yourself`. a dit Timothy Leary"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Gnôthi seauton"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Les vainqueurs ne se droguent pas... a moins que..."
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Seulement de nos jours, les chateaux sont des entreprises."
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "La telepathie existe ! Regardez les vibrations."
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -990,40 +990,40 @@ msgid ""
 msgstr ""
 "La config peut seulement etre changee quand aucun joueur n'est connecte."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit etre entre 1 et %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
@@ -1031,66 +1031,66 @@ msgstr "%s[%d] est %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Structure liste redimentionnee a %d elements\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1167,7 +1167,7 @@ msgstr ""
 "dopewars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1179,7 +1179,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1244,7 +1244,7 @@ msgstr ""
 "dopewars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1254,7 +1254,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1264,7 +1264,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1274,7 +1274,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1282,7 +1282,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1556,11 +1556,11 @@ msgid "How many do you drop? "
 msgstr "Combien d'unites tu laisses tomber? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Que souhaites tu acheter? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "Que souhaites tu vendre? "
 
@@ -1589,7 +1589,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Etes vous sur de vouloir quitter? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "ON"
 
@@ -1606,51 +1606,51 @@ msgstr "Vous avez ete vire du serveur. Devient solo."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Devient solo"
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitte la partie."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s est maintenant %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Malheureusement, qq d'autre utilise deja ton nom. Merci d'en changer"
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "H I G H   S C O R E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Tu n'as aucun %tde a vendre!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "T'en as aucun a vendre!"
 
@@ -1658,27 +1658,27 @@ msgstr "T'en as aucun a vendre!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour porter plus de %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Tu n'as pas assez d'espace pour porter ce %tde"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Tu n'as pas assez de fric pour achter ce %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 
@@ -1686,41 +1686,41 @@ msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Combien de fric tu rends ?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Tu n'as pas assez d'argent!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Tu veux D>eposer de l'argent, R>etirer des biftons, ou P>artir ?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRP"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
@@ -1728,47 +1728,47 @@ msgstr "Il n'y a pas autant d'argent dans la banque..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Non"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "C:Courrir"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "S:Se battre"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Attaquer"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "S: S'evader"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Appuyer sur une touche..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistiques"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Fric"
 
@@ -1776,41 +1776,41 @@ msgstr "Fric"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Sante"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banque"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Dette"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Espace %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Trenchcoat"
 
@@ -1818,141 +1818,141 @@ msgstr "Trenchcoat"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "He man, les prix du %tde sont la:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer SIGWINCH interrupt handler!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "He mec, c'est quoi ton nom? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", P>arler, R>reveiller"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", L>lister"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", dEplacer"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "C>combat, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "R>este sur place, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "S>e sauver, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>eal %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCEQ"
@@ -1960,30 +1960,30 @@ msgstr "AVLPRLDCEQ"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "DSCRQ"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "A qui tu veux parler en prive ? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Parler: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Rejouer? "
 
@@ -2068,31 +2068,31 @@ msgid "Abandon game"
 msgstr ""
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Fermer"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connection au server perdue - Mode solo"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez ete vire du serveur. Devient solo."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2127,7 +2127,7 @@ msgstr "_Vendre %Tde"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Combattre"
 
@@ -2251,16 +2251,15 @@ msgstr "Vendre combien ?"
 msgid "Drop how many?"
 msgstr "Laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Annuler"
 
@@ -2305,65 +2304,65 @@ msgid "Question"
 msgstr "Question"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espace"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Français Traduction"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Vente de camme et Recherche"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testeur de jeu"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Testeur extensif du jeu"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2374,6 +2373,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2387,7 +2387,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2397,7 +2397,7 @@ msgstr ""
 "dopewars est diffuse sous la GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2407,134 +2407,134 @@ msgstr ""
 "\n"
 "Pour infos sur les options en ligne de commande, taper: dopewars -h\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Preteur window title/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Fric: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "banque: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Rembourser:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Deposer"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirer"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Tout payer"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Liste des joueurs"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Parler au joueur(s)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Parler a tout les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Message:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Envoyer"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Nombre"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde ici"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde transporte"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Changer Nom"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2543,12 +2543,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Armurerie window title/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2720,7 +2720,7 @@ msgstr ""
 msgid "Metaserver URL"
 msgstr "Metaserver"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -2728,9 +2728,7 @@ msgstr "Commentaire"
 msgid "MOTD (welcome message)"
 msgstr ""
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Serveur"
 
@@ -2758,127 +2756,59 @@ msgstr ""
 msgid "_Help"
 msgstr "_Aide"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: Attente de l'utilisateur"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr ""
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: Essayer de contacter %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Inconnu"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Port"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Version"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Joueurs"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Salut mec, quel est ton _nom?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nom de l'hote"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Connect"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Commencer un jeu en solo"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Jouer en solo"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Metaserver"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr ""
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3317,90 +3247,90 @@ msgstr "Tu entends quelqu'un jouer %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Voulez-vous visiter %tde?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Voulez vous engager une %tde pour %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est deja la!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les flics ne peuvent pas attaquer d'autres flics!"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont deja en train de se battre!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont deja dans des bastons separees!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bagarre - pas de flingue a utiliser!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Tu payes le docteur %P pour te recoudre?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu as ete attaque dans le metro!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Tu rencontres un ami! Il te donne %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Tu rencontre un ami! Tu lui donne %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aleatoire."
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens des flics te courent apres sur %d blocs! Tu laisses tomber %tde! "
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Tu trouves %d %tde sur un mec mort dans le metro!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta maman a fait des gateaux avec un peu de ton %tde! Ils sont excellents!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3408,26 +3338,26 @@ msgid ""
 msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ca a l'air bon! Tu la fume?"
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Tu veux acheter une trenchcoat plus grande pour %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^He! mec! Je t'aiderais a porter tes %tde pour un petit %P. Oui ou non ?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Tu veux acheter un %tde pour %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3436,29 +3366,29 @@ msgstr ""
 "Tu a hallucine pendant trois jours dans le plus trip le plus sauvage "
 "que^t'aurais jamais imagine! Ensuite tu t'est mis a parler avec tes oreilles!"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard - %s vient juste de partir!"
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Joueur enleve a cause d'inactivite trop longue"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Joueur enleve a cause de temps de connection trop long"
 
@@ -3738,86 +3668,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4004,17 +3934,49 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en utilisant --enable-networking avec le script de config."
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: Essayer de contacter %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Port"
+#~ msgstr "Port"
+
+#~ msgid "Version"
+#~ msgstr "Version"
+
+#~ msgid "Players"
+#~ msgstr "Joueurs"
+
+#~ msgid "Host name"
+#~ msgstr "Nom de l'hote"
+
+#~ msgid "_Connect"
+#~ msgstr "_Connect"
+
+#~ msgid "Single player"
+#~ msgstr "Jouer en solo"
+
+#~ msgid "Metaserver"
+#~ msgstr "Metaserver"
 
 #~ msgid "bitch"
 #~ msgstr "chienne"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars 1.5.10\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2007-10-25 16:37+1300\n"
 "Last-Translator: François Marier <francois@debian.org>\n"
 "Language-Team: French\n"
@@ -19,28 +19,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -48,597 +48,597 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "le prêteur à gages"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "la Caisse populaire"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port réseau auquel se connecter"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur auquel se connecter"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Message de bienvenue du serveur pour aujourd'hui"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Adresse réseau du serveur"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "VRAI si un serveur SOCKS est nécessaire pour la connexion réseau"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "VRAI si un numéro d'identification est nécessaire pour SOCKS4"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si non-vide, le nom d'utilisateur à utiliser pour SOCKS4"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "Le nom d'hôte d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "Le numéro de port d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La version du protocole SOCKS à utiliser (4 ou 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Nom d'utilisateur pour l'authentification SOCKS5"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Mot de passe pour l'authentification SOCKS5"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "VRAI si le serveur doit se rapporter à un méta-serveur"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nom du méta-serveur auquel envoyer/recevoir les détails du serveur"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Description du serveur, rapportée au méta-serveur"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si VRAI, le serveur est réduit dans le System Tray"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Si VRAI, le serveur roule en arrière-plan"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "La commande utilisée pour lancer votre fureteur"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Nombre de tours de jeu (avec 0, le jeu ne se termine jamais)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Jour du mois durant lequel la partie débute"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Mois durant lequel la partie débute"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Année durant laquelle la partie débute"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr "Le symbôle monétaire (example: $)"
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si VRAI, le symbôle monétaire précède les prix"
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Fichier dans lequel écrire le journal"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Contrôle le nombre de messages dans le journal"
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "Chaîne de formattage strftime() pour les dates dans le journal"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Les éléments aléatioires sont nettoyés"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "VRAI si la valeur de la drogue achetée doit être sauvegardée"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Soyez verbose en lisant le fichier de configuration"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Nombre de lieux dans le jeu"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Nombre de types de policiers dans le jeu"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Nombre de guns dans le jeu"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Nombre de drogues dans le jeu"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Emplacement du prêteur à gages"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Emplacement de la banque"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Emplacement du marchand d'armes"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Emplacement du bar"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Taux d'intérêt quotidien sur l'emprunt avec le prêteur à gages"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Taux d'intérêt quotidien du compte de banque"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nom du prêteur à gages"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nom de la banque"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nom du marchand d'armes"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nom du bar"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "VRAI pour activer les sons"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Son d'une balle qui atteint sa cible"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Son d'une balle qui rate sa cible"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Son d'un gun qui est rechargé"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr "Son accompagnant la mort d'une pute ou d'un adjoint ennemi"
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr "Son accompagnant la more d'une de vos putes"
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr "Son accompagnant la mort d'un autre joueur ou d'un policier"
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Son accompagnant votre propre mort"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Son d'un joueur qui tente de s'échapper mais qui rate"
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Son accompagnant votre fuite ratée"
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr "Son d'un joueur qui s'échappe avec succès"
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr "Son accompagnant votre fuite réussie"
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Son d'arrivée dans un nouvel endroit"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr "Son à faire jouer lorsqu'un joueur se joint à la partie"
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr "Son à faire jouer lorsqu'un joueur quitte la partie"
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr "Son de début de la partie"
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr "Son de fin de la partie"
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Touche de tri pour la liste des drogues disponibles"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Nombre de secondes après quoi on peut répliquer"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Les joueurs sont déconnectés après ce nombre de secondes"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Temps en secondes pour que les connexions soient établies ou brisées"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Nombre maximum de connexions TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr ""
 "Nombre de secondes entre les tours des joueurs contrôlés par l'ordinateur"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Argent de départ de chaque joueur"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Montant des dettes en débutant la partie"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nom de chaque endroit"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Présence policiaire à chaque endroit (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Nombre minimum de drogues à chaque endroit"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Nombre maximum de drogues à chaque endroit"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% de résistance aux coups de gun de chaque joueur"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% de résistance aux coups de gun de chaque pute"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Nom de chaque policier"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Nom de chaque adjoint"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Nom de chaque adjoint"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% de résistance aux coups de gun de chaque policier"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de résistance aux coups de gun de chaque adjoint"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Pénalité d'attaque relative à un joueur"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Penalité de défense relative à un joueur"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Nombre minimum d'adjoints accompagnant un policier"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Nombre maximum d'adjoints accompagnant un policier"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Numéro du gun que les policiers utilisent"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Nombre de guns que chaque policier possède"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Nombre de guns que chaque adjoint possède"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nom de chaque drogue"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Prix normal minimal de chaque drogue"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Prix normal maximum de chaque drogue"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "VRAI si cette drogue peut être offerte à prix très bas"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "VRAI si cette drogue peut être offerte à prix exhorbitants"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Message affiché si cette drogue est offerte à prix très bas"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 "Chaîne de formattage utilisée pour les drogues dispendieuses la moitié du "
 "temps"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 "Diviseur sur le prix des drogues lorsqu'elle sont offertes à prix très bas"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 "Multiplicateur pour les drogues lorsqu'elles sont offertes à prix "
 "exhorbitants"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nom de chaque endroit"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Prix de chaque type de gun"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Espace utilisé par chaque gun"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Dommage infligé par chaque gun"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Mot utilisé pour décrire une \"pute\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Mot utilisé pour décrire deux \"putes\" ou plus"
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Mot utilisé pour décrire une arme"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Mot utilisé pour décrire deux armes ou plus"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Mot utilisé pour décrire une drogue"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Mot utilisé pour décrire deux drogues ou plus"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr "Chaîne de formattage strftime() pour l'affichage du tour"
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Prix minimum pour employer une pute"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Prix maximum pour employer une pute"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Liste des choses que vous entendez dans le métro"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Nombre de choses que vous entendez dans le métro"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Liste des chansons que vous pouvez entendre de loin"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Nombre de chansons"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Liste des choses que vous pouvez arrêter de faire"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Nombre de choses que vous pouvez arrêter de faire"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -646,139 +646,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Le marché est saturé de buvards"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -788,46 +788,46 @@ msgstr ""
 "de fumer!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Message"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr "Les boeufs ont mis la main sur un gros stock de dope (%tde) !"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
@@ -836,165 +836,165 @@ msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 "Pète pis répète sont en bateau, pète tombe à l'eau, qui est-ce qu'il reste "
 "dans le bateau?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "Tsé, le pape a déjà été juif"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Chu sûre que tu fais des rêves très intéressants"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Je pense que je vais aller à Vancouver cette année"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Vas te faire couper les cheveux le pouilleux!"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ça t'arrive tu de conduire la nuit avec des lunettes fumées ?"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "J'ai pas toujours été une femme tsé"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Est-ce que ta mère sait que tu vends de la dope ?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "T'es tu gelé là ?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Toi, tu dois venir de Vancouver ?"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Ta mère vient de faire des bons gâteaux avec un peu de ton Hash."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Ya rien comme avoir full de cash"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "Sauvez des arbres, torchez-vous avec un lapin !"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Bon chu trop décriss, j'm'en vas me coucher."
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 "Les terroristes dirigent la maison blanche depuis les dernières élections."
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "C'est vous que j'ai vu à la télé ?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Vous avez les yeux rouges, jeune homme."
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Un jour sans dope, c'est la nuit."
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "On utilise 20% de nos cerveaux, alors pourquoi ne pas en détruire 80% ?"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 "« Le seul moyen de se délivrer de la tentation, c'est d'y céder. » a dit "
 "Oscar Wilde"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "C'est à vous l'éléphant rose là-haut ?"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 "Les vainqueurs ne se droguent pas... à moins qu'ils prennent de la drogue"
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Jésus t'aime beaucoup plus que tu ne le sauras jamais"
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "La télépathie existe ! Check les vibrations."
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Impossible de lire le fichier de configuration %s (ligne %d)"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -1004,40 +1004,40 @@ msgstr ""
 "joueur n'est connecté.  Attendez que tous les joueurs se déconnectent\n"
 "ou éjecter-les avec la commande push ou kill et essayer à nouveau."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit être entre 1 et %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
@@ -1045,42 +1045,42 @@ msgstr "%s[%d] est %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d!"
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Liste de structure redimentionée à %d éléments\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "valeur booléenne attendue (0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1088,7 +1088,7 @@ msgstr ""
 "  -u, --plugin=FICHIER    utiliser le plugin de son \"FICHIER\"\n"
 "                            "
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1096,19 +1096,19 @@ msgstr ""
 "  -u fichier   utiliser le plugin de son \"fichier\"\n"
 "\t          "
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1191,7 +1191,7 @@ msgstr ""
 "  -C, --convert=FILE     convertir un vieux fichier de scores au nouveau \n"
 "                           format\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 #, fuzzy
 msgid ""
 "  -h, --help              display this help information\n"
@@ -1210,7 +1210,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1272,7 +1272,7 @@ msgstr ""
 "scores au nouveau format\n"
 "  -A       se connecte au serveur local pour l'administration\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 #, fuzzy
 msgid ""
 "  -h       display this help information\n"
@@ -1288,7 +1288,7 @@ msgstr ""
 "dopewars est un Copyright (C) Ben Webb 1998-2022, et distribué sous GNU GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1298,7 +1298,7 @@ msgstr ""
 "--enable-curses-client comme configuration, ou utiliser un client\n"
 "graphique (si disponible) à la place!\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1308,7 +1308,7 @@ msgstr ""
 "--enable-gui-client comme configuration, ou utiliser un client\n"
 "curses à la place!\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1319,7 +1319,7 @@ msgstr ""
 "fonctionner en mode serveur. Recompilez avec l'option --enable-networking\n"
 "dans le script configure.\n"
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1600,11 +1600,11 @@ msgid "How many do you drop? "
 msgstr "Combien d'unités veux-tu crisser à terre? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Qu'est-ce que tu veux acheter? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "Qu'est-ce que tu veux vendre? "
 
@@ -1633,7 +1633,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Êtes-vous sur de vouloir quitter? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "ON"
 
@@ -1650,51 +1650,51 @@ msgstr "La connexion avec le serveur a été terminée. Mode solo."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Mode solo"
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitté la partie."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s est maintenant %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Endroit présent/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Malheureusement, quelqu'un d'autre utilise déjà ton nom. Change-le."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "M E I L L E U R S   S C O R E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "T'as pas de %tde à vendre!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "T'en n'as pas à vendre!"
 
@@ -1702,27 +1702,27 @@ msgstr "T'en n'as pas à vendre!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour transporter plus de %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "T'as pas assez d'espace pour transporter: %tde"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "T'as pas assez de cash pour acheter: %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 
@@ -1730,42 +1730,42 @@ msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Combien de cash tu rends ? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "T'as pas assez de cash!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 "Tu veux D>époser de l'argent, R>etirer de l'argents, ou S>acrer ton camp ? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Ya pas autant d'argent dans la banque..."
 
@@ -1773,47 +1773,47 @@ msgstr "Ya pas autant d'argent dans la banque..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Non"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "D:écrisser"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "S:Se battre"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Attaquer"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "S:Se sauver"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Pèse sur une touche..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Messages (-/+ avancer/reculer)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistiques"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Cash"
 
@@ -1821,41 +1821,41 @@ msgstr "Cash"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Santé"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banque"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Dette"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Espace %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Manteau"
 
@@ -1863,141 +1863,141 @@ msgstr "Manteau"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Heille man, les prix du %tde sont la:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer le handleur d'interruptions SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Heille man, comment tu t'appelles ? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", P>lacotter, R>éveiller"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", L>ister"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", S>'en aller ailleurs"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "C>ombattre, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "R>ester sur place, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "T>e sauver, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>endre des %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCSQ"
@@ -2005,30 +2005,30 @@ msgstr "AVLPRLDCSQ"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "VTCRQ"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "À qui que tu veux parler en privé ? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Parler: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Jouer à nouveau? "
 
@@ -2113,31 +2113,31 @@ msgid "Abandon game"
 msgstr "Abandonner la partie"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Fermer"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connexion au serveur perdue - Mode solo"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez été expulsé(e) du serveur. Mode solo."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2172,7 +2172,7 @@ msgstr "_Vendre de la dope"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Combattre"
 
@@ -2296,16 +2296,15 @@ msgstr "En vendre combien ?"
 msgid "Drop how many?"
 msgstr "En laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Annuler"
 
@@ -2350,65 +2349,65 @@ msgid "Question"
 msgstr "Question"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espace"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "Dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traduction québécoise"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Icônes et graphiques"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Effets sonores"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Vente de drogue et recherche"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testeurs de jeu"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Testeurs maniaques du jeu"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2419,6 +2418,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2432,7 +2432,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2442,7 +2442,7 @@ msgstr ""
 "dopewars est distribué sous la licence GNU GPL\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2453,134 +2453,134 @@ msgstr ""
 "Pour afficher l'aide sur les options disponible sur la ligne de commande,\n"
 "tapez dopewars -h sur votre prompt UNIX.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Documentation HTML locale"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Prêteur window title/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Vous devez entrer un montant positif!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Argent: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banque: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Rembourser:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Déposer"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirer"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Tout payer"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Liste des joueurs"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Parler au(x) joueur(s)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Parler à tous les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Message:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Envoyer"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Quantité"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde en vente/demande ici"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde transporté(e)s"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Changer de nom"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2589,12 +2589,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Marchand d'armes window title/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2772,7 +2772,7 @@ msgstr "Minimiser dans le System Tray"
 msgid "Metaserver URL"
 msgstr "Méta-serveur"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -2780,9 +2780,7 @@ msgstr "Commentaire"
 msgid "MOTD (welcome message)"
 msgstr "Message du jour"
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Serveur"
 
@@ -2810,127 +2808,59 @@ msgstr "Jouer"
 msgid "_Help"
 msgstr "A_ide"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "Impossible de débuter une partie sans se nommer!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: En attente de l'utilisateur"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Connexion terminée par l'autre partie"
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: En train de contacter %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Inconnu"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Connecté au serveur SOCKS %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: En cours d'authentification avec le serveur SOCKS"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Status: En train de demander à SOCKS d'établir la connexion avec %s..."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Port"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Version"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Joueurs"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Heille man, c'est quoi ton _nom?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nom de l'hôte"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Connecter"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Débuter la partie en mode solo"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Mode solo"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr "_Rafraîchir"
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Méta-serveur"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "Authentification SOCKS nécessaire"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3395,91 +3325,91 @@ msgstr "Tu entends quelqu'un jouer %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Veux-tu visiter %tde?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Veux-tu engager une %tde pour %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est déjà là!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "Pas de boeufs ou de guns"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les boeufs ne peuvent pas attaquer d'autres boeufs!"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont déjà en train de se battre!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont déjà dans des batailles séparées!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bataille - pas de gun à utiliser!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Vas-tu payer le docteur %P pour te ramancher?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu t'es fait pété la gueule dans le métro!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "T'as rencontré un chum, il t'a donné %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "T'as rencontré ton meilleur chum pis tu lui a donné %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aléatoire."
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens de police te courent après sur %d blocs! T'as échappé: %tde!"
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "T'as trouvé %d %tde sur un gars mort dans le métro!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta mère a fait des gâteaux avec un peu de %tde! Y'étaient vraiment bons!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3488,27 +3418,27 @@ msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ça a l'air bon! Veux-tu la "
 "fumer? "
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Veux-tu acheter un manteau plus gros %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Heille man! J'pourrais t'aider à transporter tes %tde pour un petit %P. "
 "Qu'est-ce que t'en dis ?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Veux-tu acheter un %tde pour %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3518,29 +3448,29 @@ msgstr ""
 "^jamais pu imaginer! Ensuite t'es mort parce que ton cerveau s'est "
 "désintégré!"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard, %s vient juste de partir!"
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, fuzzy, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Les boeufs t'ont vu jeter ton stock (%tde)!"
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Envoi des mise à jours au méta-serveur..."
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr "Envoi du rappel au méta-serveur..."
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Joueur éjecté à cause d'une période d'inactivité trop longue"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Joueur éjecté à cause d'un temps de connexion trop long"
 
@@ -3820,86 +3750,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "Impossible d'initialiser WinSock (%s)!"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Échec général du serveur SOCKS"
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Connexion refusée par les règles SOCKS"
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Connexion réseau impossible"
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Connexion à l'hôte impossible"
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Connexion refusée"
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: Le TTL a expiré"
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Commande non-supportée"
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Type d'adresse non-supporté"
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr "Le serveur SOCKS a réjeté toutes les méthodes offertes"
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr "Le type de l'adresse SOCKS retournée est inconnu"
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr "Échec d'authentification SOCKS"
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "Authentification SOCKS annulée par l'utilisateur"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Requête rejetée ou échouée"
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rejeté - impossible de contacter identd"
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rejeté - identd rapporte un nom d'utilisateur différent"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Code de réponse SOCKS inconnu"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr "Code de version de réponse SOCKS inconnu"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr "Version de serveur SOCKS inconnue"
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Code d'error SOCKS: %d"
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4091,12 +4021,12 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en passant --enable-networking au script de configuration."
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4104,6 +4034,44 @@ msgid ""
 msgstr ""
 "Le plugin sélectionné (\"%s\") est invalide.\n"
 "(%s est disponible, utilisation de \"%s\".)"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: En train de contacter %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Inconnu"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Port"
+#~ msgstr "Port"
+
+#~ msgid "Version"
+#~ msgstr "Version"
+
+#~ msgid "Players"
+#~ msgstr "Joueurs"
+
+#~ msgid "Host name"
+#~ msgstr "Nom de l'hôte"
+
+#~ msgid "_Connect"
+#~ msgstr "_Connecter"
+
+#~ msgid "Single player"
+#~ msgstr "Mode solo"
+
+#~ msgid "_Refresh"
+#~ msgstr "_Rafraîchir"
+
+#~ msgid "Metaserver"
+#~ msgstr "Méta-serveur"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "Authentification SOCKS nécessaire"
 
 #~ msgid "bitch"
 #~ msgstr "pute"

--- a/po/nn.po
+++ b/po/nn.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nn_new\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2003-08-31 22:58+0200\n"
 "Last-Translator: Åsmund Skjæveland <aasmunds@fys.uio.no>\n"
 "Language-Team: Norsk nynorsk <i18n-nn@lister.ping.uio.no>\n"
@@ -34,28 +34,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -63,592 +63,592 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "Lånehaien"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "Banken"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Nettverksport å kopla til"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Namn på poengfila"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Namn på tenaren du vil kopla deg til"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Tenaren si velkomsthelsing for dagen"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Netverkadressa tenaren skal lytta på"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE viss ein SOCKS-tenar skal brukast i nettverket"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE viss numerisk brukar-ID skal brukast for SOCKS4"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Viss ikkje blank, brukarnamnet som skal brukast til SOCKS4"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "Vertsnamnet på SOCKS-tenaren"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "Portnummeret på SOCKS-tenaren"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Versjonen av SOCKS-protokollen du vil bruka (4 eller 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Brukarnamn for SOCKS5-autentisering"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Passord for SOCKS5-autentisering"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE viss tenaren skal rapportera til ein metatenar"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Metatenar å rapportera til/få tenar-detaljar frå"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Føretrukke vertsnamn på tenarmaskinen din"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentisering for LocalName med metatenaren"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Tenarskildring, rapportert til metatenaren"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Viss TRUE, vil tenaren minimera til systemtrauet"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Viss TRUE, så vil tenaren køyra i bakgrunnen"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "Kommandoen som startar nettlesaren din"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Tal på rundar i spelet (viss 0 vil spelet aldri slutta)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Dagen i månaden som spelet startar på"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Månaden spelet startar i"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Året spelet startar i"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr "Valutasymbolet (t.d. $)"
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Viss TRUE, går valutasymbolet framfor prisane"
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Fil som loggmeldingar skal skrivast til"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Kontrollerer talet på loggmeldingar som blir laga"
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "strftime()-format-streng for logg-tidsmerker"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Tilfeldige hendingar er rensa"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE viss verdien av det kjøpte dopet skal hugsast"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Vér ordrik når oppsettfila blir lest"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Tal på stader i spelet"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Tal på typar politimenn i spelet"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Tal på våpen i spelet"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Tal på sortar dop i spelet"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Staden Lånehaien held til"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Staden banken held til"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Staden våpenbutikken held til"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Staden puben held til"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Dagleg rente på gjelda til lånehaien"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Dagleg rente på innskotet i banken"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Namnet på lånehaien"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Namnet på banken"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Namnet på våpenforretningen"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Namnet på puben"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "SANN for å slå på lyd"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Lyd som blir spelt når eit skot treff"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Lyd som blir spelt når eit skot bommar"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Lyd som blir spelt når våpna blir lada"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr "Lyd som blir spelt når ei fientleg hore eller betjent blir drepen"
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr "Lyd som blir spelt når ei av horene dine blir drepen"
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Lyd som blir spelt når ein annan spelar eller ei politimann blir drepen"
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Lyd som blir spelt når du blir drepen"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Lyd som blir spelt når ein spelar ikkje klarer å koma seg unna"
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Lyd som blir spelt når du ikkje klarer å koma deg unna"
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr "Lyd som blir spelt når ein spelar klarer å koma seg unna"
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr "Lyd som blir spelt når du klarer å koma deg unna"
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Lyd som blir spelt når du kjem til ein ny stad"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr "Lyd som blir spelt når ein annan blir med i spelet"
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr "Lyd som blir spelt når ein spelar går ut av spelet"
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr "Lyd som blir spelt i byrjinga av spelet"
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr "Lyd som blir spelt i slutten av spelet"
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Sorteringsnøkkel for lista over det tilgjengelege dopet"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Tal på sekund du har på deg til å skyta tilbake"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Spelarar blir kopla frå etter så mange sekund"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tida i sekund for å kopla til eller bryta samband"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maksimalt tal på TCP/IP-sambandar"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Sekund mellom rundane for AI-spelarar"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Kor mykje pengar kvar spelar startar med"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Kor mykje gjeld kvar spelar startar med"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Namn på kvar stad"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Politinærleik på kvar stad (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Minste tal på dopsortar på kvar plass"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Største tal på dopsortar på kvar plass"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr "% motstand mot skot for kvar spelar"
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr "% motstand mot skot for kvar hore"
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Namn på kvar politimann"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Namn på kvar politimann sin betjent"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Namn på kvar politimann sine betjentar"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr "% motstand mot skot for kvar purk"
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr "% motstand mot skot for kvar politibetjent"
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Åtaks-handikap relativt til ein spelar"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Forsvars-handikap relativt til ein spelar"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Minste tal på politibetjentar"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Største tal på politibetjentar"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Null-basert indeks på våpenet politiet er væpna med"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Tal på våpen kvar politimann har"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr "Tal på våpen kvar politibetjent har"
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Namn på kvart dop"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Minste vanlege pris på kvart dop"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Største vanlege pris på kvart dop"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE viss dette dopet kan vera ekstra billeg"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE viss dette dopet kan vera ekstra dyrt"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Melding som skal visast når dette dopet er ekstra billeg"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Formatstreng brukt for dyrt dop 50% av tida"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Tal som prisen på dopet skal delast på når det er ekstra billeg"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Tal som prisen på dopet skal gangast med når det er ekstra dyrt"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Namn på kvar stad"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Prisen på kvart våpen"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Plassen kvart våpen tek"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Skaden kvart våpen gjer"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Ord for ei einskild «hore»"
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Ord for to eller fleire «horer»"
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Ord for eit einskild våpen eller tilsvarande"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Ord for to eller fleire våpen"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Ord for eit einskild narkotikum eller tilsvarande"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Ord for to eller fleire slag dop"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() formatstreng for å visa tida i spelet"
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Minstepris for å tilsetja ei hore"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Høgaste pris for å tilsetja ei hore"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Liste over ting du høyrer på T-banen"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Tal på ting som blir sagt på T-banen"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Liste over songar du kan høyra bli spelt"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Tal på sogar som spelar"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Liste over ting du kan stoppa for å gjera"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Tal på ting du kan stoppa for å gjera"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -656,139 +656,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Marknaden er oversvømt med billeg heimelaga syre!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -796,46 +796,46 @@ msgid ""
 msgstr "Colombiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Melding"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr "Politiet gjorde eit kjempebeslag av %tde! Prisane er skyhøge!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Narkomane kjøper %tde til avsindige prisar!"
@@ -844,159 +844,159 @@ msgstr "Narkomane kjøper %tde til avsindige prisar!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Ville det ikkje vore festleg viss alle plutseleg kvekkte samtidig?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "Paven var jøde ein gong, veit du."
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Eg er sikker på at du har nokon ordentleg interessante draumar."
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Eg trur eg skal reisa til Amsterdam i år"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Guten min, du treng ein gul hårklipp."
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Eg synest det er fantastisk kva dei får til med røykjelse no til dags."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "Eg har ikkje vore kvinne heile livet, veit du"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Veit mora di at du sel dop?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "Er du høg på noko?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Å, du må vera frå California"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Eg var hippie sjølv ein gong i tida"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Det er ingenting som å ha mykje pengar"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "Du ser ut som eit beltedyr!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Eg trur ikkje på Ronald Reagan"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Ha mot! Bush er ein nuddel!"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Har eg ikkje sett deg på fjernsynet?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Me vinn krigen mot narkotika!"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Ein dag utan dop er som ei natt"
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Me bruker berre 20% av hjernane våre, så kvifor ikkje øydeleggja resten"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Eg samlar inn pengar til Zomibiar for Kristus"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Eg vil gjerne selja deg ein etande puddel"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Vinnarar dopar seg ikkje... viss ikkje dei gjer det"
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus elskar deg meir enn du veit"
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "Vil du ha ein seigmann?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Kan ikkje tolka oppsettfila %s, linje %d"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Klarte ikkje å opna fila %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -1006,40 +1006,40 @@ msgstr ""
 " er logga på. Vent til alle spelarane har logga av, eller\n"
 "fjern dei med dytt- eller-drep-kommandoane, og prøv igjen."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks til %s array burde vore mellom 1 og %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s er %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s er %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s er %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s er «%s»\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] er %s\n"
@@ -1047,42 +1047,42 @@ msgstr "%s[%d] er %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s er { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kan ikkje vera mindre enn %d - ignorerer!"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kan ikkje vera større enn %d - ignorerer!"
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Forandra storleiken på strukturlista til %d element\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Venta ein boolsk verdi (ein av 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=TRUE"
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1090,7 +1090,7 @@ msgstr ""
 "  -u, --plugin=FIL        bruk lydmodul «FIL»\n"
 "                            "
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1098,19 +1098,19 @@ msgstr ""
 "  -u fil   bruk lydmodul «fil»\n"
 "\t          "
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s tilgjengeleg)\n"
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars versjon %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1190,7 +1190,7 @@ msgstr ""
 "  -C, --convert=FIL       konverter ei poengfil i gamalt format til det\n"
 "                            nye formatet\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 #, fuzzy
 msgid ""
 "  -h, --help              display this help information\n"
@@ -1209,7 +1209,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1269,7 +1269,7 @@ msgstr ""
 "  -C fil   konverter ei poengfil i gamalt format til det nye formatet\n"
 "  -A       kopla til ein lokalt køyrande tenar for administrasjon\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 #, fuzzy
 msgid ""
 "  -h       display this help information\n"
@@ -1286,7 +1286,7 @@ msgstr ""
 "GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1296,7 +1296,7 @@ msgstr ""
 "på nytt, med valet --enable-curses-client til configure,\n"
 "eller bruk ein grafisk klient (viss tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1307,7 +1307,7 @@ msgstr ""
 "configure, eller bruk tekstmodus-klienten (viss\n"
 "tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1315,7 +1315,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1593,11 +1593,11 @@ msgid "How many do you drop? "
 msgstr "Kor mange vil du kasta? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Kva vil du kjøpa? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "Kva vil du selja? "
 
@@ -1626,7 +1626,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Er du viss på at du vil avslutta? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "JN"
 
@@ -1643,51 +1643,51 @@ msgstr "Du har blitt dytta av tenaren. Byter til einspelar-modus."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Tenaren har stengt. Byter til einspelar-modus."
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s blir med i spelet!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s har forlatt spelet."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s er no kjend som %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Staden du er no/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Diverre er det alt nokon som brukar «ditt» namn. Vér snill og byt det."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "P O E N G L I S T E"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du har ikkje noko %tde å selja!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Du har ikkje noko å selja!"
 
@@ -1695,27 +1695,27 @@ msgstr "Du har ikkje noko å selja!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du treng fleire %tde for å bera meir %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du har ikkje nok plass til å bera det %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du har ikkje nok pengar til å kjøpa det %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Vil du K>jøpa, S>elja eller G>å?"
 
@@ -1723,41 +1723,41 @@ msgstr "Vil du K>jøpa, S>elja eller G>å?"
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSG"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Kor mykje pengar vil du betala tilbake?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Du har ikkje så mykje pengar!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Vil du S>etja inn pengar, T>a ut pengar, eller G>å?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "STG"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Kor mykje pengar?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Du har ikkje så mykje i banken."
 
@@ -1765,47 +1765,47 @@ msgstr "Du har ikkje så mykje i banken."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Nei"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "S:Spring"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "K:Kjemp"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Angrip"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "U:Unngå"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Trykk ein tast..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Meldingar (-/+ rullar opp/ned)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Status"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Kontantar"
 
@@ -1813,41 +1813,41 @@ msgstr "Kontantar"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tuf"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Helse"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Bank"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Gjeld"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Plass %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d plass %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Frakk"
 
@@ -1855,141 +1855,141 @@ msgstr "Frakk"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tuf"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Ingen andre spelarar er logga på no."
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Spelarar som er logga på:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hei du. Her kostar %tbe:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kan ikkje installera SIGWINCH-avbrotshandsamar!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Namnet ditt:"
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Vil du K>jøpa"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", S>elja"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", H>iva"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", sN>akka med alle, snakka med E>in"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", sjå L>ister"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", kJ>empa"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", R>eisa"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", eller A>vslutta? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Vil du "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "K>jempa, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "V>enta, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "R>ømma, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "S>elja %tuf, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "eller A>vslutta?"
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Mista sambandet til tenaren! Går tilbake til einspelar-modus."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "KSHNELGJRA"
@@ -1997,30 +1997,30 @@ msgstr "KSHNELGJRA"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "SRKVA"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Lista opp kva? S>pelarar eller P>oeng? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Kven vil du snakka privat med? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Snakk: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Spela igjen? "
 
@@ -2105,24 +2105,24 @@ msgid "Abandon game"
 msgstr "Gje opp dette spelet"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Eignelutar"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Steng"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Mista sambandet til tenaren - byter til einspelar-modus"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -2131,7 +2131,7 @@ msgstr ""
 "Byter til einspelar-modus."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2168,7 +2168,7 @@ msgstr "_Sel %tuf"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Kjemp"
 
@@ -2292,16 +2292,15 @@ msgstr "Selja kor mange?"
 msgid "Drop how many?"
 msgstr "Hiva kor mange?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Avbryt"
 
@@ -2346,65 +2345,65 @@ msgid "Question"
 msgstr "Spørsmål"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Plass"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Norsk omsetjing"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Ikon og grafikk"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Lydar"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Dopsal og research"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Speltesting"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Grundig speltesting"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Konstruktiv kritikk"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Ukonstruktiv kritikk"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2415,6 +2414,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2428,7 +2428,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2438,7 +2438,7 @@ msgstr ""
 "dopewars er tilgjengeleg under GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2449,134 +2449,134 @@ msgstr ""
 "For informasjon om kommandolinevala, skriv dopewars -h på\n"
 "unix-kommandolinja. Det viser ein hjelpetekst med dei tilgjengelege vala.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Lokal dokumentasjon i HTML-format"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Lånehai vindagustittel/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banknamn vindaugstittel/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Du må skriva inn ei positiv mengde pengar!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Du har ikkje så mykje pengar i banken."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Kontantar: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Gjeld: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Bank: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Betal tilbake:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Sett inn"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Ta ut"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Betal alt"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Spelarliste"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Snakk med spelar(ar)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Snakk med alle spelarane"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Melding:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Send"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Namn"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Pris"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Mengde"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Kjøp ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Sel"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Hiv <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tuf her"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tuf du har"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Byt namn"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2584,12 +2584,12 @@ msgstr "Diverre, nokon andre bruker «ditt» namn. Ver snill og byt det:-"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Våpenforretning-tittel/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr "Minimer til systemtrauet"
 msgid "Metaserver URL"
 msgstr "Metatenar"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -2775,9 +2775,7 @@ msgstr "Kommentar"
 msgid "MOTD (welcome message)"
 msgstr "Velkomstmelding"
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Tenar"
 
@@ -2805,127 +2803,59 @@ msgstr "Spel"
 msgid "_Help"
 msgstr "_Hjelp"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kan ikkje starta spelet utan å velja eit namn!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nytt spel"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: Ventar på brukaren"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Sambandet vart stengd av nettverksverten."
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Kunne ikkje kopla til (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: Freistar å kopla til %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Ukjend"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d av %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Kopla til SOCKS-tenar %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Autentiserer mot SOCKS-tenar"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Ber SOCKS om samband til %s..."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Port"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Versjon"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Spelarar"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Namnet ditt:"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Vertsnamn"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Kopla til"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Start spel for ein spelar"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Ein spelar"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr "_Frisk opp"
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Metatenar"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "Må ha SOCKS-autentisering"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3391,90 +3321,90 @@ msgstr "Du høyrer nokon som speler %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Vil du vitja %tde?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Vil du hyra ei %tue for %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s er alt her!^Vil du gå til Angrep, eller Stikka av?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "Ingen politi eller våpen!"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "Politi kan ikkje gå til åtak på andre politi!"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "Spelarane er allereie i ein kamp!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "Spelarane er alt i kvar sine kampar!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kan ikkje starta kamp - har ingen våpen!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^vil du betala %P til ein doktor for å lappa deg saman?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du vart rana på t-banen!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du møter ein venn! Han gjev deg %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du møter ein venn, og gjev han %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Luka vekk eit RandomOffer"
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Politihundar jagar deg %d kvartal! Du mista litt %tde. Det er hardt, mann."
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du finn %d %tde på ein daud kar på t-banen!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mora di laga sjokoladekjeks med litt av %tbe. Dei var kjempegode!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3483,25 +3413,25 @@ msgstr ""
 "YN^Det er litt jazztobakk som luktar ugraskverk her.^Det ser bra ut! Vil du "
 "røyka det?"
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du stoppa for å %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Vil du kjøpa ein større frakk for %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hei du! Eg kan hjelpa deg å bera %tde for berre %P. Ja eller nei?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Vil du kjøpa ein %tue for %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3510,29 +3440,29 @@ msgstr ""
 "Du hallusinerte i tre dagar på den villaste trippen du kunne^ forestilla "
 "deg! Så døydde du fordi hjernen din smuldra opp!"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "For seint. %s har nett gått."
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, fuzzy, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Politiet ser at du kastar %tde!"
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sender oppdateringar til metatenaren"
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sender påminningsmelding til metatenaren..."
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Spelaren fjerna: Han/ho var ikkje aktiv"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Spelaren fjerna pga. tidsavbrot i sambandet"
 
@@ -3812,86 +3742,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kan ikkje starta opp WinSock (%s)!"
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "SOCKS server generell feil"
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Samband nekta av SOCKS-regelsett"
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Kan ikkje nå nettverket"
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Kan ikkje nå verten"
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr "Samband nekta"
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL gjekk ut"
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Kommandoen er ikkje støtta"
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Adressetypen er ikkje støtta"
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS-tenar avviste alle tilbudte metodar"
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr "Ukjend SOCKS-adressetype returnert"
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-autentiserer feila"
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-autentisering avbroten av brukar"
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Førespurnad vart avvist eller feila"
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Avslått - kan ikkje kontakta identd"
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Avslått - identd rapporterer ein annan brukaridentitet"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Ukjend SOCKS svarkode"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr "Ukjend SOCKS svar-versjon-kode"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr "Ukjend SOCKS tenarversjon"
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS feilkode %d"
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4082,12 +4012,12 @@ msgstr ""
 "ikkje fungera som ein nettverksspelar.\n"
 "Kompiler på nytt med opsjonen --enable-networking til configure."
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Klarte ikkje å opna fila %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4095,6 +4025,44 @@ msgid ""
 msgstr ""
 "Ugyldig modul «%s» vald.\n"
 "(%s tilgjengeleg, brukar «%s» no.)"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: Freistar å kopla til %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Ukjend"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d av %d"
+
+#~ msgid "Port"
+#~ msgstr "Port"
+
+#~ msgid "Version"
+#~ msgstr "Versjon"
+
+#~ msgid "Players"
+#~ msgstr "Spelarar"
+
+#~ msgid "Host name"
+#~ msgstr "Vertsnamn"
+
+#~ msgid "_Connect"
+#~ msgstr "_Kopla til"
+
+#~ msgid "Single player"
+#~ msgstr "Ein spelar"
+
+#~ msgid "_Refresh"
+#~ msgstr "_Frisk opp"
+
+#~ msgid "Metaserver"
+#~ msgstr "Metatenar"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "Må ha SOCKS-autentisering"
 
 #~ msgid "bitch"
 #~ msgstr "hore_ue_hore_be_hora"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2001-04-08 16:16+01000\n"
 "Last-Translator: Slawomir Molenda <jeszua@panda.bg.univ.gda.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -49,591 +49,591 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "siedziba Złotych Pasów"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "bank"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port do połączenia"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nazwa pliku z najlepszymi wynikami"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nazwa serwera do połączenia się"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "Niezerowa wartość jeżeli serwer ma się kontaktować z metaserwerem"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 #, fuzzy
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nazwa metaserwera do wysyłania szczegółów o serwerze"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Preferowana nazwa hosta twojego serwera"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentyfikacja dla LocalName z metaserwerem"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Opis serwera, zgłaszany do metaserwera"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr ""
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Ilość tur (jeżeli 0, brak ograniczeń)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Losowe zdarzenia umiarkowane"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Tryb śledzenia dla pliku konfiguracji"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Ilość miejsc w grze"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Ilość broni w grze"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Ilość narkotyków w grze"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Położenie Złotych Pasów"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Położenie banku"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Położenie ruskiego bazaru z bronią"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Położenie dyskoteki"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nazwa Złotych Pasów"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nazwa banku"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nazwa sklepu z bronią"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nazwa dyskoteki"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr ""
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Rodzaj klucza sortującego dostępne narkotyki"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Ilość sekund na oddanie strzału"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Gracze są rozłączani po tej liczbie sekund"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Liczba sekund na nawiązanie połącznia albo zerwanie"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maksymalna ilość połączeń TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Liczba sekund pomiędzy turami komputerowych graczy"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Ilość gotówki, z jaką gracz zaczyna"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Z jakim długiem zaczyna każdy gracz"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nazwa każdej lokacji"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Policja obecna w każdym miejscu (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Minimalna ilość dragów dla każdego miejsca"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Maksymalna ilość dragów dla każdego miejsca"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr ""
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nazwa poszczególnych narkotyków"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Minimalna cena każdego draga"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Maksymalna cena każdego draga"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Niezerowa wartość jeżeli ten drag ma być szczególnie tani"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Niezerowa wartość jeżeli ten drag ma być szczególnie drogi"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Wiadomość wyświetlana, gdy drag jest szczególnie tani"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Format używany dla drogich dragów przez 50% czasu"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Separator dla ceny szczególnie taniego draga"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Mnożnik dla szczególnie drogich dragów"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nazwa każdej lokacji"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Cena każdej broni"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Miejsce zajmowane przez poszczególną broń"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Obrażenia zadawane prze poszczególne bronie"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Słowo określające jedną \"dziwkę\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Słowo określające dwie lub więcej \"dziwek\""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Słowo określające jedną broń"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Słowo określające więcej broni"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Słowo określające jednego draga"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Słowo określające więcej dragów"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Minimalna cena wynajęcia dziwki"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Maksymalna wynajęcia dziwki"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Lista rzeczy jakie słyszysz na dworcu"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Liczba komentarzy na dworcu"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Liczba piosenek, które możesz usłyszeć"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Liczba granych piosenek"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Lista rzeczy, które możesz przestać robić"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Liczba rzeczy, które możesz przestać robić"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -641,139 +641,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Rynek jest pełen taniego, domowej roboty kwasu!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -781,46 +781,46 @@ msgid ""
 msgstr "Świeża dostawa marihuany z Holandii! Ceny trawy lecą w dół"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Wiadomość"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr "Gliny zrobiły obławę na %tde ! Ceny towaru są kosmiczne!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
@@ -829,158 +829,158 @@ msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Byłoby fajnie gdyby wszyscy wyszli na ulicę i się pieprzyli"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "Zażywasz-przegrywasz!"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Hej cieciu, zwolnij trochę"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Po co ci mózg, jak masz dresy"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Wiesz, nie zawsze byłam kobietą"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Masz niezły tyłek...chcesz się zabawić?"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "Wiesz, nie zawsze byłam kobietą"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Czy twoja stara wie, że jesteś dilerem?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "Co dziś wciągnąłeś?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Pan z Wołomina?"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Kiedyś też byłem śmieciem, tak ja ty."
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Nic się nie liczy oprócz pieniędzy"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "Niezły dres, widzę, że zarabiasz na tym gównie kupę szmalu"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Przypominasz mi zafajdanego ćpuna"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Odwagi! Zajaraj sobie i się wyluzujesz!"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Czy ja cie czasem nie widziałem w TV?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Wygramy tę wojnę o narkotyki!"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Dzień bez prochów jest jak noc"
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "Używamy tylko 10% naszego mózgu, czemu nie zjarać reszty?"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Zbieram datki na Kościół Zombich Chrystusa"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Sprzedać ci trochę pyłku kosmicznego?"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Zwycięzcy nie używają dragów...dopóki są zwycięzcami"
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Jezus kocha cię bardziej ode mnie"
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "Chcesz landrynkę kotku?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -990,40 +990,40 @@ msgstr ""
 "żaden z graczy nie jest zalogowany. Zaczekaj, aż wszyscy się wylogują\n"
 "lub usuń ich komendami \"push\" albo \"kill\" i spróbuj jeszcze raz."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks w tablicy %s powinien być pomiędzy 1 i %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s jest %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s jest %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s jest %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s jest \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] jest %s\n"
@@ -1031,66 +1031,66 @@ msgstr "%s[%d] jest %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s jest { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Zmieniono strukturę listy do %d elementów\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1164,7 +1164,7 @@ msgstr ""
 "dopewars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1176,7 +1176,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1238,7 +1238,7 @@ msgstr ""
 "dopewars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1248,7 +1248,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1258,7 +1258,7 @@ msgstr ""
 "opcję --enable-curses-client to pliku konfigurancyjnego, albo użyj\n"
 "zamiast tego okienkowej wersji klienta (jeżeli jest dostępny).\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1268,7 +1268,7 @@ msgstr ""
 "--enable-gui-client do skryptu konfiguracyjnego, albo użyj\n"
 "zamiast tego (jeżeli jest dostępny) klienta opartego na curses.\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1276,7 +1276,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1547,11 +1547,11 @@ msgid "How many do you drop? "
 msgstr "Ile chcesz zostawić? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Co chcesz kupić? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "Co chcesz sprzedać? "
 
@@ -1580,7 +1580,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Na pewno chcesz wyjść? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "YN"
 
@@ -1597,51 +1597,51 @@ msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s dołączył do gry!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s opuścił grę."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s będzie teraz znany jako %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "N A J L E P S Z E   W Y N I K I"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Nie masz żadnej %tde do sprzedania!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Nie masz nic do opchnięcia!"
 
@@ -1649,27 +1649,27 @@ msgstr "Nie masz nic do opchnięcia!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Będziesz potrzebował więcej %tde aby jeszcze unieść %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Nie masz wystarczająco dużo miejsca, aby unieść tę %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Nie masz tyle kasy na %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "K>upić, S>przedać, czy W>yjść? "
 
@@ -1677,41 +1677,41 @@ msgstr "K>upić, S>przedać, czy W>yjść? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSW"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Ile forsy oddajesz Złotym Pasom? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Nie masz tak dużo kasy!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Zamierzasz Z>deponować, W>ycofać gotówkę czy O>puścić bank? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ZWO"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Ile kasy? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Nie ma tyle gotówki w banku..."
 
@@ -1719,47 +1719,47 @@ msgstr "Nie ma tyle gotówki w banku..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "T:Tak"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Nie"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "U:Uciekasz"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "A:Atak"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Atakuj"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "E:Ewakuuj się"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Naciśnij dowolny klawisz..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statystyka"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Kasa"
 
@@ -1767,41 +1767,41 @@ msgstr "Kasa"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Zdrowie"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Bank"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Debet"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Miejsce %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Miejsce %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Twój płaszcz"
 
@@ -1809,139 +1809,139 @@ msgstr "Twój płaszcz"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Nie ma aktualnie innych zalogowanych graczy!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Gracze aktualnie zalogowani:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hej cieciu, oto %tde jakie są w obiegu:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Jak się nazywasz cieciu? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "K>up"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr " S>przedaj"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr " U>puść"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr " G>adaj P>owiedz "
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr " Z>obacz"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr " A>takuj"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr " J>edź"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr " W>yjście"
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Czy "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "A>takujesz"
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "S>toisz, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "U>ciekasz, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>ilujesz %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "czy W>yjście "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Połączenie z serwerem zerwane! Włączenie trybu dla jednego gracza"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "KSUGPZDAJW"
@@ -1949,30 +1949,30 @@ msgstr "KSUGPZDAJW"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "DUASW"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Co chcesz zobaczyć? G>raczy W>yniki"
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "GW"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Do kogo prywatnie zagadujesz ? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Nawijaj: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Grasz jeszcze raz? "
 
@@ -2057,31 +2057,31 @@ msgid "Abandon game"
 msgstr ""
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Plecak"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Zamknij"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Połączenie z serwerem przerwane - włączenie trybu dla jednego gracza"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2116,7 +2116,7 @@ msgstr "_Diluj %Tde"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Atakujesz"
 
@@ -2240,16 +2240,15 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "Z_aniechaj"
 
@@ -2294,65 +2293,65 @@ msgid "Question"
 msgstr "Pytanie"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Miejsce"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Tłumaczenie na polski"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Dilowanie dragami i rozwój"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Testowanie gry"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Ekstensywne testowanie gry"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Konstruktywna krytyka"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Niekonstruktywna krytyka"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2363,6 +2362,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2376,7 +2376,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2386,7 +2386,7 @@ msgstr ""
 "dopewars są publikowane zgodnie z GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2397,134 +2397,134 @@ msgstr ""
 "Informacje o komendach linni poleceń uzyskasz piszać dopewars -h po\n"
 "twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Nie ma tyle gotówki w banku..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Kasa: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Debet: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Bank %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Zwróć:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Depozyt"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Wycofaj się"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Spłać wszystko"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista graczy"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Mów do gracza(y)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Mów do wszystkich graczy"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Wiadomość:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Wyślij"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nazwa"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Cena"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Ilość"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Kup ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Sprzedaj"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Zostaw <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde na rynku"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde w plecaku"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Zmień nicka"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2532,12 +2532,12 @@ msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2709,7 +2709,7 @@ msgstr ""
 msgid "Metaserver URL"
 msgstr "Metaserwer"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -2717,9 +2717,7 @@ msgstr "Komentarz"
 msgid "MOTD (welcome message)"
 msgstr ""
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Serwer"
 
@@ -2747,127 +2745,59 @@ msgstr ""
 msgid "_Help"
 msgstr "_Pomoc"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nowa Gra"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: Czekam na aktywność usera"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr ""
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr ""
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Nie mogę się połączyć (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: Próba kontaktu z %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr ""
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d z %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Port"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Wersja"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Gracze"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Jak się _nazywasz cieciu?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nazwa hosta"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Połącz"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Rozpocznij grę dla jednego gracza"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Pojedyńczy gracz"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Metaserwer"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr ""
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3300,69 +3230,69 @@ msgstr "Słyszysz jak ktoś puszcza %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Chciałbyś odwiedzić %tde?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Chciałbyś wynająć %tde za %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s już tu jest!^A>takujesz czy E>wakuujesz się?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Płacisz doktorowi %P, żeby cię pozszywał?"
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Zostałeś obrzygany w pociągu!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Spotykasz starego dilera! Daje ci %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Spotkałeś przyjaciela! Dajesz mu %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Wyłączono RandomOffer"
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3370,17 +3300,17 @@ msgstr ""
 "Policyjne psy skoczyły ci do gardła %d! Upuściłeś jakieś %tde! Ale "
 "rozpierdol!dresie!"
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Znalazłeś %d %tde przy zwłokach jakiegoś ćpuna w WC!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mamuśka zrobiła ci kanapki z odrobiną %tde! Były super!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3389,25 +3319,25 @@ msgstr ""
 "YN^Znalazłeś trochę ziela, które pachnie tak świeżo!^Dobrze wygląda! "
 "Zapalisz? "
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Zatrzymujesz się i %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Chciałbyć kupić większy płaszcz za %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hej koleś! Pomogę ci ponieść %tde za jedyne %P. Zgadzasz się?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Chciałbyś kupić %tde za %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3416,29 +3346,29 @@ msgstr ""
 "Miałeś haluny przez trzy dni i najlepszego tripa w swoim życiu!^Potem "
 "umarłeś, bo dla twojego mózga ta wycieczka była za mocna!"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Za późno - %s właśnie zwiał!"
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Gracz usunięty przez przekroczenie czasu na ruch"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Gracz usunięty przez przekroczenia czasu przy połączeniu"
 
@@ -3716,86 +3646,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -3981,17 +3911,46 @@ msgstr ""
 "jakby był komputerowym graczem.\n"
 "Skonfiguruj z opcją --enable-networking i przekompiluj"
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: Próba kontaktu z %s..."
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d z %d"
+
+#~ msgid "Port"
+#~ msgstr "Port"
+
+#~ msgid "Version"
+#~ msgstr "Wersja"
+
+#~ msgid "Players"
+#~ msgstr "Gracze"
+
+#~ msgid "Host name"
+#~ msgstr "Nazwa hosta"
+
+#~ msgid "_Connect"
+#~ msgstr "_Połącz"
+
+#~ msgid "Single player"
+#~ msgstr "Pojedyńczy gracz"
+
+#~ msgid "Metaserver"
+#~ msgstr "Metaserwer"
 
 #~ msgid "bitch"
 #~ msgstr "dziwka"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-11 20:52+0000\n"
+"POT-Creation-Date: 2025-08-12 10:09+0000\n"
 "PO-Revision-Date: 2022-06-10 23:06-0300\n"
 "Last-Translator: Bruno Lopes <brunoml@bol.com.br>\n"
 "Language-Team: Portuguese/Brazil <pt_BR@li.org>\n"
@@ -21,28 +21,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:179
+#: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more bitches
-#: src/dopewars.c:181
+#: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:183
+#: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:185
+#: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:187 src/dopewars.c:189
+#: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
@@ -50,590 +50,590 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:194
+#: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Loan Collector"
 msgstr "o agiota"
 
-#: src/dopewars.c:197
+#: src/dopewars.c:198
 #, fuzzy
 msgid "the Merchant Bank"
 msgstr "o Banco"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:237
+#: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Porta de rede para conectar"
 
-#: src/dopewars.c:240
+#: src/dopewars.c:241
 msgid "Name of the high score file"
 msgstr "Nome do arquivo de pontuação"
 
-#: src/dopewars.c:243
+#: src/dopewars.c:244
 msgid "Name of the server to connect to"
 msgstr "Nome do servidor para conectar"
 
-#: src/dopewars.c:246
+#: src/dopewars.c:247
 msgid "Server's welcome message of the day"
 msgstr "Mensagem de boas vindas do dia no servidor"
 
-#: src/dopewars.c:249
+#: src/dopewars.c:250
 msgid "Network address for the server to listen on"
 msgstr "Endereço de rede para em que o servidor aguardará conexões"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:254
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE se um servidor SOCKS deve ser usado para conectar à rede"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:258
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE se IDs numéricos de usuário devem ser usados para SOCKS4"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:262
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Se não em branco, será o nome de usuário a usar para SOCKS4"
 
-#: src/dopewars.c:264
+#: src/dopewars.c:265
 msgid "The hostname of a SOCKS server to use"
 msgstr "O hostname do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:267
+#: src/dopewars.c:268
 msgid "The port number of a SOCKS server to use"
 msgstr "O número da porta do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:270
+#: src/dopewars.c:271
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "A versão do protocolo SOCKS a usar (4 ou 5)"
 
-#: src/dopewars.c:273
+#: src/dopewars.c:274
 msgid "Username for SOCKS5 authentication"
 msgstr "Nome de usuário para autenticação SOCKS5"
 
-#: src/dopewars.c:276
+#: src/dopewars.c:277
 msgid "Password for SOCKS5 authentication"
 msgstr "Senha para autenticação SOCKS5"
 
-#: src/dopewars.c:279
+#: src/dopewars.c:280
 msgid "TRUE if server should report to a metaserver"
 msgstr "Não-zero se o servidor deve reportar ao servidor meta"
 
-#: src/dopewars.c:282
+#: src/dopewars.c:283
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nome do meta-servidor para reportar/obter os detalhes do servidor"
 
-#: src/dopewars.c:285
+#: src/dopewars.c:286
 msgid "Preferred hostname of your server machine"
 msgstr "Nome do host preferido para a sua máquina servidor"
 
-#: src/dopewars.c:288
+#: src/dopewars.c:289
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentificação para o NomeLocal com o servidor meta"
 
-#: src/dopewars.c:291
+#: src/dopewars.c:292
 msgid "Server description, reported to the metaserver"
 msgstr "Descrição do servidor, reportado para o servidor meta"
 
-#: src/dopewars.c:296
+#: src/dopewars.c:297
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Se TRUE, o servidor minimiza a Barra do Sistema"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:301
 msgid "If TRUE, the server runs in the background"
 msgstr "Se TRUE, o servidor executa em background"
 
-#: src/dopewars.c:303
+#: src/dopewars.c:304
 msgid "The command used to start your web browser"
 msgstr "O comando usado para iniciar seu navegador"
 
-#: src/dopewars.c:307
+#: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "No. de turnos do jogo (se 0, o jogo nunca acaba)"
 
-#: src/dopewars.c:310
+#: src/dopewars.c:311
 msgid "Day of the month on which the game starts"
 msgstr "Dia do mês em que o jogo inicia"
 
-#: src/dopewars.c:313
+#: src/dopewars.c:314
 msgid "Month in which the game starts"
 msgstr "Mês em que o jogo inicia"
 
-#: src/dopewars.c:316
+#: src/dopewars.c:317
 msgid "Year in which the game starts"
 msgstr "Ano em que o jogo inicia"
 
-#: src/dopewars.c:319
+#: src/dopewars.c:320
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:322
+#: src/dopewars.c:323
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:325
+#: src/dopewars.c:326
 msgid "File to write log messages to"
 msgstr "Arquivo onde escrever mensagens de log"
 
-#: src/dopewars.c:328
+#: src/dopewars.c:329
 msgid "Controls the number of log messages produced"
 msgstr "Controla o número de mensagens de log produzidas"
 
-#: src/dopewars.c:331
+#: src/dopewars.c:332
 msgid "strftime() format string for log timestamps"
 msgstr "String de formato strftime() para timestamps de log"
 
-#: src/dopewars.c:334
+#: src/dopewars.c:335
 msgid "Random events are sanitized"
 msgstr "Eventos aleatórios são censurados"
 
-#: src/dopewars.c:337
+#: src/dopewars.c:338
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "Não-zero se o valor das drogas compradas devem ser salvos"
 
-#: src/dopewars.c:340
+#: src/dopewars.c:341
 msgid "Be verbose in processing config file"
 msgstr "Mostrar mensagens processando o arquivo de configuração"
 
-#: src/dopewars.c:343
+#: src/dopewars.c:344
 msgid "Number of locations in the game"
 msgstr "Quantidade de locais no jogo"
 
-#: src/dopewars.c:347
+#: src/dopewars.c:348
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de policiais no jogo"
 
-#: src/dopewars.c:351
+#: src/dopewars.c:352
 msgid "Number of guns in the game"
 msgstr "Número de armas no jogo"
 
-#: src/dopewars.c:355
+#: src/dopewars.c:356
 msgid "Number of drugs in the game"
 msgstr "Número de drogas no jogo"
 
-#: src/dopewars.c:359
+#: src/dopewars.c:360
 msgid "Location of the Loan Shark"
 msgstr "Localização do agiota"
 
-#: src/dopewars.c:361
+#: src/dopewars.c:362
 msgid "Location of the bank"
 msgstr "Localização do banco"
 
-#: src/dopewars.c:364
+#: src/dopewars.c:365
 msgid "Location of the gun shop"
 msgstr "Localização da loja de armas"
 
-#: src/dopewars.c:367
+#: src/dopewars.c:368
 msgid "Location of the pub"
 msgstr "Localização do bordel"
 
-#: src/dopewars.c:370
+#: src/dopewars.c:371
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Juros diários na dívida do agiota"
 
-#: src/dopewars.c:373
+#: src/dopewars.c:374
 msgid "Daily interest rate on your bank balance"
 msgstr "Juros diários em sua poupança"
 
-#: src/dopewars.c:376
+#: src/dopewars.c:377
 msgid "Name of the loan shark"
 msgstr "Nome do agiota"
 
-#: src/dopewars.c:378
+#: src/dopewars.c:379
 msgid "Name of the bank"
 msgstr "Nome do banco"
 
-#: src/dopewars.c:380
+#: src/dopewars.c:381
 msgid "Name of the gun shop"
 msgstr "Nome da loja de armas"
 
-#: src/dopewars.c:382
+#: src/dopewars.c:383
 msgid "Name of the pub"
 msgstr "Nome do bordel"
 
-#: src/dopewars.c:384
+#: src/dopewars.c:385
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE se sons devem ser habilitados"
 
-#: src/dopewars.c:387
+#: src/dopewars.c:388
 msgid "Sound file played for a gun \"hit\""
 msgstr "Arquivo de som tocado para um tiro que acerta o alvo"
 
-#: src/dopewars.c:390
+#: src/dopewars.c:391
 msgid "Sound file played for a gun \"miss\""
 msgstr "Arquivo de som tocado quando um tiro erra o alvo"
 
-#: src/dopewars.c:393
+#: src/dopewars.c:394
 msgid "Sound file played when guns are reloaded"
 msgstr "Arquivo de som tocado quando armas são recarregadas"
 
-#: src/dopewars.c:396
+#: src/dopewars.c:397
 msgid "Sound file played when an enemy bitch/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:399
+#: src/dopewars.c:400
 msgid "Sound file played when one of your bitches is killed"
 msgstr ""
 
-#: src/dopewars.c:402
+#: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:405
+#: src/dopewars.c:406
 msgid "Sound file played when you are killed"
 msgstr "Arquivo de som tocado quando você é morto"
 
-#: src/dopewars.c:408
+#: src/dopewars.c:409
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:411
+#: src/dopewars.c:412
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:414
+#: src/dopewars.c:415
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:417
+#: src/dopewars.c:418
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:420
+#: src/dopewars.c:421
 msgid "Sound file played on arriving at a new location"
 msgstr "Arquivo de som tocado ao chegar em um novo local"
 
-#: src/dopewars.c:429
+#: src/dopewars.c:424
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:432
+#: src/dopewars.c:427
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:435
+#: src/dopewars.c:430
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:438
+#: src/dopewars.c:433
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:441
+#: src/dopewars.c:436
 msgid "Sort key for listing available drugs"
 msgstr "Teclas de ordenação para a listagem de drogas disponíveis"
 
-#: src/dopewars.c:444
+#: src/dopewars.c:439
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos em para revidar tiro"
 
-#: src/dopewars.c:447
+#: src/dopewars.c:442
 msgid "Players are disconnected after this many seconds"
 msgstr "Jogadores são desconectados depois destes segundos"
 
-#: src/dopewars.c:450
+#: src/dopewars.c:445
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tempo em segundos para conexões a serem feitas ou quebradas"
 
-#: src/dopewars.c:453
+#: src/dopewars.c:448
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexões TCP/IP"
 
-#: src/dopewars.c:456
+#: src/dopewars.c:451
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre turnos dos jogadores IA"
 
-#: src/dopewars.c:459
+#: src/dopewars.c:454
 msgid "Amount of cash that each player starts with"
 msgstr "Quantidade de dinheiro que cada jogador começa"
 
-#: src/dopewars.c:462
+#: src/dopewars.c:457
 msgid "Amount of debt that each player starts with"
 msgstr "Quantidade de débito que cada jogador começa"
 
-#: src/dopewars.c:465
+#: src/dopewars.c:460
 msgid "Name of each location"
 msgstr "Nome de cada local"
 
-#: src/dopewars.c:469
+#: src/dopewars.c:464
 msgid "Police presence at each location (%)"
 msgstr "Polícia presente em cada local (%)"
 
-#: src/dopewars.c:473
+#: src/dopewars.c:468
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas em cada local"
 
-#: src/dopewars.c:477
+#: src/dopewars.c:472
 msgid "Maximum number of drugs at each location"
 msgstr "Número máximo de drogas em cada local"
 
-#: src/dopewars.c:481 src/dopewars.c:484
+#: src/dopewars.c:476 src/dopewars.c:479
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:487 src/dopewars.c:490
+#: src/dopewars.c:482 src/dopewars.c:485
 msgid "% resistance to gunshots of each bitch"
 msgstr ""
 
-#: src/dopewars.c:493
+#: src/dopewars.c:488
 msgid "Name of each cop"
 msgstr "Nome de cada policial"
 
-#: src/dopewars.c:497
+#: src/dopewars.c:492
 msgid "Name of each cop's deputy"
 msgstr "Nome de cada ajudante do policial"
 
-#: src/dopewars.c:501
+#: src/dopewars.c:496
 msgid "Name of each cop's deputies"
 msgstr "Nome dos ajudantes do policial"
 
-#: src/dopewars.c:505 src/dopewars.c:509
+#: src/dopewars.c:500 src/dopewars.c:504
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:513 src/dopewars.c:517
+#: src/dopewars.c:508 src/dopewars.c:512
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:521
+#: src/dopewars.c:516
 msgid "Attack penalty relative to a player"
 msgstr "Valor relativo de ataque para o jogador"
 
-#: src/dopewars.c:525
+#: src/dopewars.c:520
 msgid "Defend penalty relative to a player"
 msgstr "Valor relativo de defesa para o jogador"
 
-#: src/dopewars.c:529
+#: src/dopewars.c:524
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ajudantes acompanhantes"
 
-#: src/dopewars.c:533
+#: src/dopewars.c:528
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ajudantes acompanhantes"
 
-#: src/dopewars.c:537
+#: src/dopewars.c:532
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Índice baseado-em-zero da arma que os policiais estão armados"
 
-#: src/dopewars.c:541
+#: src/dopewars.c:536
 msgid "Number of guns that each cop carries"
 msgstr "Número de armas que cada policial carrega"
 
-#: src/dopewars.c:545
+#: src/dopewars.c:540
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:549
+#: src/dopewars.c:544
 msgid "Name of each drug"
 msgstr "Nome de cada droga"
 
-#: src/dopewars.c:553
+#: src/dopewars.c:548
 msgid "Minimum normal price of each drug"
 msgstr "Preço mínimo normal de cada droga"
 
-#: src/dopewars.c:557
+#: src/dopewars.c:552
 msgid "Maximum normal price of each drug"
 msgstr "Preço máximo normal de cada droga"
 
-#: src/dopewars.c:561
+#: src/dopewars.c:556
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Não-zero se esta droga pode ser especialmente barata"
 
-#: src/dopewars.c:565
+#: src/dopewars.c:560
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Não-zero se esta droga pode ser especialmente cara"
 
-#: src/dopewars.c:569
+#: src/dopewars.c:564
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensagem mostrada quando esta droga é especialmente barata"
 
-#: src/dopewars.c:573 src/dopewars.c:577
+#: src/dopewars.c:568 src/dopewars.c:572
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Formato da string usada para drogas caras em 50% do tempo"
 
-#: src/dopewars.c:580
+#: src/dopewars.c:575
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor para os preços da droga especialmente barata"
 
-#: src/dopewars.c:584
+#: src/dopewars.c:579
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para para os preços da droga especialmente cara"
 
-#: src/dopewars.c:587
+#: src/dopewars.c:582
 #, fuzzy
 msgid "Name of each weapon"
 msgstr "Nome de cada local"
 
-#: src/dopewars.c:591
+#: src/dopewars.c:586
 #, fuzzy
 msgid "Price of each weapon"
 msgstr "Preço de cada arma"
 
-#: src/dopewars.c:595
+#: src/dopewars.c:590
 #, fuzzy
 msgid "Space taken by each weapon"
 msgstr "Espaço tomado por cada arma"
 
-#: src/dopewars.c:599
+#: src/dopewars.c:594
 #, fuzzy
 msgid "Damage done by each weapon"
 msgstr "Dano de cada arma"
 
-#: src/dopewars.c:603
+#: src/dopewars.c:598
 msgid "Word used to denote a single \"bitch\""
 msgstr "Palavra usada para denominar uma simples \"puta\""
 
-#: src/dopewars.c:606
+#: src/dopewars.c:601
 msgid "Word used to denote two or more \"bitches\""
 msgstr "Palavra usada para denominar duas ou mais \"putas\""
 
-#: src/dopewars.c:609
+#: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palavra usada para detominar uma simples arma ou equivalente"
 
-#: src/dopewars.c:612
+#: src/dopewars.c:607
 msgid "Word used to denote two or more guns"
 msgstr "Palavra usada para denominar duas ou mais armas"
 
-#: src/dopewars.c:615
+#: src/dopewars.c:610
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palavra usada para denominar uma simples droga ou equivalente"
 
-#: src/dopewars.c:618
+#: src/dopewars.c:613
 msgid "Word used to denote two or more drugs"
 msgstr "Palavra usada para denominar duas ou mais drogas"
 
-#: src/dopewars.c:621
+#: src/dopewars.c:616
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:624
+#: src/dopewars.c:619
 msgid "Cost for a bitch to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:627
+#: src/dopewars.c:622
 msgid "Cost for a bitch to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:630
+#: src/dopewars.c:625
 msgid "Minimum price to hire a bitch"
 msgstr "Preço mínimo para contratar uma puta"
 
-#: src/dopewars.c:633
+#: src/dopewars.c:628
 msgid "Maximum price to hire a bitch"
 msgstr "Preço máximo para contratar uma puta"
 
-#: src/dopewars.c:636
+#: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de coisas ao qual você ouve no metrô"
 
-#: src/dopewars.c:639
+#: src/dopewars.c:634
 msgid "Number of subway sayings"
 msgstr "Número de falas no metrô"
 
-#: src/dopewars.c:642
+#: src/dopewars.c:637
 msgid "List of songs which you can hear playing"
 msgstr "Lista de sons ao qual você ouve tocando"
 
-#: src/dopewars.c:645
+#: src/dopewars.c:640
 msgid "Number of playing songs"
 msgstr "Número de sons tocando"
 
-#: src/dopewars.c:648
+#: src/dopewars.c:643
 msgid "List of things which you can stop to do"
 msgstr "Lista de coisas que você pode parar de fazer"
 
-#: src/dopewars.c:651
+#: src/dopewars.c:646
 msgid "Number of things which you can stop to do"
 msgstr "Número de coisas que você pode parar de fazer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:661
+#: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:657
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:658
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:659
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:660
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:661
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:662
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:663
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:664
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:665
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:666
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:667
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:668
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:674
+#: src/dopewars.c:669
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:675
+#: src/dopewars.c:670
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:676
+#: src/dopewars.c:671
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:677
+#: src/dopewars.c:672
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:678
+#: src/dopewars.c:673
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -641,139 +641,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:687
+#: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:688
+#: src/dopewars.c:683
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:689
+#: src/dopewars.c:684
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:690
+#: src/dopewars.c:685
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:691
+#: src/dopewars.c:686
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:696
+#: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:698 src/dopewars.c:702
+#: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:700 src/dopewars.c:702
+#: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:702
+#: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:704
+#: src/dopewars.c:699
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:704 src/gui_client/optdialog.c:952
+#: src/dopewars.c:699 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:709
+#: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:710
+#: src/dopewars.c:705
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:711
+#: src/dopewars.c:706
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:712
+#: src/dopewars.c:707
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:718
+#: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:714
 #, fuzzy
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "O mercado está cheio de ácido caseiro barato!"
 
-#: src/dopewars.c:720
+#: src/dopewars.c:715
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:721
+#: src/dopewars.c:716
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:717
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:718
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:719
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:720
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:726 src/gui_client/optdialog.c:947
+#: src/dopewars.c:721 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:722
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:723
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:729
+#: src/dopewars.c:724
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:730
+#: src/dopewars.c:725
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:731
+#: src/dopewars.c:726
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:732
+#: src/dopewars.c:727
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:733
+#: src/dopewars.c:728
 #, fuzzy
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
@@ -781,46 +781,46 @@ msgid ""
 msgstr "Colombianos enganaram a Guarda Costeira! Preços de maconha abaixaram!"
 
 #. The names of the default locations
-#: src/dopewars.c:741
+#: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:737
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:738
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:744
+#: src/dopewars.c:739
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:745
+#: src/dopewars.c:740
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:746
+#: src/dopewars.c:741
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:747
+#: src/dopewars.c:742
 #, fuzzy
 msgid "Edessa"
 msgstr "Mensagem"
 
-#: src/dopewars.c:748
+#: src/dopewars.c:743
 msgid "Nicaea"
 msgstr ""
 
 #. Messages displayed for drug busts, etc.
-#: src/dopewars.c:754
+#: src/dopewars.c:749
 #, fuzzy, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
 msgstr "Policiais apreenderam %tde! Preços estão super altos!"
 
-#: src/dopewars.c:755
+#: src/dopewars.c:750
 #, fuzzy, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Viciados estão comprando %tde a preços ridículos!"
@@ -829,160 +829,160 @@ msgstr "Viciados estão comprando %tde a preços ridículos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:765
+#: src/dopewars.c:760
 #, fuzzy
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Não seria engraçado se todos tivessem de uma vez só?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:761
 msgid "The Pope was once Jewish, you know"
 msgstr "O Papa já foi judeu uma vez, você sabe"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:762
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Eu aposto que você tem sonhos realmente interessantes"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:763
 #, fuzzy
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Então eu acho que vou para Amsterdã este ano"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:764
 #, fuzzy
 msgid "Son, you need a yellow horse"
 msgstr "Filho, você precisa de um corte de cabelo amarelo"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:765
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Eu acho maravilhoso o que estão fazendo com incenso estes dias"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:766
 msgid "I wasn't always a woman, you know"
 msgstr "I eu não fui sempre uma mulher, você sabe"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:767
 #, fuzzy
 msgid "Does your mother know you're a war monger?"
 msgstr "Sua mãe sabe que você é um traficante de drogas?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:768
 #, fuzzy
 msgid "Are you praying something?"
 msgstr "Você está doidão ou coisa parecida?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:769
 #, fuzzy
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, você deve ser da Califórnia"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:770
 #, fuzzy
 msgid "I used to be a Manichaean, myself"
 msgstr "Eu mesmo costumava ser hippe"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:771
 msgid "There's nothing like having lots of money"
 msgstr "Não há nada como ter muito dinheiro"
 
-#: src/dopewars.c:777
+#: src/dopewars.c:772
 msgid "You look like an aardvark!"
 msgstr "Você tá parecendo um aardvark!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:773
 #, fuzzy
 msgid "I don't believe in Pope Urban II"
 msgstr "Eu não acredito no Ronal Reagan"
 
-#: src/dopewars.c:779
+#: src/dopewars.c:774
 #, fuzzy
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Coragem! Bush é um zé!"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:775
 #, fuzzy
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Eu já não te vi na TV?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:776
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:777
 #, fuzzy
 msgid "We're winning the war for Empire!"
 msgstr "Nós estamos ganhando a guerra das drogas!"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:778
 #, fuzzy
 msgid "A day without grace is like night"
 msgstr "Um dia sem droga é como a noite"
 
-#: src/dopewars.c:785
+#: src/dopewars.c:780
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Nós usamos apenas 20% de nossos cérebros, então porque não estragar os "
 "outros 80%"
 
-#: src/dopewars.c:786
+#: src/dopewars.c:781
 #, fuzzy
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Eu estou solicitando contribuições para os Zumbis de Cristo"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:782
 #, fuzzy
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Eu queria te mandar um poodle"
 
-#: src/dopewars.c:788
+#: src/dopewars.c:783
 #, fuzzy
 msgid "Saints don't do Confession... unless they do"
 msgstr "Vencedores não usam drogas... ao menos que usem"
 
-#: src/dopewars.c:789
+#: src/dopewars.c:784
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:785
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:786
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus ama você mais do que você sabe"
 
-#: src/dopewars.c:792
+#: src/dopewars.c:787
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:793
+#: src/dopewars.c:788
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:794
+#: src/dopewars.c:789
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:795
+#: src/dopewars.c:790
 #, fuzzy
 msgid "Would you like a cabbage?"
 msgstr "Você gostaria de um doce, bebê?"
 
-#: src/dopewars.c:796
+#: src/dopewars.c:791
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1763
+#: src/dopewars.c:1758
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Não foi possível processar o arquivo de configuração %s, linha %d"
 
-#: src/dopewars.c:1799
+#: src/dopewars.c:1794
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: src/dopewars.c:1863
+#: src/dopewars.c:1858
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -992,40 +992,40 @@ msgstr ""
 "nenhum jogador está logado. Espere por todos os jogadores saírem,\n"
 "ou remove eles com os comandos push ou kill, e tente de novo."
 
-#: src/dopewars.c:1976
+#: src/dopewars.c:1971
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Índice da array %s deve ser entre 1 e %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2001
+#: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s é %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s é %s\n"
 
 #. Display of a price config. file variable - e.g. "Bitch.MinPrice is
 #. $200"
-#: src/dopewars.c:2012
+#: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s é %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2017
+#: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s é \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2023
+#: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] é %s\n"
@@ -1033,42 +1033,42 @@ msgstr "%s[%d] é %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2032
+#: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
 msgstr "%s é { "
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2082
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s não pode ser menor que %d - ignorando!"
 
-#: src/dopewars.c:2093
+#: src/dopewars.c:2088
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s não pode ser maior que %d - ignorando!"
 
-#: src/dopewars.c:2102
+#: src/dopewars.c:2097
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estrutura de lista redimensionada para %d elementos\n"
 
-#: src/dopewars.c:2140
+#: src/dopewars.c:2135
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Valor booleano esperado (om dentre 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2324
-msgid "Â£"
+#: src/dopewars.c:2319
+msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2328
+#: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2449
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1076,7 +1076,7 @@ msgstr ""
 "  -u, --plugin=ARQUIVO    use plugin de som \"ARQUIVO\"\n"
 "                            "
 
-#: src/dopewars.c:2459
+#: src/dopewars.c:2452
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1084,19 +1084,19 @@ msgstr ""
 "  -u arquivo  use plugin de som \"arquivo\"\n"
 "\t          "
 
-#: src/dopewars.c:2463
+#: src/dopewars.c:2456
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s dispnível)\n"
 
-#: src/dopewars.c:2469
+#: src/dopewars.c:2462
 #, c-format
 msgid "dopewars version %s\n"
 msgstr "dopewars versão %s\n"
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (version with support for GNU long options)
-#: src/dopewars.c:2478
+#: src/dopewars.c:2471
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1169,7 +1169,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2508
+#: src/dopewars.c:2501
 #, fuzzy
 msgid ""
 "  -h, --help              display this help information\n"
@@ -1187,7 +1187,7 @@ msgstr ""
 
 #. Usage information, printed when the user runs "dopewars -h"
 #. (short options only version)
-#: src/dopewars.c:2515
+#: src/dopewars.c:2508
 #, fuzzy, c-format
 msgid ""
 "Usage: dopewars [OPTION]...\n"
@@ -1248,7 +1248,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2544
+#: src/dopewars.c:2537
 #, fuzzy
 msgid ""
 "  -h       display this help information\n"
@@ -1264,7 +1264,7 @@ msgstr ""
 "dopewars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2811
+#: src/dopewars.c:2805
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1274,7 +1274,7 @@ msgstr ""
 "--enable-curses-client para configurar, ou use o cliente gráfico\n"
 "(se disponível) no lugar!\n"
 
-#: src/dopewars.c:2831
+#: src/dopewars.c:2825
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1284,7 +1284,7 @@ msgstr ""
 "a opção --enable-gui-client para configurar, ou use o cliente\n"
 "curses (se disponível) no lugar!\n"
 
-#: src/dopewars.c:2879
+#: src/dopewars.c:2873
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1295,7 +1295,7 @@ msgstr ""
 "em modo admin. Recompile passando --enable-networking para o script de "
 "configuração.\n"
 
-#: src/dopewars.c:2900 src/winmain.c:359
+#: src/dopewars.c:2894 src/winmain.c:359
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1578,11 +1578,11 @@ msgid "How many do you drop? "
 msgstr "Que quantidade você quer largar? "
 
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1345
+#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "O que você quer comprar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1297
+#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
 msgid "What do you wish to sell? "
 msgstr "O que você quer vender? "
 
@@ -1611,7 +1611,7 @@ msgid "Are you sure you want to quit? "
 msgstr "Você tem certeza que quer sair? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2748
+#: src/curses_client/curses_client.c:2746
 msgid "YN"
 msgstr "SN"
 
@@ -1628,51 +1628,51 @@ msgstr "Você foi tirado do servidor. Revertendo para modo de jogador único."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "O servidor foi terminado. Revertendo para modo de jogador único."
 
-#: src/curses_client/curses_client.c:1112 src/gui_client/gtk_client.c:499
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
 #: src/serverside.c:377
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s entrou no jogo!"
 
-#: src/curses_client/curses_client.c:1119 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
 #, c-format
 msgid "%s has left the game."
 msgstr "%s saiu do jogo."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1127
+#: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s agora vai ser conhecido como %s."
 
-#: src/curses_client/curses_client.c:1149
+#: src/curses_client/curses_client.c:1147
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1156
-#: src/curses_client/curses_client.c:2014 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:1154
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
 msgid "%/Current location/%tde"
 msgstr "%/Local atual/%tde"
 
-#: src/curses_client/curses_client.c:1198
+#: src/curses_client/curses_client.c:1196
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o."
 
-#: src/curses_client/curses_client.c:1225
+#: src/curses_client/curses_client.c:1223
 msgid "H I G H   S C O R E S"
 msgstr "M E L H O R E S   P O N T U A Ç Õ E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1289 src/gui_client/gtk_client.c:1781
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Você não tem nenhum %tde para vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1308 src/gui_client/gtk_client.c:1802
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Você não tem nenhum para vender!"
 
@@ -1680,27 +1680,27 @@ msgstr "Você não tem nenhum para vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1336 src/gui_client/gtk_client.c:1787
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Você irá precisar de mais %tde para carregar ainda mais %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1357 src/gui_client/gtk_client.c:1793
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Você não tem espaço suficiente para carregar aquele %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1367 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Você não tem dinheiro suficiente para comprar aquele %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1407
+#: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Você irá C>omprar, V>ender, ou S>air? "
 
@@ -1708,41 +1708,41 @@ msgstr "Você irá C>omprar, V>ender, ou S>air? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1417
+#: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVS"
 
-#: src/curses_client/curses_client.c:1440
+#: src/curses_client/curses_client.c:1438
 msgid "How much money do you pay back? "
 msgstr "Quanto dinheiro você quer pagar de volta? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1451
-#: src/curses_client/curses_client.c:1497 src/gui_client/gtk_client.c:2469
+#: src/curses_client/curses_client.c:1449
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Você não tem todo esse dinheiro!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1476
+#: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Você quer D>epositar dinheiro, R>etirar dinheiro, ou S>air ? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1482
+#: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1486
+#: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Quanto dinheiro? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1502
+#: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Não há todo este dinheiro no banco..."
 
@@ -1750,47 +1750,47 @@ msgstr "Não há todo este dinheiro no banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sim"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "N:No"
 msgstr "N:Não"
 
-#: src/curses_client/curses_client.c:1552
+#: src/curses_client/curses_client.c:1550
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "F:Fight"
 msgstr "L:Lutar"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1553
+#: src/curses_client/curses_client.c:1551
 msgid "E:Evade"
 msgstr "E:Evacuar"
 
-#: src/curses_client/curses_client.c:1690
+#: src/curses_client/curses_client.c:1688
 msgid "Press any key..."
 msgstr "Pressione qualquer tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1954
+#: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1964 src/gui_client/gtk_client.c:2199
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Estatísticas"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1969 src/gui_client/gtk_client.c:2023
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Dinheiro"
 
@@ -1798,41 +1798,41 @@ msgstr "Dinheiro"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1975
-#: src/curses_client/curses_client.c:2054 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:1973
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1981 src/gui_client/gtk_client.c:2054
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Pontos de vida"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1986 src/gui_client/gtk_client.c:2037
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1994 src/gui_client/gtk_client.c:2030
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Débito"
 
-#: src/curses_client/curses_client.c:2006
+#: src/curses_client/curses_client.c:2004
 #, c-format
 msgid "Space %6d"
 msgstr "Espaço %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2010
+#: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espaço %6d"
 
-#: src/curses_client/curses_client.c:2023
+#: src/curses_client/curses_client.c:2021
 msgid "Trenchcoat"
 msgstr "Casaco"
 
@@ -1840,141 +1840,141 @@ msgstr "Casaco"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2029
+#: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Estatísticas: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2037
+#: src/curses_client/curses_client.c:2035
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2044
+#: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2059
+#: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2084
+#: src/curses_client/curses_client.c:2082
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2090
+#: src/curses_client/curses_client.c:2088
 #, fuzzy
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Estatísticas: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2098
+#: src/curses_client/curses_client.c:2096
 #, fuzzy
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2126
+#: src/curses_client/curses_client.c:2124
 msgid "No other players are currently logged on!"
 msgstr "Nenhum outro jogador está atualmente logado!"
 
-#: src/curses_client/curses_client.c:2131
+#: src/curses_client/curses_client.c:2129
 msgid "Players currently logged on:-"
 msgstr "Jogadores atualmente logados:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2307
+#: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Ei carinha, os preços de %tde aqui estão:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2318
+#: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2364
+#: src/curses_client/curses_client.c:2362
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2381
+#: src/curses_client/curses_client.c:2379
 #, fuzzy
 msgid "Hey there! What's your name? "
 msgstr "Ei carinha, qual seu nome? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Você irá C>omprar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", D>rop"
 msgstr ", L>argar"
 
-#: src/curses_client/curses_client.c:2431
+#: src/curses_client/curses_client.c:2429
 msgid ", T>alk, P>age"
 msgstr ", F>alar, P>agear"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", L>ist"
 msgstr ", J>ogadores"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", F>ight"
 msgstr ", L>utar"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", J>et"
 msgstr ", I>r"
 
-#: src/curses_client/curses_client.c:2438
+#: src/curses_client/curses_client.c:2436
 msgid ", or Q>uit? "
 msgstr ", ou S>air? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2447
+#: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Você quer "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "F>ight, "
 msgstr "L>utar, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2450
 msgid "S>tand, "
 msgstr "F>icar paradão, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2454
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2459
+#: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
 msgstr "T>raficar %tde, "
 
-#: src/curses_client/curses_client.c:2460
+#: src/curses_client/curses_client.c:2458
 msgid "or Q>uit? "
 msgstr "ou S>air? "
 
-#: src/curses_client/curses_client.c:2525
+#: src/curses_client/curses_client.c:2523
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Conexão com o servidor perdida! Revertendo para o modo de um jogador"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2550
+#: src/curses_client/curses_client.c:2548
 #, fuzzy
 msgid "BSDTPLFJQ"
 msgstr "CVLFPJDLIS"
@@ -1982,30 +1982,30 @@ msgstr "CVLFPJDLIS"
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2556
+#: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "TCLFS"
 
-#: src/curses_client/curses_client.c:2586
+#: src/curses_client/curses_client.c:2584
 msgid "List what? P>layers or S>cores? "
 msgstr "Listar o que? J>ogadores ou P>ontuações? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2588
+#: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2601
+#: src/curses_client/curses_client.c:2599
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Quem você quer pagear (falar privadamente) ? "
 
 #. Prompt for sending player-player messages
-#: src/curses_client/curses_client.c:2607
-#: src/curses_client/curses_client.c:2621
+#: src/curses_client/curses_client.c:2605
+#: src/curses_client/curses_client.c:2619
 msgid "Talk: "
 msgstr "Fale: "
 
-#: src/curses_client/curses_client.c:2747
+#: src/curses_client/curses_client.c:2745
 msgid "Play again? "
 msgstr "Jogar novamente? "
 
@@ -2090,31 +2090,31 @@ msgid "Abandon game"
 msgstr "Abandonar jogo"
 
 #. Title of inventory window
-#: src/gui_client/gtk_client.c:312
+#: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventário"
 
-#: src/gui_client/gtk_client.c:335 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2629 src/gui_client/gtk_client.c:2769
-#: src/gui_client/gtk_client.c:3064 src/gui_client/gtk_client.c:3119
+#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2771
+#: src/gui_client/gtk_client.c:3066 src/gui_client/gtk_client.c:3121
 msgid "_Close"
 msgstr "_Fechar"
 
 #. The network connection to the server was dropped unexpectedly
-#: src/gui_client/gtk_client.c:391
+#: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Conexão com o servidor perdida - mudando para modo de um jogador"
 
 #. The server admin has asked us to leave - so warn the user, and do
 #. so
-#: src/gui_client/gtk_client.c:459
+#: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Você foi tirado do servidor. Revertendo para modo de um jogador."
 
 #. The server has sent us notice that it is shutting down
-#: src/gui_client/gtk_client.c:467
+#: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -2149,7 +2149,7 @@ msgstr "_Traficar %Tde"
 #. Button for shooting at other players in the "Fight" dialog, or for
 #. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2076
+#: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Lutar"
 
@@ -2273,16 +2273,15 @@ msgstr "Vender que quantidade?"
 msgid "Drop how many?"
 msgstr "Largar que quantidade?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2401
-#: src/gui_client/gtk_client.c:2570 src/gui_client/gtk_client.c:3010
-#: src/gui_client/optdialog.c:1050 src/gui_client/newgamedia.c:774
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3012
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2582
-#: src/gui_client/optdialog.c:1060 src/gui_client/newgamedia.c:779
-#: src/gtkport/gtkport.c:5381 src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
+#: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
 msgstr "_Cancelar"
 
@@ -2327,65 +2326,65 @@ msgid "Question"
 msgstr "Pergunta"
 
 #. Available space label in GTK+ client status display
-#: src/gui_client/gtk_client.c:2016
+#: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espaço"
 
 #. Caption of 'Jet' button in main window
-#: src/gui_client/gtk_client.c:2079
+#: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
 #. Title of main window in GTK+ client
-#: src/gui_client/gtk_client.c:2170 src/winmain.c:381 src/winmain.c:390
+#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Tradução de Portugal"
 
-#: src/gui_client/gtk_client.c:2305
+#: src/gui_client/gtk_client.c:2306
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2307
 msgid "Icons and graphics"
 msgstr "Ícones e gráficos"
 
-#: src/gui_client/gtk_client.c:2307 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sons"
 
-#: src/gui_client/gtk_client.c:2308
+#: src/gui_client/gtk_client.c:2309
 #, fuzzy
 msgid "History and Research"
 msgstr "Tráfico de Drogas e Pesquisas"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2310
 msgid "Play Testing"
 msgstr "Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2311
 msgid "Extensive Play Testing"
 msgstr "Extensivo Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2312
+#: src/gui_client/gtk_client.c:2313
 msgid "Constructive Criticism"
 msgstr "Crítica Construtiva"
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2315
 msgid "Unconstructive Criticism"
 msgstr "Crítica não construtiva"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2333
+#: src/gui_client/gtk_client.c:2334
 msgid ""
 "It's AD 1095, and the Crusades are about to begin. As a dedicated Trader-"
 "Saint, \n"
@@ -2396,6 +2395,7 @@ msgid ""
 "crusade. \n"
 "\n"
 "The Empire of the Holy Trinity relies on you!\n"
+"May your faith guide your trades.\n"
 "\n"
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of "
 "an\n"
@@ -2409,7 +2409,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2355
+#: src/gui_client/gtk_client.c:2357
 #, fuzzy, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2419,7 +2419,7 @@ msgstr ""
 "dopewars está lançado sob a GNU General Public License\n"
 
 #. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2384
+#: src/gui_client/gtk_client.c:2386
 msgid ""
 "\n"
 "For information on the command line options, type dopewars -h at your\n"
@@ -2432,134 +2432,134 @@ msgstr ""
 "prompt Unix. Isto irá mostrar a tela de ajuda, listando as opções "
 "disponíveis.\n"
 
-#: src/gui_client/gtk_client.c:2391
+#: src/gui_client/gtk_client.c:2393
 msgid "Local HTML documentation"
 msgstr "Documentação local em HTML"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2447 src/gui_client/gtk_client.c:2499
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título da janela do agiota/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2454 src/gui_client/gtk_client.c:2503
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título da janela do NomeDoBanco/%Tde"
 
-#: src/gui_client/gtk_client.c:2463
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Você precisa entrar uma quantidade positiva de dinheiro!"
 
-#: src/gui_client/gtk_client.c:2466
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Não há todo este dinheiro no banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2519
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Dinheiro: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2525
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Débito: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2536
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Pagar de volta:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2540
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Depositar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2546
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2577
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar tudo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2608
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jogadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2720
+#: src/gui_client/gtk_client.c:2722
 msgid "Talk to player(s)"
 msgstr "Falar com jogador(es)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2742
+#: src/gui_client/gtk_client.c:2744
 msgid "Talk to all players"
 msgstr "Falar com todos os jogadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2748
+#: src/gui_client/gtk_client.c:2750
 msgid "Message:-"
 msgstr "Mensagem:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2763
+#: src/gui_client/gtk_client.c:2765
 msgid "Send"
 msgstr "Mandar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2844 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2846 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nome"
 
-#: src/gui_client/gtk_client.c:2845 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2847 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preço"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2848
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2851
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2850
+#: src/gui_client/gtk_client.c:2852
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2853
 msgid "_Drop <-"
 msgstr "_Largar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2858
+#: src/gui_client/gtk_client.c:2860
 msgid "%Tde here"
 msgstr "%Tde aqui"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2866
 msgid "%Tde carried"
 msgstr "%Tde carregados"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2983
+#: src/gui_client/gtk_client.c:2985
 msgid "Change Name"
 msgstr "Mudar Nome"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2998
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2567,12 +2567,12 @@ msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o:
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3041
+#: src/gui_client/gtk_client.c:3043
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/Título da janela da LojaDeArmas/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3103
+#: src/gui_client/gtk_client.c:3105
 msgid "Spy reports"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr "Minimizar para a Barra do Sistema"
 msgid "Metaserver URL"
 msgstr "URL do metaservidor"
 
-#: src/gui_client/optdialog.c:974 src/gui_client/newgamedia.c:438
+#: src/gui_client/optdialog.c:974
 msgid "Comment"
 msgstr "Comentário"
 
@@ -2756,9 +2756,7 @@ msgstr "Comentário"
 msgid "MOTD (welcome message)"
 msgstr ""
 
-#. Column titles of metaserver information
-#: src/gui_client/optdialog.c:985 src/gui_client/newgamedia.c:434
-#: src/gui_client/newgamedia.c:595
+#: src/gui_client/optdialog.c:985
 msgid "Server"
 msgstr "Servidor"
 
@@ -2786,127 +2784,59 @@ msgstr ""
 msgid "_Help"
 msgstr "_Ajudar"
 
-#: src/gui_client/newgamedia.c:72
+#: src/gui_client/newgamedia.c:66
 msgid "You can't start the game without giving a name first!"
 msgstr "Você não pode iniciar um jogo antes de dar a ele um nome!"
 
 #. Title of 'New Game' dialog
-#: src/gui_client/newgamedia.c:73 src/gui_client/newgamedia.c:516
+#: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Novo Jogo"
 
-#: src/gui_client/newgamedia.c:81
+#: src/gui_client/newgamedia.c:75
 msgid "Status: Waiting for user input"
 msgstr "Status: Esperando por algo do usuário"
 
-#: src/gui_client/newgamedia.c:89 src/gui_client/newgamedia.c:348
-#, c-format
-msgid "Status: ERROR: %s"
-msgstr "Status: ERRO: %s"
-
-#: src/gui_client/newgamedia.c:156 src/AIPlayer.c:72
+#: src/gui_client/newgamedia.c:93 src/AIPlayer.c:72
 msgid "Connection closed by remote host"
 msgstr "Conexão encerrada pelo host remoto"
 
 #. Error: GTK+ client could not connect to the given dopewars server
-#: src/gui_client/newgamedia.c:160
+#: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Não foi possível conectar (%s)"
 
-#. Message displayed during the attempted connect to a dopewars server
-#. Message displayed during the attempted connect to the metaserver
-#: src/gui_client/newgamedia.c:188 src/gui_client/newgamedia.c:342
-#, c-format
-msgid "Status: Attempting to contact %s..."
-msgstr "Status: Tentando contacatar %s..."
-
-#. Displayed if we don't know how many players are logged on to a
-#. server
-#: src/gui_client/newgamedia.c:264
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#. e.g. "5 of 20" means 5 players are logged on to a server, out of
-#. a maximum of 20
-#: src/gui_client/newgamedia.c:268
-#, c-format
-msgid "%d of %d"
-msgstr "%d de %d"
-
 #. Tell the user that we've successfully connected to a SOCKS server,
 #. and are now ready to tell it to initiate the "real" connection
-#: src/gui_client/newgamedia.c:301
+#: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Conectado ao servidor SOCKS %s..."
 
 #. Tell the user that the SOCKS server is asking us for a username
 #. and password
-#: src/gui_client/newgamedia.c:309
+#: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Statis: Autenticando com o servidor SOCKS"
 
 #. Tell the user that all necessary SOCKS authentication has been
 #. completed, and now we're going to try to have it connect to
 #. the final destination
-#: src/gui_client/newgamedia.c:316
+#: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
 msgstr "Status: Pedindo ao SOCKS para conectar a %s.."
 
-#: src/gui_client/newgamedia.c:435 src/gui_client/newgamedia.c:576
-msgid "Port"
-msgstr "Porta"
-
-#: src/gui_client/newgamedia.c:436
-msgid "Version"
-msgstr "Versão"
-
-#: src/gui_client/newgamedia.c:437
-msgid "Players"
-msgstr "Jogadores"
-
-#. Prompt for player's name in 'New
-#. Game' dialog
-#: src/gui_client/newgamedia.c:533
+#: src/gui_client/newgamedia.c:252
 #, fuzzy
 msgid "Greetings Trader, what's your _name?"
 msgstr "Ei carinha, qual o seu _nome?"
 
-#. Prompt for hostname to connect to in GTK+ new game dialog
-#: src/gui_client/newgamedia.c:558
-msgid "Host name"
-msgstr "Nome do host"
-
-#. Button to connect to a named dopewars server
-#: src/gui_client/newgamedia.c:588 src/gui_client/newgamedia.c:642
-msgid "_Connect"
-msgstr "_Conectar"
-
 #. Button to start a new single-player (standalone, non-network) game
-#: src/gui_client/newgamedia.c:612
+#: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Iniciar jogo de um jogador"
-
-#. Title of 'New Game' dialog notebook tab for single-player mode
-#: src/gui_client/newgamedia.c:619
-msgid "Single player"
-msgstr "Apenas um jogador"
-
-#. Button to update metaserver information
-#: src/gui_client/newgamedia.c:636
-msgid "_Refresh"
-msgstr ""
-
-#. Title of Metaserver notebook tab in New Game dialog
-#: src/gui_client/newgamedia.c:654
-msgid "Metaserver"
-msgstr "Servidor Meta"
-
-#: src/gui_client/newgamedia.c:733
-msgid "SOCKS Authentication Required"
-msgstr "Autenticação SOCKS Necessária"
 
 #: src/gtkport/gtkport.c:5508
 msgid "_Select"
@@ -3346,73 +3276,73 @@ msgstr "Você escuta alguém tocando %s"
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Você gostaria de visitar %tde?"
 
-#: src/serverside.c:2292
+#: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Você gostaria de contratar %tde por %P?"
 
-#: src/serverside.c:2305
+#: src/serverside.c:2306
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s está aqui!^Você Ataca, ou Evacua?"
 
-#: src/serverside.c:2372
+#: src/serverside.c:2373
 #, fuzzy
 msgid "No Amirs or weapons!"
 msgstr "Nenhum policial ou armas!"
 
-#: src/serverside.c:2378
+#: src/serverside.c:2379
 #, fuzzy
 msgid "Amirs cannot attack other amirs!"
 msgstr "Policiais não podem atacar outros policiais"
 
-#: src/serverside.c:2420
+#: src/serverside.c:2421
 msgid "Players are already in a fight!"
 msgstr "Jogadores já estão brigando!"
 
-#: src/serverside.c:2422
+#: src/serverside.c:2423
 msgid "Players are already in separate fights!"
 msgstr "Jogadores estão em lutas separadas!"
 
-#: src/serverside.c:2427
+#: src/serverside.c:2428
 #, fuzzy
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Não é possível começar briga - nenhuma arma para usar!"
 
-#: src/serverside.c:2656
+#: src/serverside.c:2657
 #, fuzzy
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2887
+#: src/serverside.c:2888
 msgid "You're dead! Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2895
+#: src/serverside.c:2897
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2924
+#: src/serverside.c:2926
 #, fuzzy
 msgid "You were mugged outside Holy Mass!"
 msgstr "Você foi massacrado no metrô!"
 
-#: src/serverside.c:2936
+#: src/serverside.c:2938
 #, fuzzy, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Você encontrou um amigo! Ele lhe dá %d %tde."
 
-#: src/serverside.c:2942
+#: src/serverside.c:2944
 #, fuzzy, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Você encontrou um amigo! Você dá a ele %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2955
+#: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Sanitized away a RandomOffer"
 
-#: src/serverside.c:2960
+#: src/serverside.c:2962
 #, fuzzy, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3420,17 +3350,17 @@ msgstr ""
 "Cães policiais caçam você por %d blocos! Você largou algum %tde! Que droga, "
 "cara!"
 
-#: src/serverside.c:2977
+#: src/serverside.c:2979
 #, fuzzy, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Você acha %d %tde em um cara morto no metrô!"
 
-#: src/serverside.c:2992
+#: src/serverside.c:2994
 #, fuzzy, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Sua mamãe fez comida com algumas de suas %tde! Ela estava ótima!"
 
-#: src/serverside.c:3002
+#: src/serverside.c:3004
 #, fuzzy
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
@@ -3438,26 +3368,26 @@ msgid ""
 msgstr ""
 "YN^Tem uma maconha aqui que cheira muito bem!^Parece bom! Você irá fumar? "
 
-#: src/serverside.c:3009
+#: src/serverside.c:3011
 #, c-format
 msgid "You stopped to %s."
 msgstr "Você parou para %s."
 
-#: src/serverside.c:3034
+#: src/serverside.c:3036
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Você gostaria de comprar um colete por %P?"
 
-#: src/serverside.c:3041
+#: src/serverside.c:3044
 #, fuzzy
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Ei carinha! Eu posso ajudar você carregar %tde por meros %P. Sim ou não?"
 
-#: src/serverside.c:3054
+#: src/serverside.c:3057
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Você gostaria de comprar %tde por %P?"
 
-#: src/serverside.c:3236
+#: src/serverside.c:3239
 #, fuzzy
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
@@ -3466,29 +3396,29 @@ msgstr ""
 "Você alucionou por três dias na viagem mais louca que você jamais imaginou!"
 "^Então você morreu porque seu cérebro desintegrou!"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3265
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Muito tarde - %s já saiu!"
 
-#: src/serverside.c:3336
+#: src/serverside.c:3339
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3572
+#: src/serverside.c:3575
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando atualizações pendentes ao metaservidor..."
 
-#: src/serverside.c:3577
+#: src/serverside.c:3580
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3586
+#: src/serverside.c:3589
 msgid "Player removed due to idle timeout"
 msgstr "Jogador removido por ter ficado muito tempo parado"
 
-#: src/serverside.c:3599
+#: src/serverside.c:3602
 msgid "Player removed due to connect timeout"
 msgstr "Jogador removido por expiração da conexão"
 
@@ -3768,86 +3698,86 @@ msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
 #. SOCKS version 5 error messages
-#: src/network.c:381
+#: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:382
+#: src/network.c:384
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:383
+#: src/network.c:385
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:386
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:387
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:388
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:389
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:390
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:391
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:392
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:393
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:394
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:395
+#: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:396
+#: src/network.c:398
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:400
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:401
+#: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1277
+#: src/network.c:1282
 msgid "Could not init curl"
 msgstr ""
 
@@ -4035,12 +3965,12 @@ msgstr ""
 "como um jogador com IA.\n"
 "Recompile passando a opção --enable-networking para o script configure."
 
-#: src/sound.c:201
+#: src/sound.c:216
 #, fuzzy, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: src/sound.c:209
+#: src/sound.c:225
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -4048,6 +3978,45 @@ msgid ""
 msgstr ""
 "Plugin inválido \"%s\" selecionado.\n"
 "(%s disponível; agora usando \"%s\".)"
+
+#, c-format
+#~ msgid "Status: ERROR: %s"
+#~ msgstr "Status: ERRO: %s"
+
+#, c-format
+#~ msgid "Status: Attempting to contact %s..."
+#~ msgstr "Status: Tentando contacatar %s..."
+
+#~ msgid "Unknown"
+#~ msgstr "Desconhecido"
+
+#, c-format
+#~ msgid "%d of %d"
+#~ msgstr "%d de %d"
+
+#~ msgid "Port"
+#~ msgstr "Porta"
+
+#~ msgid "Version"
+#~ msgstr "Versão"
+
+#~ msgid "Players"
+#~ msgstr "Jogadores"
+
+#~ msgid "Host name"
+#~ msgstr "Nome do host"
+
+#~ msgid "_Connect"
+#~ msgstr "_Conectar"
+
+#~ msgid "Single player"
+#~ msgstr "Apenas um jogador"
+
+#~ msgid "Metaserver"
+#~ msgstr "Servidor Meta"
+
+#~ msgid "SOCKS Authentication Required"
+#~ msgstr "Autenticação SOCKS Necessária"
 
 #~ msgid "bitch"
 #~ msgstr "puta"

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2334,12 +2334,13 @@ void display_intro(GtkWidget *widget, gpointer data)
   label = gtk_label_new(_("It's AD 1095, and the Crusades are about to begin. "
                           "As a dedicated Trader-Saint, \nPope Urban II has "
                           "entrusted you with a crucial mission: navigate "
-                          "the bustling \nmedieval cities and trade valuable " 
+                          "the bustling \nmedieval cities and trade valuable "
                           "goods to amass significant wealth. \nYour efforts "
                           "will directly support the Holy Christian Church's "
                           "forthcoming crusade. \n\nThe Empire of the Holy "
-                          "Trinity relies on you!\n\n"
-  
+                          "Trinity relies on you!\nMay your faith guide your "
+                          "trades.\n\n"
+
                           "Based on John E. Dell's old Drug Wars game, "
                           "Church Wars is a simulation of an\nimaginary Crusader "
                           "market.  Church Wars is a Crusades game which "


### PR DESCRIPTION
## Summary
- add a faith-guiding sentence to the GTK+ client's About dialog
- regenerate translation template and merge updates into all `.po` files

## Testing
- `xgettext --keyword=_ --keyword=N_ --add-comments --from-code=UTF-8 --output=po/dopewars.pot --files-from=po/POTFILES.in --package-name=dopewars --package-version=SVN --msgid-bugs-address=benwebb@users.sf.net --copyright-holder="Ben Webb"`
- `for f in po/*.po; do msgmerge --update --backup=none "$f" po/dopewars.pot; done`
- `for f in po/*.po; do msgfmt --check --output=/dev/null "$f"; done` *(errors reported in es.po, es_ES.po, nn.po)*

------
https://chatgpt.com/codex/tasks/task_e_689b125c752883268696de203f8991b8