### PR TITLE
Silence warnings for unused talk functions in GTK client

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -130,9 +130,9 @@ static void DealGuns(GtkWidget *widget, gpointer data);
 static void QuestionDialog(char *Data, Player *From);
 static void TransferDialog(gboolean Debt);
 static void ListPlayers(GtkWidget *widget, gpointer data);
-static void TalkToAll(GtkWidget *widget, gpointer data);
-static void TalkToPlayers(GtkWidget *widget, gpointer data);
-static void TalkDialog(gboolean TalkToAll);
+static void TalkToAll(GtkWidget *widget, gpointer data) G_GNUC_UNUSED;
+static void TalkToPlayers(GtkWidget *widget, gpointer data) G_GNUC_UNUSED;
+static void TalkDialog(gboolean TalkToAll) G_GNUC_UNUSED;
 static GtkWidget *CreatePlayerList(void);
 static void UpdatePlayerList(GtkWidget *clist, gboolean IncludeSelf);
 static void DestroyShowing(GtkWidget *widget, gpointer data);
@@ -2699,17 +2699,17 @@ static void TalkSend(GtkWidget *widget, struct TalkStruct *TalkData)
   g_string_free(msg, TRUE);
 }
 
-void TalkToAll(GtkWidget *widget, gpointer data)
+static void TalkToAll(GtkWidget *widget, gpointer data)
 {
   TalkDialog(TRUE);
 }
 
-void TalkToPlayers(GtkWidget *widget, gpointer data)
+static void TalkToPlayers(GtkWidget *widget, gpointer data)
 {
   TalkDialog(FALSE);
 }
 
-void TalkDialog(gboolean TalkToAll)
+static void TalkDialog(gboolean TalkToAll)
 {
   GtkWidget *dialog, *clist, *button, *entry, *label, *vbox, *hsep,
       *checkbutton, *hbbox;


### PR DESCRIPTION
## Summary
- mark TalkToAll, TalkToPlayers, and TalkDialog as unused to suppress compiler warnings
- ensure talk dialog helpers are defined as static

## Testing
- `gcc -Wall -c src/gui_client/gtk_client.c -Isrc -Isrc/gtkport` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b404ac4ec8326b417aae57826259a