### PR TITLE
Right justify About dialog text

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2354,6 +2354,7 @@ void display_intro(GtkWidget *widget, gpointer data)
                           "\n"
                           "“Though a mighty army surrounds me, my heart will not\n"
                           "be afraid!”\n"));
+  gtk_label_set_justify(GTK_LABEL(label), GTK_JUSTIFY_RIGHT);
   gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
 
   /* Version and copyright notice in GTK+ 'about' dialog */


### PR DESCRIPTION
## Summary
- Right-justify the About dialog's main paragraph to create a ragged left edge.

## Testing
- `make -j2` *(fails: No targets specified and no makefile found)*
- `./autogen.sh` *(fails: automake not installed)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b3dddb1408326a41eecc1d72302f7