### PR TITLE
Fix Spanish translation placeholders

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -3371,7 +3371,7 @@ msgstr "Oye a alguien poner %s"
 #: src/serverside.c:2280
 #, c-format
 msgid "YN^Would you like to visit %tde?"
-msgstr "YN^¿Quiere visitar %tal?"
+msgstr "YN^¿Quiere visitar %tde?"
 
 #: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
@@ -3706,7 +3706,7 @@ msgstr "¡Pánico! ¡No puede escapar!"
 #: src/message.c:1366
 #, c-format
 msgid "%s has got away to %tde!"
-msgstr "¡%s ha conseguido escapar %tal!"
+msgstr "¡%s ha conseguido escapar a %tde!"
 
 #: src/message.c:1369
 #, c-format

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -3367,7 +3367,7 @@ msgstr "Oyes a alguien poner %s"
 #: src/serverside.c:2280
 #, c-format
 msgid "YN^Would you like to visit %tde?"
-msgstr "YN^¿Quieres visitar %tal?"
+msgstr "YN^¿Quieres visitar %tde?"
 
 #: src/serverside.c:2293
 msgid "YN^^Would you like to hire a %tde for %P?"
@@ -3702,7 +3702,7 @@ msgstr "¡Pánico! ¡No puedes escapar!"
 #: src/message.c:1366
 #, c-format
 msgid "%s has got away to %tde!"
-msgstr "¡%s ha conseguido escapar %tal!"
+msgstr "¡%s ha conseguido escapar a %tde!"
 
 #: src/message.c:1369
 #, c-format


### PR DESCRIPTION
## Summary
- Align placeholder formats in Spanish translations so `%` specs match the English originals

## Testing
- `msgfmt -c -o /dev/null po/es.po`
- `msgfmt -c -o /dev/null po/es_ES.po`
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689b356a84688326bc56706e0e52080d