### PR TITLE
Update about dialog link and translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2001-04-08 15:48+0100\n"
 "Last-Translator: Benjamin Karaca <mister-freeze@web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -18,46 +18,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "den Kredithai"
@@ -74,9 +58,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Netzwerk-Port zu dem verbunden werden soll"
@@ -563,9 +544,6 @@ msgstr "Liste der Dinge die du machen kannst"
 msgid "Number of things which you can stop to do"
 msgstr "Anzahl der Dinge die du machen kannst"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -638,10 +616,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -662,22 +636,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -694,7 +664,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -711,8 +680,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -782,7 +749,6 @@ msgstr ""
 "Ein kolumbianischer Frachter hat die Küstenwache umschippert. Der Preis für "
 "Weed ist ins bodenlose gefallen!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -815,7 +781,6 @@ msgstr "Nachricht"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -828,10 +793,6 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Junkies kaufen %tde für horrende Summen!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Wäre es nicht cool, wenn alle plötzlich mal zittern würden?"
@@ -985,42 +946,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Index in Array %s sollte zwischen 1 und %d sein"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s ist %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s ist %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s ist %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s ist \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] ist %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1045,13 +994,10 @@ msgstr "Optimierte Struktur-Liste von %d Elementen\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Erwarteter Boolean-Wert (0, FALSE, 1, TRUE"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1078,8 +1024,6 @@ msgstr ""
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1163,8 +1107,6 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1278,7 +1220,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Deutsche Übersetzung         Benjamin Karaca"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1361,8 +1302,6 @@ msgid ""
 msgstr ""
 "deiner Unix Prompt ein. Dies listet dir alle verfügbaren Parameter auf."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Bitte gib den Hostnamen und Port des Dopewars servers an:-"
@@ -1379,7 +1318,6 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Bitte warten... Erstelle Verbindung zu Metaserver..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1419,10 +1357,6 @@ msgstr "Kommentar: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>ächster ; V>orheriger ; W>ähle diesen Server... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NVW"
@@ -1458,14 +1392,10 @@ msgstr "Passwort: "
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Bitten warten... versuche Dopewars-Server zu kontaktieren..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Bekomme keine Details des Metaserver"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Kann den Multiplayer-Modus nicht starten"
@@ -1491,20 +1421,15 @@ msgstr "möchtest Du das Spiel B>eenden"
 msgid "         or P>lay single-player ? "
 msgstr " oder möchtest Du als E>inzelspieler spielen "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "VLBE"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Wohin soll's gehen, Kumpel? "
@@ -1513,8 +1438,6 @@ msgstr "Wohin soll's gehen, Kumpel? "
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1528,7 +1451,6 @@ msgstr "Was willst du wegwerfen? "
 msgid "How many do you drop? "
 msgstr "Wie viel schmeißt du weg? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Was willst du kaufen? "
@@ -1537,8 +1459,6 @@ msgstr "Was willst du kaufen? "
 msgid "What do you wish to sell? "
 msgstr "Was möchtest du verscherbeln? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1566,7 +1486,6 @@ msgstr "Willst du wirklich aufhören? "
 msgid "YN"
 msgstr "JN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Neuer Name: "
@@ -1591,7 +1510,6 @@ msgstr "%s betritt das Spiel!"
 msgid "%s has left the game."
 msgstr "%s hat das Spiel verlassen."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1616,50 +1534,34 @@ msgstr "Leider benutzt schon jemand anders \"deinen\" Namen. Bitte ändere Ihn"
 msgid "H I G H   S C O R E S"
 msgstr "B E S T E N L I S T E"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du brauchst mehr %tde Platz um noch mehr %tde tragen zu können!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du hast nicht genug Platz um eine %tde zu tragen!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du hast nicht genug Kohle für eine %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "EVG"
@@ -1668,40 +1570,27 @@ msgstr "EVG"
 msgid "How much money do you pay back? "
 msgstr "Wieviel Geld möchtest Du zurückzahlen?"
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "Soviel Kohle hast Du nicht!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Möchtest Du E>inzahlen, A>bheben, oder die Bank V>erlassen? "
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "EAV"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Wie viel Kohle?"
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "So viel Knete hast du gar nicht..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
@@ -1730,45 +1619,31 @@ msgstr "V:Verschwinden"
 msgid "Press any key..."
 msgstr "Drück irgend'ne Taste..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Nachrichten (-/+ zum Scrollen)"
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistik"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Bargeld"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Gesundheit"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Konto"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Schulden"
@@ -1778,8 +1653,6 @@ msgstr "Schulden"
 msgid "Space %6d"
 msgstr "Platz %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Platz %6d"
@@ -1788,10 +1661,6 @@ msgstr "%Tde %3d  Platz %6d"
 msgid "Trenchcoat"
 msgstr "Mantel"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogen/%Tde"
@@ -1800,13 +1669,11 @@ msgstr "%/Stats: Drogen/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1817,13 +1684,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogen/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1836,14 +1700,11 @@ msgstr "Tja, Du bist alleine auf der Welt!"
 msgid "Players currently logged on:-"
 msgstr "Eingeloggte Mitspieler:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hey Kleiner, die %tde Preise von hier:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1856,7 +1717,6 @@ msgstr "Kann den SIGWINCH Interrupt Handler nicht installieren"
 msgid "Hey there! What's your name? "
 msgstr "Hey Kleiner, wie lautet dein Name? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Willst Du E>inkaufen"
@@ -1889,7 +1749,6 @@ msgstr ", R>eisen"
 msgid ", or Q>uit? "
 msgstr ", oder B>eenden? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Willst Du "
@@ -1906,7 +1765,6 @@ msgstr "S>tehen bleiben, "
 msgid "R>un, "
 msgstr "R>ennen, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1921,16 +1779,10 @@ msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre in den Einzelspieler-Modus zurück"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "EVWSFLAKRB"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "HRKSE"
@@ -1939,7 +1791,6 @@ msgstr "HRKSE"
 msgid "List what? P>layers or S>cores? "
 msgstr "Zeige S>pieler oder P>unkte? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "SP"
@@ -1948,7 +1799,6 @@ msgstr "SP"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Wem möchtest du etwas zuflüstern ? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1958,7 +1808,6 @@ msgstr "Sprich: "
 msgid "Play again? "
 msgstr "Möchtest du noch mal spielen? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Spiel"
@@ -1971,7 +1820,6 @@ msgstr "/Spiel/_Neu..."
 msgid "/Game/_Abandon..."
 msgstr "/Spiel/_Abbrechen..."
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Spiel/Sound"
@@ -2004,7 +1852,6 @@ msgstr "/_Hilfe"
 msgid "/Help/_About..."
 msgstr "/Hilfe/_Über..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Warnung"
@@ -2017,45 +1864,37 @@ msgstr "Fehler"
 msgid "Message"
 msgstr "Nachricht"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Willst du das aktuelle Spiel abbrechen?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Spiel verlassen"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Neues Spiel starten"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Spiel Abbrechen"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventar"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Schließen"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Verbindung zum Server verloren - wechsle in Einzelspieler-Modus"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
@@ -2064,7 +1903,6 @@ msgstr ""
 "Du wurdest vom Server geworfen.\n"
 "Kehre in Einzelspieler-Modus zurück."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
@@ -2073,18 +1911,15 @@ msgstr ""
 "Verbindung zu Server unterbrochen!\n"
 "Kehre zurück in den Einzelspieler-Modus"
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Reise zu %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "B E S T E N  L I S T E"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "Fehlerhafte Bestenliste!"
@@ -2094,31 +1929,23 @@ msgstr "Fehlerhafte Bestenliste!"
 msgid "Fight"
 msgstr "Kämpfen"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_%Tde dealen"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Kämpfen"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Stehen bleiben"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Rennen"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Kampf: Huren/%d %tde"
@@ -2136,13 +1963,10 @@ msgstr "(Tot)"
 msgid "Health: %d"
 msgstr "Gesundheit: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Du"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Huren/%Tde"
@@ -2155,7 +1979,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr "Inventar"
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Reise zu Ort"
@@ -2164,34 +1987,25 @@ msgstr "Reise zu Ort"
 msgid "%/Location to jet to/%tde"
 msgstr "%/Reiseziel/%tde"
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "für %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Zur Zeit trägst Du %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Verfügbarer Platz: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2213,7 +2027,6 @@ msgstr "Wegwerfen"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "Wieviel Einkaufen?"
@@ -2226,13 +2039,13 @@ msgstr "Wieviel Verkaufen?"
 msgid "Drop how many?"
 msgstr "Wieviel Wegwerfen?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2253,8 +2066,6 @@ msgstr "Verkaufen %tde"
 msgid "Drop %tde"
 msgstr "Wegwerfen %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2273,27 +2084,22 @@ msgstr "_Angriff"
 msgid "_Evade"
 msgstr "_Verschwinden"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Frage"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Platz"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Deutsche Übersetzung"
@@ -2330,49 +2136,38 @@ msgstr "Konstruktive Kritik"
 msgid "Unconstructive Criticism"
 msgstr "Unkonstruktive Kritik"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2381,160 +2176,121 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Dopewars wurde unter der GNU General Public License veröffentlicht.\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"Für Informationen über Kommandozeilen-Parameter, gib 'dopewars -h' in "
-"deiner \n"
-"UNIX-shell ein. Alle verfügbaren Kommandos werden dann angezeigt.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Lokale HTML Dokumentation"
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Kredithai Fenstertitel/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/BankName Fenstertitel/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "Sie müßen einen positiven Geldbetrag eingeben!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Ein B?nker spricht: \"Soviel Geld haben Sie nicht.\""
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Bargeld: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Schulden: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Konto: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Zurückzahlen:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Einzahlen"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Abheben"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Bezahle alles"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Spieler Liste"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Rede mit Spieler(n)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Rede mit allen Spielern"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Nachricht:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Senden"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Name"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preis"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Anzahl"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Einkaufen ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Verkaufen"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Wegwerfen <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde hier"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde dabei"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Ändere Name"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Leider benutzt schon jemand anders \"deinen\" Namen, ändere Ihn bitte."
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Waffenladen Fenstertitel/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2743,7 +2499,6 @@ msgstr "_Hilfe"
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kannst kein Spiel starten, ohne vorher einen Namen anzugeben!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Neues Spiel"
@@ -2756,28 +2511,20 @@ msgstr "Status: Warte auf Benutzereingabe"
 msgid "Connection closed by remote host"
 msgstr "Verbindung wurde durch remote Host geschlossen"
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Konnte keine Verbindung zu %s herstellen"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Verbinde mit SOCKS server %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Authentifizieren mit SOCKS server"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2787,7 +2534,6 @@ msgstr "Status: Frage SOCKS um zu %s zu verbinden..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Hey Kleiner, wie heißt Du? "
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Starte Einzelspieler Spiel"
@@ -2796,9 +2542,6 @@ msgstr "_Starte Einzelspieler Spiel"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2807,18 +2550,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "Dopewars Server"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "dopewars AI"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2831,14 +2570,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr ""
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2919,16 +2654,12 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxKlients (%d) erreicht - verwerfe Verbindung"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr "Sorry, aber hier dürfen max. 1 spielen.^Bitte versuchs später nochmal."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2937,9 +2668,6 @@ msgid ""
 msgstr ""
 "Sorry, aber hier dürfen max. %d spielen.^Bitte versuchs später nochmal."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2950,15 +2678,10 @@ msgstr "%s ist nun bekannt als %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: VERWEIGERT Reise zu %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Deine Zeit als Dealer ist vorbei..."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3000,7 +2723,6 @@ msgid ""
 msgstr ""
 "dopewars server version %s klar und wartet auf verbindungen auf port %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kann SIGUSR1 nicht installieren, breche ab"
@@ -3043,8 +2765,6 @@ msgstr "Drücke %s\n"
 msgid "No such user!\n"
 msgstr "Kein solcher Benutzer!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3292,8 +3012,6 @@ msgstr "Du triffst einen Freund! Er gibt dir %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du triffst einen Freund! Du gibst ihm %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
@@ -3389,8 +3107,6 @@ msgstr "Verbindung abgebrochen aufgrund eines vollen Buffers"
 msgid "Internal error code %d"
 msgstr "Interner Fehler %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock wurde nicht richtig initialisiert"
@@ -3455,7 +3171,6 @@ msgstr "Protokoll nicht unterstützt"
 msgid "Socket type not supported"
 msgstr "Sockeltyp nicht unterstützt"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Host nicht gefunden"
@@ -3648,7 +3363,6 @@ msgstr "Du plünderst die verdammte Leiche!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kann WinSock nicht initialisieren (%s)"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "SOCKS-Server allgemeiner Fehler"
@@ -3697,7 +3411,6 @@ msgstr "SOCKS-Bestätigung fehlgeschlagen"
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-Bestätigung vom Benutzer abgebrochen"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Nachfrage abgelehnt oder fehlgeschlagen"
@@ -3710,7 +3423,6 @@ msgstr "SOCKS: Abgelehnt  unmöglich identd zu kontaktieren"
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Abgelehnt  identd meldet andere Benutzer-ID"
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Unbekannter SOCKS Antwort-Code"
@@ -3878,7 +3590,6 @@ msgstr "Pub ist in %s\n"
 msgid "Bank located at %s\n"
 msgstr "Bank ist in %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Ihr nennt euch Drogendealer?"
@@ -3922,6 +3633,20 @@ msgid ""
 msgstr ""
 "Ungültiges Plugin \"%s\" ausgewählt.\n"
 "(%s verfügbar; verwende nun \"%s\".)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Für Informationen über Kommandozeilen-Parameter, gib 'dopewars -h' in "
+#~ "deiner \n"
+#~ "UNIX-shell ein. Alle verfügbaren Kommandos werden dann angezeigt.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Lokale HTML Dokumentation"
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,46 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr ""
@@ -73,9 +57,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr ""
@@ -557,9 +538,6 @@ msgstr ""
 msgid "Number of things which you can stop to do"
 msgstr ""
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -632,10 +610,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -656,22 +630,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -688,7 +658,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -705,8 +674,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -773,7 +740,6 @@ msgid ""
 "out!"
 msgstr ""
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -806,7 +772,6 @@ msgstr ""
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -817,10 +782,6 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -968,42 +929,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr ""
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1028,13 +977,10 @@ msgstr ""
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1061,8 +1007,6 @@ msgstr ""
 msgid "dopewars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1118,8 +1062,6 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1197,7 +1139,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr ""
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr ""
@@ -1276,8 +1217,6 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr ""
@@ -1294,7 +1233,6 @@ msgstr ""
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1334,10 +1272,6 @@ msgstr ""
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr ""
@@ -1372,14 +1306,10 @@ msgstr ""
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr ""
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr ""
@@ -1405,20 +1335,15 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr ""
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr ""
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr ""
@@ -1427,8 +1352,6 @@ msgstr ""
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1442,7 +1365,6 @@ msgstr ""
 msgid "How many do you drop? "
 msgstr ""
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
@@ -1451,8 +1373,6 @@ msgstr ""
 msgid "What do you wish to sell? "
 msgstr ""
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1480,7 +1400,6 @@ msgstr ""
 msgid "YN"
 msgstr ""
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr ""
@@ -1504,7 +1423,6 @@ msgstr ""
 msgid "%s has left the game."
 msgstr ""
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1529,50 +1447,34 @@ msgstr ""
 msgid "H I G H   S C O R E S"
 msgstr ""
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr ""
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
@@ -1581,40 +1483,27 @@ msgstr ""
 msgid "How much money do you pay back? "
 msgstr ""
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr ""
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
@@ -1643,45 +1532,31 @@ msgstr ""
 msgid "Press any key..."
 msgstr ""
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr ""
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr ""
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr ""
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr ""
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr ""
@@ -1691,8 +1566,6 @@ msgstr ""
 msgid "Space %6d"
 msgstr ""
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
@@ -1701,10 +1574,6 @@ msgstr ""
 msgid "Trenchcoat"
 msgstr ""
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1713,13 +1582,11 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1730,13 +1597,10 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1749,14 +1613,11 @@ msgstr ""
 msgid "Players currently logged on:-"
 msgstr ""
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
@@ -1769,7 +1630,6 @@ msgstr ""
 msgid "Hey there! What's your name? "
 msgstr ""
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr ""
@@ -1802,7 +1662,6 @@ msgstr ""
 msgid ", or Q>uit? "
 msgstr ""
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr ""
@@ -1819,7 +1678,6 @@ msgstr ""
 msgid "R>un, "
 msgstr ""
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1833,16 +1691,10 @@ msgstr ""
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr ""
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr ""
@@ -1851,7 +1703,6 @@ msgstr ""
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr ""
@@ -1860,7 +1711,6 @@ msgstr ""
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr ""
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1870,7 +1720,6 @@ msgstr ""
 msgid "Play again? "
 msgstr ""
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr ""
@@ -1883,7 +1732,6 @@ msgstr ""
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr ""
@@ -1916,7 +1764,6 @@ msgstr ""
 msgid "/Help/_About..."
 msgstr ""
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr ""
@@ -1929,70 +1776,58 @@ msgstr ""
 msgid "Message"
 msgstr ""
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr ""
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr ""
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr ""
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr ""
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr ""
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr ""
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr ""
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr ""
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr ""
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr ""
@@ -2001,31 +1836,23 @@ msgstr ""
 msgid "Fight"
 msgstr ""
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr ""
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr ""
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr ""
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr ""
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
@@ -2043,13 +1870,10 @@ msgstr ""
 msgid "Health: %d"
 msgstr ""
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr ""
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
@@ -2062,7 +1886,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr ""
@@ -2071,34 +1894,25 @@ msgstr ""
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr ""
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr ""
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr ""
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2120,7 +1934,6 @@ msgstr ""
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr ""
@@ -2133,13 +1946,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2160,8 +1973,6 @@ msgstr ""
 msgid "Drop %tde"
 msgstr ""
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2180,27 +1991,22 @@ msgstr ""
 msgid "_Evade"
 msgstr ""
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr ""
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr ""
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr ""
@@ -2237,205 +2043,159 @@ msgstr ""
 msgid "Unconstructive Criticism"
 msgstr ""
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
 "Church Wars is released under the GNU General Public License\n"
 msgstr ""
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr ""
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr ""
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr ""
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr ""
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr ""
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr ""
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr ""
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr ""
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr ""
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr ""
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr ""
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr ""
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr ""
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr ""
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr ""
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr ""
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr ""
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr ""
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr ""
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2644,7 +2404,6 @@ msgstr ""
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
@@ -2657,28 +2416,20 @@ msgstr ""
 msgid "Connection closed by remote host"
 msgstr ""
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2688,7 +2439,6 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr ""
@@ -2697,9 +2447,6 @@ msgstr ""
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2708,18 +2455,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr ""
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr ""
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2732,14 +2475,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr ""
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2802,16 +2541,12 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2819,9 +2554,6 @@ msgid ""
 "^Please try connecting again later."
 msgstr ""
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2832,15 +2564,10 @@ msgstr ""
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr ""
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -2881,7 +2608,6 @@ msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
@@ -2924,8 +2650,6 @@ msgstr ""
 msgid "No such user!\n"
 msgstr ""
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3153,8 +2877,6 @@ msgstr ""
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
@@ -3243,8 +2965,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3309,7 +3029,6 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3502,7 +3221,6 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
@@ -3551,7 +3269,6 @@ msgstr ""
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
@@ -3564,7 +3281,6 @@ msgstr ""
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
@@ -3727,7 +3443,6 @@ msgstr ""
 msgid "Bank located at %s\n"
 msgstr ""
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars SVN\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2020-12-09 12:02-0800\n"
 "Last-Translator: Ben Webb <benwebb@users.sf.net>\n"
 "Language-Team: British English <en@li.org>\n"
@@ -15,46 +15,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr ""
@@ -71,9 +55,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr ""
@@ -555,9 +536,6 @@ msgstr ""
 msgid "Number of things which you can stop to do"
 msgstr ""
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -630,10 +608,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -654,22 +628,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -686,7 +656,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -703,8 +672,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -771,7 +738,6 @@ msgid ""
 "out!"
 msgstr ""
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -804,7 +770,6 @@ msgstr ""
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -815,10 +780,6 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -966,42 +927,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr ""
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1026,13 +975,10 @@ msgstr ""
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1059,8 +1005,6 @@ msgstr ""
 msgid "dopewars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1156,8 +1100,6 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1264,7 +1206,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr ""
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr ""
@@ -1343,8 +1284,6 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr ""
@@ -1361,7 +1300,6 @@ msgstr ""
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1401,10 +1339,6 @@ msgstr ""
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr ""
@@ -1439,14 +1373,10 @@ msgstr ""
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr ""
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr ""
@@ -1472,20 +1402,15 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr ""
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr ""
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr ""
@@ -1494,8 +1419,6 @@ msgstr ""
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1509,7 +1432,6 @@ msgstr ""
 msgid "How many do you drop? "
 msgstr ""
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
@@ -1518,8 +1440,6 @@ msgstr ""
 msgid "What do you wish to sell? "
 msgstr ""
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1547,7 +1467,6 @@ msgstr ""
 msgid "YN"
 msgstr ""
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr ""
@@ -1571,7 +1490,6 @@ msgstr ""
 msgid "%s has left the game."
 msgstr ""
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1596,50 +1514,34 @@ msgstr ""
 msgid "H I G H   S C O R E S"
 msgstr ""
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr ""
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
@@ -1648,40 +1550,27 @@ msgstr ""
 msgid "How much money do you pay back? "
 msgstr ""
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr ""
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
@@ -1710,45 +1599,31 @@ msgstr ""
 msgid "Press any key..."
 msgstr ""
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr ""
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr ""
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr ""
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr ""
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr ""
@@ -1758,8 +1633,6 @@ msgstr ""
 msgid "Space %6d"
 msgstr ""
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
@@ -1768,10 +1641,6 @@ msgstr ""
 msgid "Trenchcoat"
 msgstr ""
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1780,13 +1649,11 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1797,13 +1664,10 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1816,14 +1680,11 @@ msgstr ""
 msgid "Players currently logged on:-"
 msgstr ""
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
@@ -1836,7 +1697,6 @@ msgstr ""
 msgid "Hey there! What's your name? "
 msgstr ""
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr ""
@@ -1869,7 +1729,6 @@ msgstr ""
 msgid ", or Q>uit? "
 msgstr ""
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr ""
@@ -1886,7 +1745,6 @@ msgstr ""
 msgid "R>un, "
 msgstr ""
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1900,16 +1758,10 @@ msgstr ""
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr ""
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr ""
@@ -1918,7 +1770,6 @@ msgstr ""
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr ""
@@ -1927,7 +1778,6 @@ msgstr ""
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr ""
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1937,7 +1787,6 @@ msgstr ""
 msgid "Play again? "
 msgstr ""
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr ""
@@ -1950,7 +1799,6 @@ msgstr ""
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr ""
@@ -1983,7 +1831,6 @@ msgstr ""
 msgid "/Help/_About..."
 msgstr ""
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr ""
@@ -1996,70 +1843,58 @@ msgstr ""
 msgid "Message"
 msgstr ""
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr ""
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr ""
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr ""
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr ""
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr ""
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr ""
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr ""
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr ""
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr ""
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr ""
@@ -2068,31 +1903,23 @@ msgstr ""
 msgid "Fight"
 msgstr ""
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr ""
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr ""
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr ""
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr ""
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
@@ -2110,13 +1937,10 @@ msgstr ""
 msgid "Health: %d"
 msgstr ""
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr ""
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
@@ -2129,7 +1953,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr ""
@@ -2138,34 +1961,25 @@ msgstr ""
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr ""
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr ""
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr ""
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2187,7 +2001,6 @@ msgstr ""
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr ""
@@ -2200,13 +2013,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2227,8 +2040,6 @@ msgstr ""
 msgid "Drop %tde"
 msgstr ""
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2247,27 +2058,22 @@ msgstr ""
 msgid "_Evade"
 msgstr ""
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr ""
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr ""
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr ""
@@ -2304,49 +2110,38 @@ msgstr ""
 msgid "Unconstructive Criticism"
 msgstr ""
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2355,156 +2150,121 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars is released under the GNU General Public Licence\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr ""
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr ""
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr ""
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr ""
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr ""
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr ""
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr ""
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr ""
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr ""
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr ""
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr ""
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr ""
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr ""
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr ""
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr ""
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr ""
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr ""
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr ""
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr ""
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2713,7 +2473,6 @@ msgstr ""
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
@@ -2726,28 +2485,20 @@ msgstr ""
 msgid "Connection closed by remote host"
 msgstr ""
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2757,7 +2508,6 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr ""
@@ -2766,9 +2516,6 @@ msgstr ""
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2777,18 +2524,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr ""
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr ""
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2801,14 +2544,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr ""
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2871,16 +2610,12 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2888,9 +2623,6 @@ msgid ""
 "^Please try connecting again later."
 msgstr ""
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2901,15 +2633,10 @@ msgstr ""
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr ""
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -2950,7 +2677,6 @@ msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
@@ -2993,8 +2719,6 @@ msgstr ""
 msgid "No such user!\n"
 msgstr ""
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3222,8 +2946,6 @@ msgstr ""
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr ""
@@ -3312,8 +3034,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock has not been properly initialised"
@@ -3378,7 +3098,6 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3571,7 +3290,6 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Cannot initialise WinSock (%s)!"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
@@ -3620,7 +3338,6 @@ msgstr ""
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS authentication cancelled by user"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
@@ -3633,7 +3350,6 @@ msgstr ""
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
@@ -3796,7 +3512,6 @@ msgstr ""
 msgid "Bank located at %s\n"
 msgstr ""
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2003-12-10 09:29+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -24,46 +24,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
@@ -80,9 +64,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
@@ -572,9 +553,6 @@ msgstr "Lista de cosas que puede dejar de hacer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puede dejar de hacer"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -647,10 +625,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -671,22 +645,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -703,7 +673,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -720,8 +689,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -788,7 +755,6 @@ msgid ""
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -821,7 +787,6 @@ msgstr "Mensaje"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -833,10 +798,6 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los adictos están comprando %tde a precios absurdos!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite!"
@@ -993,42 +954,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1053,13 +1002,10 @@ msgstr "Estructura lista redimensionada a %d elementos\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
@@ -1090,8 +1036,6 @@ msgstr "(%s disponible)\n"
 msgid "dopewars version %s\n"
 msgstr "dopewars versión %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1199,8 +1143,6 @@ msgstr ""
 "GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1323,7 +1265,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1409,8 +1350,6 @@ msgstr ""
 "en su terminal. Se mostrará una pantalla de ayuda con las opciones "
 "disponibles."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Introduzca el nombre y puerto de un servidor dopewars:-"
@@ -1427,7 +1366,6 @@ msgstr "Puerto: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espere... intentando contactar con el metaservidor..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1467,10 +1405,6 @@ msgstr "Comentario: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SAE"
@@ -1506,14 +1440,10 @@ msgstr "Contraseña: "
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Por favor, espere... intentando contactar con el servidor dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "No se pueden obtener los detalles del metaservidor"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "No se puede iniciar dopewars en modo multijugador"
@@ -1540,20 +1470,15 @@ msgstr "            S>alir (puede iniciar un servidor tecleando «dopewars -s»)
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "¿Dónde quiere ir, caballero? "
@@ -1562,8 +1487,6 @@ msgstr "¿Dónde quiere ir, caballero? "
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1577,7 +1500,6 @@ msgstr "¿Qué quiere tirar? "
 msgid "How many do you drop? "
 msgstr "¿Cuántas quiere tirar? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quiere comprar? "
@@ -1586,8 +1508,6 @@ msgstr "¿Qué quiere comprar? "
 msgid "What do you wish to sell? "
 msgstr "¿Qué quiere vender? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1615,7 +1535,6 @@ msgstr "¿Está seguro de que quiere salir? "
 msgid "YN"
 msgstr "SN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nuevo nombre: "
@@ -1639,7 +1558,6 @@ msgstr "¡%s se une al juego!"
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1664,50 +1582,34 @@ msgstr "Desgraciadamente ya hay alguien usando «su» nombre. Elija otro."
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tiene ningún %tde que vender!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "¡No tiene ninguna que vender!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesita más %tde para que le guarden más %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tiene suficiente espacio para llevar ese %tde!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tiene suficiente dinero para comprar ese %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVI"
@@ -1716,40 +1618,27 @@ msgstr "CVI"
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quiere devolver? "
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "¡No tiene tanto dinero!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quiere I>ngresar dinero, O>btener dinero o S>alir?"
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "IOS"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tiene tanto dinero en el banco..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
@@ -1778,45 +1667,31 @@ msgstr "H:Huir"
 msgid "Press any key..."
 msgstr "Pulse cualquier tecla..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Situación"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Dinero"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Salud"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Deuda"
@@ -1826,8 +1701,6 @@ msgstr "Deuda"
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
@@ -1836,10 +1709,6 @@ msgstr "%Tde %5d  Espacio %4d"
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
@@ -1848,13 +1717,11 @@ msgstr "%/Situación: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1865,13 +1732,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1884,14 +1748,11 @@ msgstr "¡No hay ningún otro jugador conectado en este momento!"
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, oiga. Los precios de las %tde aquí son:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1904,7 +1765,6 @@ msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 msgid "Hey there! What's your name? "
 msgstr "Eh oiga, ¿cómo se llama? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "¿Quiere C>omprar"
@@ -1937,7 +1797,6 @@ msgstr ", I>r a otro sitio"
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "¿Quiere "
@@ -1954,7 +1813,6 @@ msgstr "E>sperar, "
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1968,16 +1826,10 @@ msgstr "o S>alir? "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "CVTHJLMEIS"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "VCLES"
@@ -1986,7 +1838,6 @@ msgstr "VCLES"
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quiere? ¿J>ugadores o P>untuaciones? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
@@ -1995,7 +1846,6 @@ msgstr "JP"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "¿Con quién quiere hablar en privado?"
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -2005,7 +1855,6 @@ msgstr "Decir: "
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Juego"
@@ -2018,7 +1867,6 @@ msgstr "/Juego/_Nueva partida..."
 msgid "/Game/_Abandon..."
 msgstr "/Juego/_Abandonar partida..."
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Juego/Activar_sonido"
@@ -2051,7 +1899,6 @@ msgstr "/_Ayuda"
 msgid "/Help/_About..."
 msgstr "/Ayuda/_Acerca de..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Advertencia"
@@ -2064,45 +1911,37 @@ msgstr "Error"
 msgid "Message"
 msgstr "Mensaje"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "¿Abandonar esta partida?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Salir del juego"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Empezar nueva partida"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventario"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
@@ -2111,7 +1950,6 @@ msgstr ""
 "Ha sido expulsado del servidor.\n"
 "Pasando al modo 1 jugador."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
@@ -2120,18 +1958,15 @@ msgstr ""
 "El servidor se ha apagado.\n"
 "Pasando al modo 1 jugador."
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Yendo a %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Puntuaciones"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "El fichero de puntuaciones está corrupto :-("
@@ -2140,31 +1975,23 @@ msgstr "El fichero de puntuaciones está corrupto :-("
 msgid "Fight"
 msgstr "Enfrentarse"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "¡A _traficar!"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Luchar"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Esperar"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Correr"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Enfrentamiento: Putas/%d %tde"
@@ -2182,13 +2009,10 @@ msgstr "(Muertas)"
 msgid "Health: %d"
 msgstr "Salud: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Usted"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putas/%Tde"
@@ -2201,7 +2025,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Ir al barrio:"
@@ -2210,34 +2033,25 @@ msgstr "Ir al barrio:"
 msgid "%/Location to jet to/%tde"
 msgstr "%/Lugar al que irse/%tde"
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "a %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Ahora lleva %d dosis de %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Espacio disponible: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2259,7 +2073,6 @@ msgstr "Tirar"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "¿Cuánto quiere comprar?"
@@ -2272,13 +2085,13 @@ msgstr "¿Cuánto quiere vender?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quiere tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2299,8 +2112,6 @@ msgstr "Vender %tde"
 msgid "Drop %tde"
 msgstr "Tirar %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2319,27 +2130,22 @@ msgstr "_Atacar"
 msgid "_Evade"
 msgstr "_Huir"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Pregunta"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espacio"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traducción al español"
@@ -2376,49 +2182,38 @@ msgstr "Críticas constructivas"
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2427,160 +2222,121 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars está publicado bajo la GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"Para obtener información sobre las opciones en la línea de órdenes,\n"
-"escriba dopewars -h en su terminal Unix. Esto mostrará una pantalla\n"
-"de ayuda con las opciones disponibles.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Documentación local en HTML "
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tiene que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "No tiene tanto dinero en el banco..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Dinero en efectivo: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Deuda: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Saldar:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Ingresar"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Sacar"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Pagar todo"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Lista de jugadores"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Mensaje:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Enviar"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Número"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde que tiene"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Desgraciadamente ya hay otro jugador usando «su» nombre. Elija otro"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2789,7 +2545,6 @@ msgstr "_Ayuda"
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puede empezar la partida sin dar un nombre antes!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
@@ -2802,28 +2557,20 @@ msgstr "Situación: Esperando datos del usuario"
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2833,7 +2580,6 @@ msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh oiga, ¿cuál es su _nombre?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
@@ -2842,9 +2588,6 @@ msgstr "_Empezar partida para 1 jugador"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2857,18 +2600,14 @@ msgstr ""
 "de procesar el fichero de configuración, etc.\n"
 "\n"
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "servidor dopewars"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Jugador automático de dopewars"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2881,14 +2620,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr "AH"
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2984,8 +2719,6 @@ msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 "Alcanzado el número máximo de clientes (MaxClients %d) - cerrando la conexión"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2994,8 +2727,6 @@ msgstr ""
 "Disculpe, pero este servidor tiene un límite de 1 jugador, que ya ha sido "
 "alcanzado. ^Pruebe más tarde a conectarte de nuevo."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -3005,9 +2736,6 @@ msgstr ""
 "Disculpe, pero este servidor tiene un límite de %d jugadores, que ya ha sido "
 "alcanzado. ^Pruebe a conectarte de nuevo más tarde."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -3018,15 +2746,10 @@ msgstr "%s es ahora conocido como %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO irse a %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Se acabó su tiempo para traficar..."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3070,7 +2793,6 @@ msgstr ""
 "servidor dopewars versión %s preparado y esperando conexiones por el puerto "
 "%d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
@@ -3113,8 +2835,6 @@ msgstr "Echando a %s\n"
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3368,8 +3088,6 @@ msgstr "¡Se encuentra con un amigo! Le da a usted  %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Se encuentra con un amigo! Usted le da %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
@@ -3466,8 +3184,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código de error interno %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock no ha sido inicializado correctamente."
@@ -3532,7 +3248,6 @@ msgstr "Protocolo no soportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket no soportado"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Servidor no encontrado"
@@ -3725,7 +3440,6 @@ msgstr " ¡Le roba al cadaver!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
@@ -3774,7 +3488,6 @@ msgstr "Error de autenticación SOCKS"
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
@@ -3787,7 +3500,6 @@ msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
@@ -3960,7 +3672,6 @@ msgstr "El bar está en %s\n"
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y usted se hace llamar traficante?"
@@ -4005,6 +3716,20 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Para obtener información sobre las opciones en la línea de órdenes,\n"
+#~ "escriba dopewars -h en su terminal Unix. Esto mostrará una pantalla\n"
+#~ "de ayuda con las opciones disponibles.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Documentación local en HTML "
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es_ES\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2003-12-10 09:48+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -24,46 +24,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
@@ -80,9 +64,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
@@ -570,9 +551,6 @@ msgstr "Lista de cosas que puedes dejar de hacer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puedes dejar de hacer"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -645,10 +623,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -669,22 +643,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -701,7 +671,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -718,8 +687,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -787,7 +754,6 @@ msgid ""
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -820,7 +786,6 @@ msgstr "Mensaje"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -832,10 +797,6 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite, co!"
@@ -990,42 +951,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1050,13 +999,10 @@ msgstr "Estructura lista redimensionada a %d elementos\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
@@ -1087,8 +1033,6 @@ msgstr "(%s disponible)\n"
 msgid "dopewars version %s\n"
 msgstr "dopewars versión %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1196,8 +1140,6 @@ msgstr ""
 "GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1320,7 +1262,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1405,8 +1346,6 @@ msgstr ""
 "en tu terminal. Se mostrará una pantalla de ayuda con las opciones "
 "disponibles."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Introduce el nombre y puerto de un servidor doperwars:-"
@@ -1423,7 +1362,6 @@ msgstr "Puerto: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espera... intentando contactar con el metaservidor..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1463,10 +1401,6 @@ msgstr "Comentario: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SAE"
@@ -1502,14 +1436,10 @@ msgstr "Contraseña: "
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Por favor, espera... intentando contactar con el servidor dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "No se pueden obtener los detalles del metaservidor"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "No se puede iniciar dopewars en modo multijugador"
@@ -1537,20 +1467,15 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "¿Dónde quieres ir, colega? "
@@ -1559,8 +1484,6 @@ msgstr "¿Dónde quieres ir, colega? "
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1574,7 +1497,6 @@ msgstr "¿Qué quieres tirar? "
 msgid "How many do you drop? "
 msgstr "¿Cuántas quieres tirar? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quieres pillar? "
@@ -1583,8 +1505,6 @@ msgstr "¿Qué quieres pillar? "
 msgid "What do you wish to sell? "
 msgstr "¿Qué quieres pulir? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1612,7 +1532,6 @@ msgstr "¿Estás seguro de que quieres salir? "
 msgid "YN"
 msgstr "SN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nuevo nombre: "
@@ -1636,7 +1555,6 @@ msgstr "¡%s se une al juego!"
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1661,50 +1579,34 @@ msgstr "Desgraciadamente ya hay alguien usando «tu» nombre. Elige otro."
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tienes ningún %tde que vender!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "¡No tienes ninguna que vender!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesitas más %tde para que te guarden más %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tienes suficiente espacio para llevar ese %tde!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tienes suficientes pelas para comprar ese %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CPD"
@@ -1713,40 +1615,27 @@ msgstr "CPD"
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quieres devolver? "
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "¡No tienes tanta pasta!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quieres I>ngresar dinero, S>acar dinero o L>argarte?"
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ISL"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tienes tantos dineros en el banco..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
@@ -1775,45 +1664,31 @@ msgstr "H:Huir"
 msgid "Press any key..."
 msgstr "Pulsa cualquier tecla..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Situación"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Pasta"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Salud"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Pufo"
@@ -1823,8 +1698,6 @@ msgstr "Pufo"
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
@@ -1833,10 +1706,6 @@ msgstr "%Tde %5d  Espacio %4d"
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
@@ -1845,13 +1714,11 @@ msgstr "%/Situación: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1862,13 +1729,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1881,14 +1745,11 @@ msgstr "¡No hay ningún otro jugador conectado en este momento!"
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, tío. Los precios de las %tde aquí son:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1901,7 +1762,6 @@ msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 msgid "Hey there! What's your name? "
 msgstr "Eh tío, ¿cómo te llamas? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "¿Quieres C>omprar"
@@ -1934,7 +1794,6 @@ msgstr ", D>arte el piro"
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "¿Quieres "
@@ -1951,7 +1810,6 @@ msgstr "E>sperar, "
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1965,16 +1823,10 @@ msgstr "o S>alir? "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "CPTHJLMEDS"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "PCLES"
@@ -1983,7 +1835,6 @@ msgstr "PCLES"
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quieres? ¿J>ugadores o P>untuaciones? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
@@ -1992,7 +1843,6 @@ msgstr "JP"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "¿Con quién quieres hablar en privado?"
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -2002,7 +1852,6 @@ msgstr "Decir: "
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Juego"
@@ -2015,7 +1864,6 @@ msgstr "/Juego/_Nueva partida..."
 msgid "/Game/_Abandon..."
 msgstr "/Juego/_Abandonar partida..."
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Juego/Habilitar _sonido"
@@ -2048,7 +1896,6 @@ msgstr "/_Ayuda"
 msgid "/Help/_About..."
 msgstr "/Ayuda/_Acerca de..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Advertencia"
@@ -2061,45 +1908,37 @@ msgstr "Error"
 msgid "Message"
 msgstr "Mensaje"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "¿Abandonar esta partida?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Salir del juego"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Empezar nueva partida"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventario"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
@@ -2108,7 +1947,6 @@ msgstr ""
 "Has sido expulsado del servidor.\n"
 "Pasando al modo 1 jugador."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
@@ -2117,18 +1955,15 @@ msgstr ""
 "El servidor se ha apagado.\n"
 "Pasando al modo 1 jugador."
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Yendo a %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Puntuaciones"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "El fichero de puntuaciones está corrupto :-("
@@ -2137,31 +1972,23 @@ msgstr "El fichero de puntuaciones está corrupto :-("
 msgid "Fight"
 msgstr "Enfrentarse"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "¡A _Trapichear!"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Luchar"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Esperar"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Correr"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Enfrentamiento: Putas/%d %tde"
@@ -2179,13 +2006,10 @@ msgstr "(Muertas)"
 msgid "Health: %d"
 msgstr "Salud: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Tú"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putas/%Tde"
@@ -2198,7 +2022,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Ir al barrio:"
@@ -2207,34 +2030,25 @@ msgstr "Ir al barrio:"
 msgid "%/Location to jet to/%tde"
 msgstr "%/Lugar al que pirarse/%tde"
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "a %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Ahora llevas %d dosis de %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Espacio disponible: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2256,7 +2070,6 @@ msgstr "Tirar"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "¿Cuánto quieres comprar?"
@@ -2269,13 +2082,13 @@ msgstr "¿Cuánto quieres pulir?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quieres tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2296,8 +2109,6 @@ msgstr "Pulir %tde"
 msgid "Drop %tde"
 msgstr "Tirar %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2316,27 +2127,22 @@ msgstr "_Atacar"
 msgid "_Evade"
 msgstr "_Huir"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Pregunta"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espacio"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traducción al español"
@@ -2373,49 +2179,38 @@ msgstr "Críticas constructivas"
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2424,160 +2219,121 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars está publicado bajo la GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"Para obtener información sobre las opciones en la línea de órdenes,\n"
-"escribe dopewars -h en tu terminal Unix. Esto mostrará una pantalla\n"
-"de ayuda con las opciones disponibles.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Documentación local en HTML "
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tienes que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "No tienes tantos dineros en el banco..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Pasta en efectivo: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Pufo: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Saldar:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Ingresar"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Sacar"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Pagar todo"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Lista de jugadores"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Mensaje:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Enviar"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Número"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Pulir"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde que tienes"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Desgraciadamente ya hay otro jugador usando «tu» nombre. Elije otro"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2786,7 +2542,6 @@ msgstr "_Ayuda"
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puedes empezar la partida sin dar un nombre antes!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
@@ -2799,28 +2554,20 @@ msgstr "Situación: Esperando input del usuario"
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2830,7 +2577,6 @@ msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh tío, ¿cuál es tu _nombre?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
@@ -2839,9 +2585,6 @@ msgstr "_Empezar partida para 1 jugador"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2854,18 +2597,14 @@ msgstr ""
 "de procesar el fichero de configuración, etc.\n"
 "\n"
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "servidor dopewars"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Jugador automático de dopewars"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2878,14 +2617,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr "AH"
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2981,8 +2716,6 @@ msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 "Alcanzado el número máximo de clientes (MaxClients %d) - cerrando la conexión"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2991,8 +2724,6 @@ msgstr ""
 "Lo siento, pero este servidor tiene un límite de 1 jugador, que ya ha sido "
 "alcanzado. ^Prueba más tarde a conectarte de nuevo."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -3002,9 +2733,6 @@ msgstr ""
 "Lo siento, pero este servidor tiene un límite de %d jugadores, que ya ha "
 "sido alcanzado. ^Prueba a conectarte de nuevo más tarde."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -3015,15 +2743,10 @@ msgstr "%s es ahora conocido como %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO largarse a %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Se acabó tu tiempo para trapichear..."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3066,7 +2789,6 @@ msgid ""
 msgstr ""
 "servidor dopewars versión %s listo y esperando conexiones por el puerto %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
@@ -3109,8 +2831,6 @@ msgstr "Echando a %s\n"
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3364,8 +3084,6 @@ msgstr "¡Te encuentras con un amigo! Te da %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Te encuentras con un amigo! Le das %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
@@ -3462,8 +3180,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código de error interno %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock no ha sido inicializado correctamente."
@@ -3528,7 +3244,6 @@ msgstr "Protocolo no soportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket no soportado"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Servidor no encontrado"
@@ -3721,7 +3436,6 @@ msgstr " ¡Le robas al cadaver!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
@@ -3770,7 +3484,6 @@ msgstr "Error de autenticación SOCKS"
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
@@ -3783,7 +3496,6 @@ msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
@@ -3956,7 +3668,6 @@ msgstr "El bar está en %s\n"
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y tú te haces llamar camello?"
@@ -4001,6 +3712,20 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Para obtener información sobre las opciones en la línea de órdenes,\n"
+#~ "escribe dopewars -h en tu terminal Unix. Esto mostrará una pantalla\n"
+#~ "de ayuda con las opciones disponibles.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Documentación local en HTML "
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2001-10-16 20:50+0100\n"
 "Last-Translator: leonard <triton@madchat.org>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -15,46 +15,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "Le Preteur a Gages"
@@ -71,9 +55,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port reseau a se connecter"
@@ -556,9 +537,6 @@ msgstr "liste des trucs que tu peux arreter de faire"
 msgid "Number of things which you can stop to do"
 msgstr "nombre de trucs que tu peux arreter de faire"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -631,10 +609,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -655,22 +629,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -687,7 +657,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -704,8 +673,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -772,7 +739,6 @@ msgid ""
 "out!"
 msgstr "de la bonne herbe d'Amsterdam vient d'arriver en masse"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -805,7 +771,6 @@ msgstr "Message"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -816,10 +781,6 @@ msgstr "Les flics ont mis la main sur un gros stock de %tde !"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les junkies achetent %tde hors de prix !"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "`Vivons dans l'extase de l'illimité`"
@@ -970,42 +931,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit etre entre 1 et %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1030,13 +979,10 @@ msgstr "Structure liste redimentionnee a %d elements\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1063,8 +1009,6 @@ msgstr ""
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1152,8 +1096,6 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1269,7 +1211,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Français Traduction           Leonard"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1352,8 +1293,6 @@ msgid ""
 msgstr ""
 "a votre prompt UNIX. Cela va afficher l'aide sur les options disponibles."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Merci d'entrer le nom du host et le port du server dopewars:-"
@@ -1370,7 +1309,6 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le metaserver..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1410,10 +1348,6 @@ msgstr "Commentaire: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>uivant server; P>recedent server; C>choisir ce serveur..."
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SPC"
@@ -1448,14 +1382,10 @@ msgstr ""
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Patientez... tentative de contacter le serveur dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Ne peux pas demarrer dopewars en multi-joueur"
@@ -1481,20 +1411,15 @@ msgstr "               Q>uitter (vous pouvez alors demarrer un server"
 msgid "         or P>lay single-player ? "
 msgstr "            ou J>ouer en solo ? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLQJ"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Ou ca, mec ? "
@@ -1503,8 +1428,6 @@ msgstr "Ou ca, mec ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1518,7 +1441,6 @@ msgstr "Que veux tu laisser tomber? "
 msgid "How many do you drop? "
 msgstr "Combien d'unites tu laisses tomber? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Que souhaites tu acheter? "
@@ -1527,8 +1449,6 @@ msgstr "Que souhaites tu acheter? "
 msgid "What do you wish to sell? "
 msgstr "Que souhaites tu vendre? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1556,7 +1476,6 @@ msgstr "Etes vous sur de vouloir quitter? "
 msgid "YN"
 msgstr "ON"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nouveau nom: "
@@ -1580,7 +1499,6 @@ msgstr "%s joint la partie!"
 msgid "%s has left the game."
 msgstr "%s a quitte la partie."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1605,50 +1523,34 @@ msgstr "Malheureusement, qq d'autre utilise deja ton nom. Merci d'en changer"
 msgid "H I G H   S C O R E S"
 msgstr "H I G H   S C O R E S"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Tu n'as aucun %tde a vendre!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "T'en as aucun a vendre!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour porter plus de %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Tu n'as pas assez d'espace pour porter ce %tde"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Tu n'as pas assez de fric pour achter ce %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
@@ -1657,40 +1559,27 @@ msgstr "AVP"
 msgid "How much money do you pay back? "
 msgstr "Combien de fric tu rends ?"
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "Tu n'as pas assez d'argent!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Tu veux D>eposer de l'argent, R>etirer des biftons, ou P>artir ?"
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRP"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent?"
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
@@ -1719,45 +1608,31 @@ msgstr "S: S'evader"
 msgid "Press any key..."
 msgstr "Appuyer sur une touche..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistiques"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Fric"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Sante"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banque"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Dette"
@@ -1767,8 +1642,6 @@ msgstr "Dette"
 msgid "Space %6d"
 msgstr "Espace %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
@@ -1777,10 +1650,6 @@ msgstr "%Tde %3d  Espace %6d"
 msgid "Trenchcoat"
 msgstr "Trenchcoat"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
@@ -1789,13 +1658,11 @@ msgstr "%/Stats: Drogues/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1806,13 +1673,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1825,14 +1689,11 @@ msgstr "Aucun autre joueur est en ligne en ce moment!"
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "He man, les prix du %tde sont la:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1845,7 +1706,6 @@ msgstr "Ne peux pas installer SIGWINCH interrupt handler!"
 msgid "Hey there! What's your name? "
 msgstr "He mec, c'est quoi ton nom? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "A>cheter"
@@ -1878,7 +1738,6 @@ msgstr ", dEplacer"
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Tu "
@@ -1895,7 +1754,6 @@ msgstr "R>este sur place, "
 msgid "R>un, "
 msgstr "S>e sauver, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1909,16 +1767,10 @@ msgstr "ou Q>uitter? "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCEQ"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "DSCRQ"
@@ -1927,7 +1779,6 @@ msgstr "DSCRQ"
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JS"
@@ -1936,7 +1787,6 @@ msgstr "JS"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "A qui tu veux parler en prive ? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1946,7 +1796,6 @@ msgstr "Parler: "
 msgid "Play again? "
 msgstr "Rejouer? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Jeu"
@@ -1959,7 +1808,6 @@ msgstr "/Jeu/_Nouveau..."
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr ""
@@ -1992,7 +1840,6 @@ msgstr "/_Aide"
 msgid "/Help/_About..."
 msgstr "/Aide/_A propos..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Avertissement"
@@ -2005,70 +1852,58 @@ msgstr ""
 msgid "Message"
 msgstr "Message"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Abandonner cette partie ?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Quitter la partie"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Commencer une nouvelle partie"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr ""
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventaire"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fermer"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connection au server perdue - Mode solo"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez ete vire du serveur. Devient solo."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Le serveur est mort. Devient solo"
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Bouger vers %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "High Scores"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "High Score corrompu!"
@@ -2077,31 +1912,23 @@ msgstr "High Score corrompu!"
 msgid "Fight"
 msgstr "Se battre"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_Vendre %Tde"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Combattre"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Rester sur place"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Courrir"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Combat: Salopes/%d %tde"
@@ -2119,13 +1946,10 @@ msgstr ""
 msgid "Health: %d"
 msgstr "Sante: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Vous"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Salopes/%Tde"
@@ -2138,7 +1962,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Se deplacer a un autre endroit"
@@ -2147,34 +1970,25 @@ msgstr "Se deplacer a un autre endroit"
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "at %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Vous portez en ce moment %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Espace disponible: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2196,7 +2010,6 @@ msgstr "Laisser tomber"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "Acheter combien ?"
@@ -2209,13 +2022,13 @@ msgstr "Vendre combien ?"
 msgid "Drop how many?"
 msgstr "Laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2236,8 +2049,6 @@ msgstr "Vendre %tde"
 msgid "Drop %tde"
 msgstr "Laisser tomber %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2256,27 +2067,22 @@ msgstr "_Attaquer"
 msgid "_Evade"
 msgstr "_S'evader"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Question"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espace"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Français Traduction"
@@ -2313,49 +2119,38 @@ msgstr "Critique constructive"
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2364,159 +2159,122 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars est diffuse sous la GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
-msgstr ""
-"\n"
-"Pour infos sur les options en ligne de commande, taper: dopewars -h\n"
-
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
 
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Preteur window title/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Fric: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "banque: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Rembourser:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Deposer"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Retirer"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Tout payer"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Liste des joueurs"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Parler au joueur(s)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Parler a tout les joueurs"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Message:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Envoyer"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Nombre"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde ici"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde transporte"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Changer Nom"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 "Malheureusement, quelqu'un d'autre utilise deja ton nom. Merci de le changer"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Armurerie window title/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2725,7 +2483,6 @@ msgstr "_Aide"
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
@@ -2738,28 +2495,20 @@ msgstr "Status: Attente de l'utilisateur"
 msgid "Connection closed by remote host"
 msgstr ""
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2769,7 +2518,6 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr "Salut mec, quel est ton _nom?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Commencer un jeu en solo"
@@ -2778,9 +2526,6 @@ msgstr "_Commencer un jeu en solo"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2793,18 +2538,14 @@ msgstr ""
 "# du fichier de config etc...\n"
 "\n"
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "serveur dopewars"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "dopewars AI"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2817,14 +2558,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr "AS"
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2903,8 +2640,6 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) exceeded - dropping connection"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2913,8 +2648,6 @@ msgstr ""
 "Desole, ce serveur a une limite atteinte de 1 joueurMerci de re-essayer "
 "votre connection plus tard."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2924,9 +2657,6 @@ msgstr ""
 "Desole, ce serveur a une limite atteinte de %d joueursMerci de re-essayer "
 "votre connection plus tard."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2937,15 +2667,10 @@ msgstr "%s est maintenant %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: deplacement vers %s INTERDIT"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Votre temps de deal est termine"
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -2988,7 +2713,6 @@ msgstr ""
 "dopewars server version %s pret et attendant les connections\n"
 "sur le port %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Cannot install SIGUSR1 interrupt handler!"
@@ -3031,8 +2755,6 @@ msgstr "Pousser %s\n"
 msgid "No such user!\n"
 msgstr "Cet user n'existe pas.\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3264,8 +2986,6 @@ msgstr "Tu rencontres un ami! Il te donne %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Tu rencontre un ami! Tu lui donne %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aleatoire."
@@ -3360,8 +3080,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3426,7 +3144,6 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3619,7 +3336,6 @@ msgstr " Tu cherches le corps!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
@@ -3668,7 +3384,6 @@ msgstr ""
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
@@ -3681,7 +3396,6 @@ msgstr ""
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
@@ -3847,7 +3561,6 @@ msgstr "Le bar est situe a %s\n"
 msgid "Bank located at %s\n"
 msgstr "La banque est situee a %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vous osez vous appeller des dealers?"
@@ -3890,6 +3603,15 @@ msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pour infos sur les options en ligne de commande, taper: dopewars -h\n"
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars 1.5.10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2007-10-25 16:37+1300\n"
 "Last-Translator: François Marier <francois@debian.org>\n"
 "Language-Team: French\n"
@@ -14,46 +14,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "le prêteur à gages"
@@ -70,9 +54,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port réseau auquel se connecter"
@@ -560,9 +541,6 @@ msgstr "Liste des choses que vous pouvez arrêter de faire"
 msgid "Number of things which you can stop to do"
 msgstr "Nombre de choses que vous pouvez arrêter de faire"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -635,10 +613,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -659,22 +633,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -691,7 +661,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -708,8 +677,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -778,7 +745,6 @@ msgstr ""
 "Les récoltes des serres hydroponiques dépassent les attentes, c'est le temps "
 "de fumer!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -811,7 +777,6 @@ msgstr "Message"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -822,10 +787,6 @@ msgstr "Les boeufs ont mis la main sur un gros stock de dope (%tde) !"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -983,42 +944,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit être entre 1 et %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1043,13 +992,10 @@ msgstr "Liste de structure redimentionée à %d éléments\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "valeur booléenne attendue (0, FALSE, 1, TRUE)"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
@@ -1080,8 +1026,6 @@ msgstr "(%s disponible)\n"
 msgid "dopewars version %s\n"
 msgstr "dopewars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1181,8 +1125,6 @@ msgstr ""
 "GNU GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1306,7 +1248,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traduction québécoise         François Marier"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1389,8 +1330,6 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "tapez dopewars -h sur votre prompt UNIX."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Merci d'entrer le nom de l'hôte et le port du serveur:-"
@@ -1407,7 +1346,6 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le méta-serveur..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1447,10 +1385,6 @@ msgstr "Commentaire: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>erveur suivant; P>récedent; C>hoisir ce serveur... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SPC"
@@ -1485,14 +1419,10 @@ msgstr "Mot de passe: "
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Patientez... tentative de contacter le serveur dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Impossible d'obtenir les détails du méta-serveur"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Ne peux pas démarrer dopewars en mode multi-joueurs"
@@ -1520,20 +1450,15 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ouer en solo ? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLQJ"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Où ça, man ? "
@@ -1542,8 +1467,6 @@ msgstr "Où ça, man ? "
 msgid "%/Location display/%tde"
 msgstr "%/Affichage de l'endroit/%tde"
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1557,7 +1480,6 @@ msgstr "Qu'est-ce que tu veux crisser à terre? "
 msgid "How many do you drop? "
 msgstr "Combien d'unités veux-tu crisser à terre? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Qu'est-ce que tu veux acheter? "
@@ -1566,8 +1488,6 @@ msgstr "Qu'est-ce que tu veux acheter? "
 msgid "What do you wish to sell? "
 msgstr "Qu'est-ce que tu veux vendre? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1595,7 +1515,6 @@ msgstr "Êtes-vous sur de vouloir quitter? "
 msgid "YN"
 msgstr "ON"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nouveau nom: "
@@ -1619,7 +1538,6 @@ msgstr "%s joint la partie!"
 msgid "%s has left the game."
 msgstr "%s a quitté la partie."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1644,50 +1562,34 @@ msgstr "Malheureusement, quelqu'un d'autre utilise déjà ton nom. Change-le."
 msgid "H I G H   S C O R E S"
 msgstr "M E I L L E U R S   S C O R E S"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "T'as pas de %tde à vendre!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "T'en n'as pas à vendre!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour transporter plus de %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "T'as pas assez d'espace pour transporter: %tde"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "T'as pas assez de cash pour acheter: %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
@@ -1696,41 +1598,28 @@ msgstr "AVP"
 msgid "How much money do you pay back? "
 msgstr "Combien de cash tu rends ? "
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "T'as pas assez de cash!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 "Tu veux D>époser de l'argent, R>etirer de l'argents, ou S>acrer ton camp ? "
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent? "
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Ya pas autant d'argent dans la banque..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
@@ -1759,45 +1648,31 @@ msgstr "S:Se sauver"
 msgid "Press any key..."
 msgstr "Pèse sur une touche..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Messages (-/+ avancer/reculer)"
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statistiques"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Cash"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Santé"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banque"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Dette"
@@ -1807,8 +1682,6 @@ msgstr "Dette"
 msgid "Space %6d"
 msgstr "Espace %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
@@ -1817,10 +1690,6 @@ msgstr "%Tde %3d  Espace %6d"
 msgid "Trenchcoat"
 msgstr "Manteau"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
@@ -1829,13 +1698,11 @@ msgstr "%/Stats: Drogues/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1846,13 +1713,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1865,14 +1729,11 @@ msgstr "Aucun autre joueur est en ligne en ce moment!"
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Heille man, les prix du %tde sont la:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1885,7 +1746,6 @@ msgstr "Ne peux pas installer le handleur d'interruptions SIGWINCH!"
 msgid "Hey there! What's your name? "
 msgstr "Heille man, comment tu t'appelles ? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "A>cheter"
@@ -1918,7 +1778,6 @@ msgstr ", S>'en aller ailleurs"
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Tu "
@@ -1935,7 +1794,6 @@ msgstr "R>ester sur place, "
 msgid "R>un, "
 msgstr "T>e sauver, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1949,16 +1807,10 @@ msgstr "ou Q>uitter? "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCSQ"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "VTCRQ"
@@ -1967,7 +1819,6 @@ msgstr "VTCRQ"
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JS"
@@ -1976,7 +1827,6 @@ msgstr "JS"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "À qui que tu veux parler en privé ? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1986,7 +1836,6 @@ msgstr "Parler: "
 msgid "Play again? "
 msgstr "Jouer à nouveau? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Jeu"
@@ -1999,7 +1848,6 @@ msgstr "/Jeu/_Nouveau..."
 msgid "/Game/_Abandon..."
 msgstr "/Jeu/_Abandonner..."
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Jeu/Activer les _sons"
@@ -2032,7 +1880,6 @@ msgstr "/_Aide"
 msgid "/Help/_About..."
 msgstr "/Aide/_À propos..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Attention"
@@ -2045,70 +1892,58 @@ msgstr "Erreur"
 msgid "Message"
 msgstr "Message"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Abandonner cette partie ?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Quitter la partie"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Commencer une nouvelle partie"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Abandonner la partie"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventaire"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fermer"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connexion au serveur perdue - Mode solo"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez été expulsé(e) du serveur. Mode solo."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Le serveur est mort. Mode solo"
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "S'en aller vers %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Meilleurs scores"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "Le fichier des meilleurs scores est corrompu!"
@@ -2117,31 +1952,23 @@ msgstr "Le fichier des meilleurs scores est corrompu!"
 msgid "Fight"
 msgstr "Se battre"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_Vendre de la dope"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Combattre"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Rester sur place"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Décrisser"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Combat: Putes/%d %tde"
@@ -2159,13 +1986,10 @@ msgstr "(Mort/es)"
 msgid "Health: %d"
 msgstr "Santé:  %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Toi"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putes/%Tde"
@@ -2178,7 +2002,6 @@ msgstr "%/Inventaire nom de la drogue/%tde"
 msgid "%/Inventory gun name/%tde"
 msgstr "%/Inventaire nom du gun/%tde"
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Se déplacer à un autre endroit"
@@ -2187,34 +2010,25 @@ msgstr "Se déplacer à un autre endroit"
 msgid "%/Location to jet to/%tde"
 msgstr "Endroit vers où se déplacer"
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "à %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Tu transportes en ce moment %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Espace disponible: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2236,7 +2050,6 @@ msgstr "Laisser tomber"
 msgid "%/DealDrugs drug name/%tde"
 msgstr "%/Vendre nom de la drogue/%tde"
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "En acheter combien ?"
@@ -2249,13 +2062,13 @@ msgstr "En vendre combien ?"
 msgid "Drop how many?"
 msgstr "En laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2276,8 +2089,6 @@ msgstr "Vendre %tde"
 msgid "Drop %tde"
 msgstr "Laisser tomber %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2296,27 +2107,22 @@ msgstr "_Attaquer"
 msgid "_Evade"
 msgstr "_S'enfuir"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Question"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espace"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "Dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Traduction québécoise"
@@ -2353,49 +2159,38 @@ msgstr "Critique constructive"
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2404,160 +2199,122 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars est distribué sous la licence GNU GPL\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"Pour afficher l'aide sur les options disponible sur la ligne de commande,\n"
-"tapez dopewars -h sur votre prompt UNIX.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Documentation HTML locale"
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Prêteur window title/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "Vous devez entrer un montant positif!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Argent: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Banque: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Rembourser:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Déposer"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Retirer"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Tout payer"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Liste des joueurs"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Parler au(x) joueur(s)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Parler à tous les joueurs"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Message:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Envoyer"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Quantité"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde en vente/demande ici"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde transporté(e)s"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Changer de nom"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 "Malheureusement, quelqu'un d'autre utilise déjà ton nom.Merci de le changer:-"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Marchand d'armes window title/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2766,7 +2523,6 @@ msgstr "A_ide"
 msgid "You can't start the game without giving a name first!"
 msgstr "Impossible de débuter une partie sans se nommer!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
@@ -2779,28 +2535,20 @@ msgstr "Status: En attente de l'utilisateur"
 msgid "Connection closed by remote host"
 msgstr "Connexion terminée par l'autre partie"
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Connecté au serveur SOCKS %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: En cours d'authentification avec le serveur SOCKS"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2810,7 +2558,6 @@ msgstr "Status: En train de demander à SOCKS d'établir la connexion avec %s...
 msgid "Greetings Trader, what's your _name?"
 msgstr "Heille man, c'est quoi ton _nom?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Débuter la partie en mode solo"
@@ -2819,9 +2566,6 @@ msgstr "_Débuter la partie en mode solo"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2834,18 +2578,14 @@ msgstr ""
 "# fichier de configuration et autre...\n"
 "\n"
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "Serveur dopewars"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "IA dopewars"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2858,14 +2598,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr "AS"
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2953,8 +2689,6 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Nombre maximum de clients (%d) dépassé - annulation de la connexion"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2963,8 +2697,6 @@ msgstr ""
 "Désolé, ce serveur a une limite d'un seul joueur et cette limite a été "
 "^atteinte. Merci de réessayer plus tard."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2974,9 +2706,6 @@ msgstr ""
 "Désolé, ce serveur a une limite de %d joueurs et cette limite a été "
 "^atteinte. Merci de réessayer plus tard."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2987,15 +2716,10 @@ msgstr "%s est maintenant connu sous le nom de %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: déplacement vers %s INTERDIT"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Votre temps de dealage est terminé"
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3036,7 +2760,6 @@ msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "Serveur dopewars version %s attendant les connexions sur le port %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGUSR1!"
@@ -3079,8 +2802,6 @@ msgstr "Intimidation de %s\n"
 msgid "No such user!\n"
 msgstr "Cet utilisateur n'existe pas.\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3331,8 +3052,6 @@ msgstr "T'as rencontré un chum, il t'a donné %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "T'as rencontré ton meilleur chum pis tu lui a donné %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aléatoire."
@@ -3430,8 +3149,6 @@ msgstr "La connexion est brisée à cause d'un tampon plein"
 msgid "Internal error code %d"
 msgstr "Code d'erreur interne: %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock n'a pas été correctement initialisé"
@@ -3496,7 +3213,6 @@ msgstr "Protocole non-supporté"
 msgid "Socket type not supported"
 msgstr "Type de socket non-supporté"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Impossible de trouver l'hôte"
@@ -3689,7 +3405,6 @@ msgstr " Tu fouilles le corps!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Impossible d'initialiser WinSock (%s)!"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "Échec général du serveur SOCKS"
@@ -3738,7 +3453,6 @@ msgstr "Échec d'authentification SOCKS"
 msgid "SOCKS authentication canceled by user"
 msgstr "Authentification SOCKS annulée par l'utilisateur"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Requête rejetée ou échouée"
@@ -3751,7 +3465,6 @@ msgstr "SOCKS: Rejeté - impossible de contacter identd"
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rejeté - identd rapporte un nom d'utilisateur différent"
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Code de réponse SOCKS inconnu"
@@ -3923,7 +3636,6 @@ msgstr "Le bar est situé à %s\n"
 msgid "Bank located at %s\n"
 msgstr "La banque est située à %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Tu oses te prendre pour un pusher?"
@@ -3967,6 +3679,20 @@ msgid ""
 msgstr ""
 "Le plugin sélectionné (\"%s\") est invalide.\n"
 "(%s est disponible, utilisation de \"%s\".)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Pour afficher l'aide sur les options disponible sur la ligne de "
+#~ "commande,\n"
+#~ "tapez dopewars -h sur votre prompt UNIX.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Documentation HTML locale"
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/nn.po
+++ b/po/nn.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nn_new\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2003-08-31 22:58+0200\n"
 "Last-Translator: Åsmund Skjæveland <aasmunds@fys.uio.no>\n"
 "Language-Team: Norsk nynorsk <i18n-nn@lister.ping.uio.no>\n"
@@ -29,46 +29,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "Lånehaien"
@@ -85,9 +69,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Nettverksport å kopla til"
@@ -570,9 +551,6 @@ msgstr "Liste over ting du kan stoppa for å gjera"
 msgid "Number of things which you can stop to do"
 msgstr "Tal på ting du kan stoppa for å gjera"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -645,10 +623,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -669,22 +643,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -701,7 +671,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -718,8 +687,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -786,7 +753,6 @@ msgid ""
 "out!"
 msgstr "Colombiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -819,7 +785,6 @@ msgstr "Melding"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -830,10 +795,6 @@ msgstr "Politiet gjorde eit kjempebeslag av %tde! Prisane er skyhøge!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Narkomane kjøper %tde til avsindige prisar!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Ville det ikkje vore festleg viss alle plutseleg kvekkte samtidig?"
@@ -985,42 +946,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks til %s array burde vore mellom 1 og %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s er %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s er %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s er %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s er «%s»\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] er %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1045,13 +994,10 @@ msgstr "Forandra storleiken på strukturlista til %d element\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Venta ein boolsk verdi (ein av 0, FALSE, 1, TRUE)"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=TRUE"
@@ -1082,8 +1028,6 @@ msgstr "(%s tilgjengeleg)\n"
 msgid "dopewars version %s\n"
 msgstr "dopewars versjon %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1180,8 +1124,6 @@ msgstr ""
 "GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1302,7 +1244,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Norsk omsetjing               Åsmund Skjæveland"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1384,8 +1325,6 @@ msgid ""
 msgstr ""
 "Unix-kommandolina. Det viser ein hjelpetekst med dei tilgjengelege vala."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Skriv vertsnamnet og porten på ein dopewars-tenar:"
@@ -1402,7 +1341,6 @@ msgstr "Port:"
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Vent litt... prøver å kontakta metatenar..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1442,10 +1380,6 @@ msgstr "Kommentar: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>este tenar: F>ørre tenar: V>el denne tenaren"
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NFV"
@@ -1480,14 +1414,10 @@ msgstr "Passord:"
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Vent litt... prøver å kopla til dopewars-tenar..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Kan ikkje henta metatenar-detaljar"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Kunne ikkje starta fleirspelar dopewars"
@@ -1513,20 +1443,15 @@ msgstr "       A>vslutta (du kan starta ein tenar med «dopewars -s»)"
 msgid "         or P>lay single-player ? "
 msgstr "       eller S>pela åleine? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "KLAS"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Kor til, kompis? "
@@ -1535,8 +1460,6 @@ msgstr "Kor til, kompis? "
 msgid "%/Location display/%tde"
 msgstr "%/Liste over stader/%tde"
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1550,7 +1473,6 @@ msgstr "Kva vil du kasta? "
 msgid "How many do you drop? "
 msgstr "Kor mange vil du kasta? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Kva vil du kjøpa? "
@@ -1559,8 +1481,6 @@ msgstr "Kva vil du kjøpa? "
 msgid "What do you wish to sell? "
 msgstr "Kva vil du selja? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1588,7 +1508,6 @@ msgstr "Er du viss på at du vil avslutta? "
 msgid "YN"
 msgstr "JN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nytt namn:"
@@ -1612,7 +1531,6 @@ msgstr "%s blir med i spelet!"
 msgid "%s has left the game."
 msgstr "%s har forlatt spelet."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1637,50 +1555,34 @@ msgstr "Diverre er det alt nokon som brukar «ditt» namn. Vér snill og byt det
 msgid "H I G H   S C O R E S"
 msgstr "P O E N G L I S T E"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du har ikkje noko %tde å selja!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Du har ikkje noko å selja!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du treng fleire %tde for å bera meir %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du har ikkje nok plass til å bera det %tde!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du har ikkje nok pengar til å kjøpa det %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Vil du K>jøpa, S>elja eller G>å?"
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSG"
@@ -1689,40 +1591,27 @@ msgstr "KSG"
 msgid "How much money do you pay back? "
 msgstr "Kor mykje pengar vil du betala tilbake?"
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "Du har ikkje så mykje pengar!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Vil du S>etja inn pengar, T>a ut pengar, eller G>å?"
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "STG"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Kor mykje pengar?"
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Du har ikkje så mykje i banken."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
@@ -1751,45 +1640,31 @@ msgstr "U:Unngå"
 msgid "Press any key..."
 msgstr "Trykk ein tast..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Meldingar (-/+ rullar opp/ned)"
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Status"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Kontantar"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tuf"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Helse"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Bank"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Gjeld"
@@ -1799,8 +1674,6 @@ msgstr "Gjeld"
 msgid "Space %6d"
 msgstr "Plass %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d plass %6d"
@@ -1809,10 +1682,6 @@ msgstr "%Tde %3d plass %6d"
 msgid "Trenchcoat"
 msgstr "Frakk"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%Tde"
@@ -1821,13 +1690,11 @@ msgstr "%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1838,13 +1705,10 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tuf"
@@ -1857,14 +1721,11 @@ msgstr "Ingen andre spelarar er logga på no."
 msgid "Players currently logged on:-"
 msgstr "Spelarar som er logga på:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hei du. Her kostar %tde:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1877,7 +1738,6 @@ msgstr "Kan ikkje installera SIGWINCH-avbrotshandsamar!"
 msgid "Hey there! What's your name? "
 msgstr "Namnet ditt:"
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Vil du K>jøpa"
@@ -1910,7 +1770,6 @@ msgstr ", R>eisa"
 msgid ", or Q>uit? "
 msgstr ", eller A>vslutta? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Vil du "
@@ -1927,7 +1786,6 @@ msgstr "V>enta, "
 msgid "R>un, "
 msgstr "R>ømma, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1941,16 +1799,10 @@ msgstr "eller A>vslutta?"
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Mista sambandet til tenaren! Går tilbake til einspelar-modus."
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "KSHNELGJRA"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "SRKVA"
@@ -1959,7 +1811,6 @@ msgstr "SRKVA"
 msgid "List what? P>layers or S>cores? "
 msgstr "Lista opp kva? S>pelarar eller P>oeng? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "SP"
@@ -1968,7 +1819,6 @@ msgstr "SP"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Kven vil du snakka privat med? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1978,7 +1828,6 @@ msgstr "Snakk: "
 msgid "Play again? "
 msgstr "Spela igjen? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Spel"
@@ -1991,7 +1840,6 @@ msgstr "/Spel/_Nytt ..."
 msgid "/Game/_Abandon..."
 msgstr "/Spel/_Gje opp"
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Spel/Slå på _lyd"
@@ -2024,7 +1872,6 @@ msgstr "/_Hjelp"
 msgid "/Help/_About..."
 msgstr "/Hjelp/_Om ..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Åtvaring"
@@ -2037,45 +1884,37 @@ msgstr "Feil"
 msgid "Message"
 msgstr "Melding"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Gje opp denne runden?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Avslutt spelet"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Start nytt spel"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Gje opp dette spelet"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Eignelutar"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Steng"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Mista sambandet til tenaren - byter til einspelar-modus"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
@@ -2084,7 +1923,6 @@ msgstr ""
 "Du har blitt dytta av tenaren.\n"
 "Byter til einspelar-modus."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
@@ -2093,18 +1931,15 @@ msgstr ""
 "Tenaren har avslutta.\n"
 "Byter til einspelar-modus."
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Reiser til %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Poengtavle"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "Poengtavlefila er øydelagt!"
@@ -2113,31 +1948,23 @@ msgstr "Poengtavlefila er øydelagt!"
 msgid "Fight"
 msgstr "Kjemp"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_Sel %tuf"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Kjemp"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Vent"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Røm"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Kamp: Horer/%d %tuf"
@@ -2155,13 +1982,10 @@ msgstr "(Daud)"
 msgid "Health: %d"
 msgstr "Helse: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "Du"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Horer/%Tuf"
@@ -2174,7 +1998,6 @@ msgstr "Narkotika"
 msgid "%/Inventory gun name/%tde"
 msgstr "Våpen"
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Reis til plass:"
@@ -2183,34 +2006,25 @@ msgstr "Reis til plass:"
 msgid "%/Location to jet to/%tde"
 msgstr "%/Plass å reisa til/%tde"
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "for %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "No har du på deg %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Ledig plass: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2232,7 +2046,6 @@ msgstr "Hiv"
 msgid "%/DealDrugs drug name/%tde"
 msgstr "%tuf"
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "Kjøpa kor mange?"
@@ -2245,13 +2058,13 @@ msgstr "Selja kor mange?"
 msgid "Drop how many?"
 msgstr "Hiva kor mange?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2272,8 +2085,6 @@ msgstr "Selja %tde"
 msgid "Drop %tde"
 msgstr "Hiva %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2292,27 +2103,22 @@ msgstr "_Angrip"
 msgid "_Evade"
 msgstr "_Dukk unna"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Spørsmål"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Plass"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Norsk omsetjing"
@@ -2349,49 +2155,38 @@ msgstr "Konstruktiv kritikk"
 msgid "Unconstructive Criticism"
 msgstr "Ukonstruktiv kritikk"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2400,159 +2195,121 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars er tilgjengeleg under GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"For informasjon om kommandolinevala, skriv dopewars -h på\n"
-"unix-kommandolinja. Det viser ein hjelpetekst med dei tilgjengelege vala.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Lokal dokumentasjon i HTML-format"
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Lånehai vindagustittel/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banknamn vindaugstittel/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "Du må skriva inn ei positiv mengde pengar!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Du har ikkje så mykje pengar i banken."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Kontantar: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Gjeld: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Bank: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Betal tilbake:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Sett inn"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Ta ut"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Betal alt"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Spelarliste"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Snakk med spelar(ar)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Snakk med alle spelarane"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Melding:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Send"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Namn"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Pris"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Mengde"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Kjøp ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Sel"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Hiv <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tuf her"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tuf du har"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Byt namn"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Diverre, nokon andre bruker «ditt» namn. Ver snill og byt det:-"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Våpenforretning-tittel/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2761,7 +2518,6 @@ msgstr "_Hjelp"
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kan ikkje starta spelet utan å velja eit namn!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nytt spel"
@@ -2774,28 +2530,20 @@ msgstr "Status: Ventar på brukaren"
 msgid "Connection closed by remote host"
 msgstr "Sambandet vart stengd av nettverksverten."
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Kunne ikkje kopla til (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Kopla til SOCKS-tenar %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Autentiserer mot SOCKS-tenar"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2805,7 +2553,6 @@ msgstr "Ber SOCKS om samband til %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Namnet ditt:"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Start spel for ein spelar"
@@ -2814,9 +2561,6 @@ msgstr "_Start spel for ein spelar"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2829,18 +2573,14 @@ msgstr ""
 "# oppsettfilene og slikt.\n"
 "\n"
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "dopewars-tenar"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "Datastyrt dopewars-spelar"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2853,14 +2593,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr "AD"
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2949,8 +2685,6 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Gjekk over MaxClients (%d) - bryt sambandet"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2959,8 +2693,6 @@ msgstr ""
 "Denne tenaren har ei grense på 1 spelar, og denne grensa har blitt nådd. "
 "^Prøv att seinare."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2970,9 +2702,6 @@ msgstr ""
 "Denne tenaren har ei grense på %d spelarar, og denne grensa har blitt^nådd. "
 "Prøv att seinare."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2983,15 +2712,10 @@ msgstr "%s kallar seg no for %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: NEKTA reise til %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Pushetida di er ute."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3032,7 +2756,6 @@ msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "dopewars-tenar versjon %s er klar og ventar på samband på port %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kan ikkje installera SIGUSR1-avbrotshandsamar!"
@@ -3075,8 +2798,6 @@ msgstr "Dyttar %s\n"
 msgid "No such user!\n"
 msgstr "Ingen slik brukar!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3327,8 +3048,6 @@ msgstr "Du møter ein venn! Han gjev deg %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du møter ein venn, og gjev han %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Luka vekk eit RandomOffer"
@@ -3422,8 +3141,6 @@ msgstr "Sambandet vart avbrote pga. fullt buffer"
 msgid "Internal error code %d"
 msgstr "Intern feilkode %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock har ikkje starta opp ordentleg"
@@ -3488,7 +3205,6 @@ msgstr "Protokollen er ikkje støtta"
 msgid "Socket type not supported"
 msgstr "Sokkeltypen er ikkje støtta"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Fann ikkje verten"
@@ -3681,7 +3397,6 @@ msgstr "Du plyndrar liket!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kan ikkje starta opp WinSock (%s)!"
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr "SOCKS server generell feil"
@@ -3730,7 +3445,6 @@ msgstr "SOCKS-autentiserer feila"
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-autentisering avbroten av brukar"
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Førespurnad vart avvist eller feila"
@@ -3743,7 +3457,6 @@ msgstr "SOCKS: Avslått - kan ikkje kontakta identd"
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Avslått - identd rapporterer ein annan brukaridentitet"
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr "Ukjend SOCKS svarkode"
@@ -3914,7 +3627,6 @@ msgstr "Puben er på %s\n"
 msgid "Bank located at %s\n"
 msgstr "Banken er på %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Og de kallar drykk dopseljarar?"
@@ -3958,6 +3670,20 @@ msgid ""
 msgstr ""
 "Ugyldig modul «%s» vald.\n"
 "(%s tilgjengeleg, brukar «%s» no.)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "For informasjon om kommandolinevala, skriv dopewars -h på\n"
+#~ "unix-kommandolinja. Det viser ein hjelpetekst med dei tilgjengelege "
+#~ "vala.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Lokal dokumentasjon i HTML-format"
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2001-04-08 16:16+01000\n"
 "Last-Translator: Slawomir Molenda <jeszua@panda.bg.univ.gda.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -15,46 +15,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "siedziba Złotych Pasów"
@@ -71,9 +55,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Port do połączenia"
@@ -555,9 +536,6 @@ msgstr "Lista rzeczy, które możesz przestać robić"
 msgid "Number of things which you can stop to do"
 msgstr "Liczba rzeczy, które możesz przestać robić"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -630,10 +608,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -654,22 +628,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -686,7 +656,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -703,8 +672,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -771,7 +738,6 @@ msgid ""
 "out!"
 msgstr "Świeża dostawa marihuany z Holandii! Ceny trawy lecą w dół"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -804,7 +770,6 @@ msgstr "Wiadomość"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -815,10 +780,6 @@ msgstr "Gliny zrobiły obławę na %tde ! Ceny towaru są kosmiczne!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Byłoby fajnie gdyby wszyscy wyszli na ulicę i się pieprzyli"
@@ -969,42 +930,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks w tablicy %s powinien być pomiędzy 1 i %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s jest %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s jest %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s jest %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s jest \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] jest %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1029,13 +978,10 @@ msgstr "Zmieniono strukturę listy do %d elementów\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1062,8 +1008,6 @@ msgstr ""
 msgid "dopewars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1148,8 +1092,6 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1262,7 +1204,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Tłumaczenie na polski         Slawomir Molenda"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D R E S S   W A R S"
@@ -1342,8 +1283,6 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "  twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Wprowadź nazwę hosta i port serwera dopewars:-"
@@ -1360,7 +1299,6 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Proszę czekać... próba kontaktu z metaserwerem..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1400,10 +1338,6 @@ msgstr "Komentarz: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>astępny serwer; P>oprzedni serwer; W>ybierz ten serwer... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NPW"
@@ -1438,14 +1372,10 @@ msgstr ""
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Proszę czekać... próba kontaktu z serwerem dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Nie mogę wystartować trybu multiplayer"
@@ -1471,20 +1401,15 @@ msgstr "          W>yjść (możesz uruchomić serwer pisząc "
 msgid "         or P>lay single-player ? "
 msgstr "          G>rać w trybie single-player"
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "PZWG"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Dokąd jedziesz ? "
@@ -1493,8 +1418,6 @@ msgstr "Dokąd jedziesz ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1508,7 +1431,6 @@ msgstr "Co chcesz zostawić? "
 msgid "How many do you drop? "
 msgstr "Ile chcesz zostawić? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Co chcesz kupić? "
@@ -1517,8 +1439,6 @@ msgstr "Co chcesz kupić? "
 msgid "What do you wish to sell? "
 msgstr "Co chcesz sprzedać? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1546,7 +1466,6 @@ msgstr "Na pewno chcesz wyjść? "
 msgid "YN"
 msgstr "YN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nowe imię: "
@@ -1570,7 +1489,6 @@ msgstr "%s dołączył do gry!"
 msgid "%s has left the game."
 msgstr "%s opuścił grę."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1595,50 +1513,34 @@ msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 msgid "H I G H   S C O R E S"
 msgstr "N A J L E P S Z E   W Y N I K I"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Nie masz żadnej %tde do sprzedania!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Nie masz nic do opchnięcia!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Będziesz potrzebował więcej %tde aby jeszcze unieść %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Nie masz wystarczająco dużo miejsca, aby unieść tę %tde!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Nie masz tyle kasy na %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "K>upić, S>przedać, czy W>yjść? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSW"
@@ -1647,40 +1549,27 @@ msgstr "KSW"
 msgid "How much money do you pay back? "
 msgstr "Ile forsy oddajesz Złotym Pasom? "
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "Nie masz tak dużo kasy!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Zamierzasz Z>deponować, W>ycofać gotówkę czy O>puścić bank? "
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ZWO"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Ile kasy? "
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Nie ma tyle gotówki w banku..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "T:Tak"
@@ -1709,45 +1598,31 @@ msgstr "E:Ewakuuj się"
 msgid "Press any key..."
 msgstr "Naciśnij dowolny klawisz..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Statystyka"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Kasa"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Zdrowie"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Bank"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Debet"
@@ -1757,8 +1632,6 @@ msgstr "Debet"
 msgid "Space %6d"
 msgstr "Miejsce %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Miejsce %6d"
@@ -1767,10 +1640,6 @@ msgstr "%Tde %3d  Miejsce %6d"
 msgid "Trenchcoat"
 msgstr "Twój płaszcz"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1779,13 +1648,11 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1796,13 +1663,10 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1815,14 +1679,11 @@ msgstr "Nie ma aktualnie innych zalogowanych graczy!"
 msgid "Players currently logged on:-"
 msgstr "Gracze aktualnie zalogowani:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hej cieciu, oto %tde jakie są w obiegu:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1835,7 +1696,6 @@ msgstr "Nie można obsłużyć przerwania SIGWINCH!"
 msgid "Hey there! What's your name? "
 msgstr "Jak się nazywasz cieciu? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "K>up"
@@ -1868,7 +1728,6 @@ msgstr " J>edź"
 msgid ", or Q>uit? "
 msgstr " W>yjście"
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Czy "
@@ -1885,7 +1744,6 @@ msgstr "S>toisz, "
 msgid "R>un, "
 msgstr "U>ciekasz, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1899,16 +1757,10 @@ msgstr "czy W>yjście "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Połączenie z serwerem zerwane! Włączenie trybu dla jednego gracza"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "KSUGPZDAJW"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "DUASW"
@@ -1917,7 +1769,6 @@ msgstr "DUASW"
 msgid "List what? P>layers or S>cores? "
 msgstr "Co chcesz zobaczyć? G>raczy W>yniki"
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "GW"
@@ -1926,7 +1777,6 @@ msgstr "GW"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Do kogo prywatnie zagadujesz ? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1936,7 +1786,6 @@ msgstr "Nawijaj: "
 msgid "Play again? "
 msgstr "Grasz jeszcze raz? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Gra"
@@ -1949,7 +1798,6 @@ msgstr "/Gra/_Nowa..."
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr ""
@@ -1982,7 +1830,6 @@ msgstr "/_Pomoc"
 msgid "/Help/_About..."
 msgstr "/Pomoc/_O programie..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Ostrzeżenie"
@@ -1995,70 +1842,58 @@ msgstr ""
 msgid "Message"
 msgstr "Wiadomość"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Zakończyć aktualną grę?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Wyjście z gry"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Rozpoczniej nową grę"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr ""
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Plecak"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Zamknij"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Połączenie z serwerem przerwane - włączenie trybu dla jednego gracza"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Podróż do miasta %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Najlepsze wyniki"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr ""
@@ -2067,31 +1902,23 @@ msgstr ""
 msgid "Fight"
 msgstr "Atak"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_Diluj %Tde"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Atakujesz"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Stoisz"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Uciekasz"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
@@ -2109,13 +1936,10 @@ msgstr ""
 msgid "Health: %d"
 msgstr "Zdrowie: %d"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr ""
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
@@ -2128,7 +1952,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Podróż"
@@ -2137,34 +1960,25 @@ msgstr "Podróż"
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "za %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Masz teraz %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Dostępne miejsce: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2186,7 +2000,6 @@ msgstr "Zostaw"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr ""
@@ -2199,13 +2012,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2226,8 +2039,6 @@ msgstr ""
 msgid "Drop %tde"
 msgstr ""
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2246,27 +2057,22 @@ msgstr "_Atakuj"
 msgid "_Evade"
 msgstr "_Ewakuuj się"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Pytanie"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Miejsce"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr ""
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Tłumaczenie na polski"
@@ -2303,49 +2109,38 @@ msgstr "Konstruktywna krytyka"
 msgid "Unconstructive Criticism"
 msgstr "Niekonstruktywna krytyka"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2354,159 +2149,121 @@ msgstr ""
 "Wersja %s    Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars są publikowane zgodnie z GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
-msgstr ""
-"\n"
-"Informacje o komendach linni poleceń uzyskasz piszać dopewars -h po\n"
-"twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami.\n"
-
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
 
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Nie ma tyle gotówki w banku..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Kasa: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Debet: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Bank %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Zwróć:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Depozyt"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Wycofaj się"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Spłać wszystko"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Lista graczy"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Mów do gracza(y)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Mów do wszystkich graczy"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Wiadomość:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Wyślij"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nazwa"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Cena"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Ilość"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Kup ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Sprzedaj"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Zostaw <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde na rynku"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde w plecaku"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Zmień nicka"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2715,7 +2472,6 @@ msgstr "_Pomoc"
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nowa Gra"
@@ -2728,28 +2484,20 @@ msgstr "Status: Czekam na aktywność usera"
 msgid "Connection closed by remote host"
 msgstr ""
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Nie mogę się połączyć (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2759,7 +2507,6 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr "Jak się _nazywasz cieciu?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Rozpocznij grę dla jednego gracza"
@@ -2768,9 +2515,6 @@ msgstr "_Rozpocznij grę dla jednego gracza"
 msgid "_Select"
 msgstr ""
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2779,18 +2523,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr ""
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr ""
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2803,14 +2543,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr ""
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2890,8 +2626,6 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) przekoroczona wartość - zrywam połączenie"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2900,8 +2634,6 @@ msgstr ""
 "Przykro mi, ale serwer ma limit do 1 gracza, który został osiągnięty. "
 "^Proszę spróbować połączyć się później."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2911,9 +2643,6 @@ msgstr ""
 "Przykro mi, ale serwer ma limit %d graczy, który został osiągnięty.^Proszę "
 "spróbować połączyć się później."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2924,15 +2653,10 @@ msgstr "%s będzie znany jako %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: ZABRONIONY przejazd do %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Twój czas dilerki dobiegł końca..."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -2973,7 +2697,6 @@ msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "serwer dopewars w wersji %s gotowy i oczekuje połączeńna porcie %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGUSR1!"
@@ -3016,8 +2739,6 @@ msgstr "Wywalam %s\n"
 msgid "No such user!\n"
 msgstr "Nie ma takiego użytkownika!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3248,8 +2969,6 @@ msgstr "Spotykasz starego dilera! Daje ci %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Spotkałeś przyjaciela! Dajesz mu %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Wyłączono RandomOffer"
@@ -3344,8 +3063,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3410,7 +3127,6 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3603,7 +3319,6 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
@@ -3652,7 +3367,6 @@ msgstr ""
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
@@ -3665,7 +3379,6 @@ msgstr ""
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
@@ -3831,7 +3544,6 @@ msgstr "Dyskoteka jest w mieście %s\n"
 msgid "Bank located at %s\n"
 msgstr "Bank jest w mieście %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Nazywacie się dilerami?"
@@ -3873,6 +3585,16 @@ msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Informacje o komendach linni poleceń uzyskasz piszać dopewars -h po\n"
+#~ "twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami.\n"
 
 #, c-format
 #~ msgid "Status: Attempting to contact %s..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: dopewars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 12:54+0000\n"
+"POT-Creation-Date: 2025-08-12 13:54+0000\n"
 "PO-Revision-Date: 2022-06-10 23:06-0300\n"
 "Last-Translator: Bruno Lopes <brunoml@bol.com.br>\n"
 "Language-Team: Portuguese/Brazil <pt_BR@li.org>\n"
@@ -16,46 +16,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Name of a single bitch - if you need to use different words for
-#. "bitch" depending on where in the sentence it occurs (e.g. subject or
-#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
-#. This notation can be used for most of the translatable strings in
-#. dopewars.
 #: src/dopewars.c:180
 msgid "cleric"
 msgstr ""
 
-#. Word used for two or more bitches
 #: src/dopewars.c:182
 msgid "clerics"
 msgstr ""
 
-#. Word used for a single gun
 #: src/dopewars.c:184
 msgid "weapon"
 msgstr ""
 
-#. Word used for two or more guns
 #: src/dopewars.c:186
 msgid "weapons"
 msgstr ""
 
-#. Word used for a single drug
-#. Word used for two or more drugs
 #: src/dopewars.c:188 src/dopewars.c:190
 msgid "goods"
 msgstr ""
 
-#. String for displaying the game date or turn number. This is passed
-#. to the strftime() function, with the exception that %T is used to
-#. mean the turn number rather than the calendar date.
-#. N_("%m-%d-%Y"),
 #: src/dopewars.c:195
 msgid "Turn %T"
 msgstr ""
 
-#. Names of the loan shark, the bank, the gun shop, and the pub,
-#. respectively
 #: src/dopewars.c:198
 msgid "the Loan Collector"
 msgstr "o agiota"
@@ -72,9 +56,6 @@ msgstr ""
 msgid "Holy Mass"
 msgstr ""
 
-#. The following strings are the helptexts for all the options that can
-#. be set in a dopewars configuration file, or in the server. See
-#. doc/configfile.html for more detailed explanations.
 #: src/dopewars.c:238
 msgid "Network port to connect to"
 msgstr "Porta de rede para conectar"
@@ -556,9 +537,6 @@ msgstr "Lista de coisas que você pode parar de fazer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de coisas que você pode parar de fazer"
 
-#. Default list of songs that you can hear playing (N.B. this can be
-#. overridden in the configuration file with the "Playing" variable) -
-#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -631,10 +609,6 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
-#. Default list of things which you can "stop to do" (random events that
-#. cost you a little money). These can be overridden with the "StoppedTo"
-#. variable in the configuration file. See the later string "You stopped
-#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -655,22 +629,18 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
-#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
-#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
-#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
-#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -687,7 +657,6 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
-#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -704,8 +673,6 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
-#. The names of the default drugs, and the messages displayed when they
-#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -772,7 +739,6 @@ msgid ""
 "out!"
 msgstr "Colombianos enganaram a Guarda Costeira! Preços de maconha abaixaram!"
 
-#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -805,7 +771,6 @@ msgstr "Mensagem"
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -816,10 +781,6 @@ msgstr "Policiais apreenderam %tde! Preços estão super altos!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Viciados estão comprando %tde a preços ridículos!"
 
-#. Default list of things which the "lady on the subway" can tell you
-#. (N.B. can be overridden with the "SubwaySaying" config. file
-#. variable). Look for "the lady next to you" to see how these strings
-#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Não seria engraçado se todos tivessem de uma vez só?"
@@ -972,42 +933,30 @@ msgstr ""
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Índice da array %s deve ser entre 1 e %d"
 
-#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
 #: src/dopewars.c:1996
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s é %d\n"
 
-#. Display of a boolean config. file variable - e.g. "DrugValue is
-#. TRUE"
 #: src/dopewars.c:2001
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s é %s\n"
 
-#. Display of a price config. file variable - e.g. "Bitch.MinPrice is
-#. $200"
 #: src/dopewars.c:2007
 msgid "%s is %P\n"
 msgstr "%s é %P\n"
 
-#. Display of a string config. file variable - e.g. "LoanSharkName is
-#. \"the loan shark\""
 #: src/dopewars.c:2012
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s é \"%s\"\n"
 
-#. Display of an indexed string list config. file variable - e.g.
-#. "StoppedTo[1] is have a beer"
 #: src/dopewars.c:2018
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] é %s\n"
 
-#. Display of the first part of an entire string list config. file
-#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
-#. "smoke a joint" etc.)
 #: src/dopewars.c:2027
 #, c-format
 msgid "%s is { "
@@ -1032,13 +981,10 @@ msgstr "Estrutura de lista redimensionada para %d elementos\n"
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Valor booleano esperado (om dentre 0, FALSE, 1, TRUE)"
 
-#. The currency symbol
 #: src/dopewars.c:2319
 msgid "£"
 msgstr ""
 
-#. Translate this to "Currency.Prefix=FALSE" if you want your currency
-#. symbol to follow all prices.
 #: src/dopewars.c:2323
 msgid "Currency.Prefix=TRUE"
 msgstr ""
@@ -1069,8 +1015,6 @@ msgstr "(%s dispnível)\n"
 msgid "dopewars version %s\n"
 msgstr "dopewars versão %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
 #: src/dopewars.c:2471
 #, c-format
 msgid ""
@@ -1159,8 +1103,6 @@ msgstr ""
 "dopewars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
 #: src/dopewars.c:2508
 #, c-format
 msgid ""
@@ -1283,7 +1225,6 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Tradução de Portugal            Bruno Lopes"
 
-#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1369,8 +1310,6 @@ msgstr ""
 "prompt Unix. Isto irá mostrar a tela de ajudam listando as opções "
 "disponíveis."
 
-#. Prompts for hostname and port when selecting a server
-#. manually
 #: src/curses_client/curses_client.c:401
 msgid "Please enter the hostname and port of a dopewars server:-"
 msgstr "Por favor entre com o nome do host e porta do servidor dopewars:-"
@@ -1387,7 +1326,6 @@ msgstr "Porta"
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Aguarde... tentando contactar o servidor meta..."
 
-#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1427,10 +1365,6 @@ msgstr "Comentário: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "P>róximo servidor; A>nterior; S>elecionar este servidor... "
 
-#. The three keys that are valid responses to the previous question -
-#. if you translate them, keep the keys in the same order (N>ext,
-#. P>revious, S>elect) as they are here, otherwise they'll do the
-#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "PAS"
@@ -1466,14 +1400,10 @@ msgstr "Senha: "
 msgid "Please wait... attempting to contact dopewars server..."
 msgstr "Aguarde... tentando contactar o servidor dopewars..."
 
-#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Não foi possível obter detalhes do metaservidor"
 
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
 #: src/curses_client/curses_client.c:717
 msgid "Could not start multiplayer dopewars"
 msgstr "Não foi possível iniciar o dopewars em multiplayer"
@@ -1499,20 +1429,15 @@ msgstr "            S>air (onde você pode iniciar um servidor digitando "
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ogar com apenas um jogador ? "
 
-#. Translate these 4 keys in line with the above options, keeping
-#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
-#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#. Prompt when the player chooses to "jet" to a new location
-#. Prompt in 'Jet' dialog
 #: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
 msgid "Where to, trader ? "
 msgstr "Para onde, cara ? "
@@ -1521,8 +1446,6 @@ msgstr "Para onde, cara ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
-#. List of drugs that you can drop (%tde = "drugs" by
-#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1536,7 +1459,6 @@ msgstr "O que você quer largar? "
 msgid "How many do you drop? "
 msgstr "Que quantidade você quer largar? "
 
-#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "O que você quer comprar? "
@@ -1545,8 +1467,6 @@ msgstr "O que você quer comprar? "
 msgid "What do you wish to sell? "
 msgstr "O que você quer vender? "
 
-#. Display of number of drugs you could buy and/or carry, when
-#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1574,7 +1494,6 @@ msgstr "Você tem certeza que quer sair? "
 msgid "YN"
 msgstr "SN"
 
-#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Novo nome: "
@@ -1598,7 +1517,6 @@ msgstr "%s entrou no jogo!"
 msgid "%s has left the game."
 msgstr "%s saiu do jogo."
 
-#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1623,50 +1541,34 @@ msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o.
 msgid "H I G H   S C O R E S"
 msgstr "M E L H O R E S   P O N T U A Ç Õ E S"
 
-#. Error - player tried to sell guns that he/she doesn't have
-#. (%tde="guns" by default)
 #: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Você não tem nenhum %tde para vender!"
 
-#. Error - player tried to sell some guns that he/she doesn't have
 #: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
 msgid "You don't have any to sell!"
 msgstr "Você não tem nenhum para vender!"
 
-#. Error - player tried to buy more guns
-#. than his/her bitches can carry (1st
-#. %tde="bitches", 2nd %tde="guns" by
-#. default)
 #: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Você irá precisar de mais %tde para carregar ainda mais %tde!"
 
-#. Error - player tried to buy a gun that he/she doesn't have
-#. space for (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Você não tem espaço suficiente para carregar aquele %tde!"
 
-#. Error - player tried to buy a gun that he/she can't afford
-#. (%tde="gun" by default)
 #: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Você não tem dinheiro suficiente para comprar aquele %tde!"
 
-#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Você irá C>omprar, V>ender, ou S>air? "
 
-#. Translate these three keys in line with the above options, keeping
-#. the order (B>uy, S>ell, L>eave) the same - you can change the
-#. wording of the prompt, but if you change the order in this key
-#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVS"
@@ -1675,40 +1577,27 @@ msgstr "CVS"
 msgid "How much money do you pay back? "
 msgstr "Quanto dinheiro você quer pagar de volta? "
 
-#. Error - player doesn't have enough money to pay back the loan
-#. Error - player has tried to put more money into the bank than
-#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2482
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
 msgid "You don't have that much money!"
 msgstr "Você não tem todo esse dinheiro!"
 
-#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Você quer D>epositar dinheiro, R>etirar dinheiro, ou S>air ? "
 
-#. Make sure you keep the order the same if you translate these keys!
-#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
-#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Quanto dinheiro? "
 
-#. Error - player has tried to withdraw more money from the bank
-#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Não há todo este dinheiro no banco..."
 
-#. Expansions of the single-letter keypresses for the benefit of the
-#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
-#. to the user which letter in the word corresponds to the keypress, by
-#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sim"
@@ -1737,45 +1626,31 @@ msgstr "E:Evacuar"
 msgid "Press any key..."
 msgstr "Pressione qualquer tecla..."
 
-#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#. Title of the "Stats" window in the curses client
 #: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
 msgid "Stats"
 msgstr "Estatísticas"
 
-#. Display of the player's cash in the stats window
-#. Player's cash label in GTK+ client status display
 #: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
 msgid "Cash"
 msgstr "Dinheiro"
 
-#. Display of the total number of guns carried (%Tde="Guns" by default)
-#. Title of the "guns" window (the only important bit in this string
-#. is the "%Tde" which is "Guns" by default)
-#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
 #: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#. Display of the player's health
-#. Player's health label in GTK+ client status display
 #: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
 msgid "Health"
 msgstr "Pontos de vida"
 
-#. Display of the player's bank balance
-#. Player's bank balance label in GTK+ client status display
 #: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
 msgid "Bank"
 msgstr "Banco"
 
-#. Display of the player's debt
-#. Player's debt label in GTK+ client status display
 #: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
 msgid "Debt"
 msgstr "Débito"
@@ -1785,8 +1660,6 @@ msgstr "Débito"
 msgid "Space %6d"
 msgstr "Espaço %6d"
 
-#. Display of the player's number of bitches, and available space
-#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espaço %6d"
@@ -1795,10 +1668,6 @@ msgstr "%Tde %3d  Espaço %6d"
 msgid "Trenchcoat"
 msgstr "Casaco"
 
-#. Title of the "drugs" window (the only important bit in this
-#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
-#. is ignored, so you don't need to translate it; see doc/i18n.html)
-#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Estatísticas: Drogas/%Tde"
@@ -1807,13 +1676,11 @@ msgstr "%/Estatísticas: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
-#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
-#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1824,13 +1691,10 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
-#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
-#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Estatísticas: Drogas/%Tde"
 
-#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1843,14 +1707,11 @@ msgstr "Nenhum outro jogador está atualmente logado!"
 msgid "Players currently logged on:-"
 msgstr "Jogadores atualmente logados:-"
 
-#. Display of drug prices (%tde="drugs" by default)
 #: src/curses_client/curses_client.c:2305
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Ei carinha, os preços de %tde aqui estão:"
 
-#. List of individual drug names for selection (%tde="Opium" etc.
-#. by default)
 #: src/curses_client/curses_client.c:2316
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
@@ -1863,7 +1724,6 @@ msgstr "Não foi possível instalar o sinal de interrupção SIGWINCH!"
 msgid "Hey there! What's your name? "
 msgstr "Ei carinha, qual seu nome? "
 
-#. Prompts for "normal" actions in curses client
 #: src/curses_client/curses_client.c:2423
 msgid "Will you B>uy"
 msgstr "Você irá C>omprar"
@@ -1896,7 +1756,6 @@ msgstr ", I>r"
 msgid ", or Q>uit? "
 msgstr ", ou S>air? "
 
-#. Prompts for actions during fights in curses client
 #: src/curses_client/curses_client.c:2445
 msgid "Do you "
 msgstr "Você quer "
@@ -1913,7 +1772,6 @@ msgstr "F>icar paradão, "
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#. (%tde = "drugs" by default here)
 #: src/curses_client/curses_client.c:2457
 #, c-format
 msgid "D>eal %tde, "
@@ -1927,16 +1785,10 @@ msgstr "ou S>air? "
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Conexão com o servidor perdida! Revertendo para o modo de um jogador"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
-#. L>ist, F>ight, J>et, Q>uit)
 #: src/curses_client/curses_client.c:2548
 msgid "BSDTPLFJQ"
 msgstr "CVLFPJDLIS"
 
-#. N.B. You must keep the order of these keys the same as the
-#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
-#. Q>uit)
 #: src/curses_client/curses_client.c:2554
 msgid "DRFSQ"
 msgstr "TCLFS"
@@ -1945,7 +1797,6 @@ msgstr "TCLFS"
 msgid "List what? P>layers or S>cores? "
 msgstr "Listar o que? J>ogadores ou P>ontuações? "
 
-#. P>layers, S>cores
 #: src/curses_client/curses_client.c:2586
 msgid "PS"
 msgstr "JP"
@@ -1954,7 +1805,6 @@ msgstr "JP"
 msgid "Whom do you want to page (talk privately to) ? "
 msgstr "Quem você quer pagear (falar privadamente) ? "
 
-#. Prompt for sending player-player messages
 #: src/curses_client/curses_client.c:2605
 #: src/curses_client/curses_client.c:2619
 msgid "Talk: "
@@ -1964,7 +1814,6 @@ msgstr "Fale: "
 msgid "Play again? "
 msgstr "Jogar novamente? "
 
-#. The names of the menus and their items in the GTK+ client
 #: src/gui_client/gtk_client.c:154
 msgid "/_Game"
 msgstr "/_Jogo"
@@ -1977,7 +1826,6 @@ msgstr "/Jogo/_Novo..."
 msgid "/Game/_Abandon..."
 msgstr "/Jogo/_Abandonar"
 
-#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
 #: src/gui_client/gtk_client.c:158
 msgid "/Game/Enable _sound"
 msgstr "/Jogo/_Habilitar som"
@@ -2010,7 +1858,6 @@ msgstr "/_Ajuda"
 msgid "/Help/_About..."
 msgstr "/Ajuda/_Sobre..."
 
-#. Titles of the message boxes for warnings and errors
 #: src/gui_client/gtk_client.c:179
 msgid "Warning"
 msgstr "Aviso"
@@ -2023,70 +1870,58 @@ msgstr "Erro"
 msgid "Message"
 msgstr "Mensagem"
 
-#. Prompt in 'quit game' dialog
 #: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
 #: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
 msgid "Abandon current game?"
 msgstr "Abandonar jogo atual?"
 
-#. Title of 'quit game' dialog
 #: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
 msgid "Quit Game"
 msgstr "Sair do Jogo"
 
-#. Title of 'stop game to start a new game' dialog
 #: src/gui_client/gtk_client.c:250
 msgid "Start new game"
 msgstr "Iniciar um novo jogo"
 
-#. Title of 'abandon game' dialog
 #: src/gui_client/gtk_client.c:272
 msgid "Abandon game"
 msgstr "Abandonar jogo"
 
-#. Title of inventory window
 #: src/gui_client/gtk_client.c:314
 msgid "Inventory"
 msgstr "Inventário"
 
 #: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2642 src/gui_client/gtk_client.c:2782
-#: src/gui_client/gtk_client.c:3077 src/gui_client/gtk_client.c:3132
+#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
+#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fechar"
 
-#. The network connection to the server was dropped unexpectedly
 #: src/gui_client/gtk_client.c:393
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Conexão com o servidor perdida - mudando para modo de um jogador"
 
-#. The server admin has asked us to leave - so warn the user, and do
-#. so
 #: src/gui_client/gtk_client.c:461
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Você foi tirado do servidor. Revertendo para modo de um jogador."
 
-#. The server has sent us notice that it is shutting down
 #: src/gui_client/gtk_client.c:469
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "O servidor foi terminado. Revertendo para modo de um jogador."
 
-#. Message displayed when the player "jets" to a new location
 #: src/gui_client/gtk_client.c:526
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Indo para %tde"
 
-#. Title of the GTK+ high score dialog
 #: src/gui_client/gtk_client.c:586
 msgid "High Scores"
 msgstr "Melhores Pontuações"
 
-#. Error - the high score from the server is invalid
 #: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
 msgid "Corrupt high score!"
 msgstr "Highscore corrompido!"
@@ -2095,31 +1930,23 @@ msgstr "Highscore corrompido!"
 msgid "Fight"
 msgstr "Lutar"
 
-#. Button for closing the "Fight" dialog and going back to dealing drugs
-#. (%Tde = "Drugs" by default)
 #: src/gui_client/gtk_client.c:890
 msgid "_Deal %Tde"
 msgstr "_Traficar %Tde"
 
-#. Button for shooting at other players in the "Fight" dialog, or for
-#. popping up the "Fight" dialog from the main window
 #: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
 #: src/gui_client/gtk_client.c:2077
 msgid "_Fight"
 msgstr "_Lutar"
 
-#. Button to stand and take it in the "Fight" dialog
 #: src/gui_client/gtk_client.c:901
 msgid "_Stand"
 msgstr "_Ficar parado"
 
-#. Button to run from combat in the "Fight" dialog
 #: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
 msgid "_Run"
 msgstr "_Correr"
 
-#. Display of number of bitches or deputies during combat
-#. (%tde="bitches" or "deputies" (etc.) by default)
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
@@ -2137,13 +1964,10 @@ msgstr "(Morto)"
 msgid "Health: %d"
 msgstr "(Pontos de vida: %d)"
 
-#. Display of the current player's name during combat
 #: src/gui_client/gtk_client.c:997
 msgid "You"
 msgstr "(Você)"
 
-#. Display of number of bitches in GTK+ client status window
-#. (%Tde="Bitches" by default)
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/Estatísticas: Putas/%Tde"
@@ -2156,7 +1980,6 @@ msgstr ""
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#. Title of 'Jet' dialog
 #: src/gui_client/gtk_client.c:1404
 msgid "Travel to location"
 msgstr "Ir para o local"
@@ -2165,34 +1988,25 @@ msgstr "Ir para o local"
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
-#. default)
 #: src/gui_client/gtk_client.c:1456
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#. Display of the current price of the selected drug in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1491
 msgid "at %P"
 msgstr "em %P"
 
-#. Display of current inventory of the selected drug in 'Deal Drugs'
-#. dialog (%tde="Opium" etc. by default)
 #: src/gui_client/gtk_client.c:1498
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Você está atualmente carregando %d %tde"
 
-#. Available space for drugs in 'Deal Drugs' dialog
 #: src/gui_client/gtk_client.c:1505
 #, c-format
 msgid "Available space: %d"
 msgstr "Espaço disponível: %d"
 
-#. Number of the selected drug that you can afford in 'Deal Drugs'
-#. dialog
 #: src/gui_client/gtk_client.c:1518
 #, c-format
 msgid "You can afford %d"
@@ -2214,7 +2028,6 @@ msgstr "Largar"
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#. Prompts for action in the "deal drugs" dialog
 #: src/gui_client/gtk_client.c:1701
 msgid "Buy how many?"
 msgstr "Comprar que quantidade?"
@@ -2227,13 +2040,13 @@ msgstr "Vender que quantidade?"
 msgid "Drop how many?"
 msgstr "Largar que quantidade?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2414
-#: src/gui_client/gtk_client.c:2583 src/gui_client/gtk_client.c:3023
+#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
+#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2595
+#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
 #: src/gtkport/gtkport.c:5507
 msgid "_Cancel"
@@ -2254,8 +2067,6 @@ msgstr "Vender %tde"
 msgid "Drop %tde"
 msgstr "Largar %tde"
 
-#. Button titles that correspond to the single-keypress options provided
-#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
 #: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
 #: src/gtkport/gtkport.c:5381
 msgid "_Yes"
@@ -2274,27 +2085,22 @@ msgstr "_Atacar"
 msgid "_Evade"
 msgstr "_Evacuar"
 
-#. Title of the 'ask player a question' dialog
 #: src/gui_client/gtk_client.c:1863
 msgid "Question"
 msgstr "Pergunta"
 
-#. Available space label in GTK+ client status display
 #: src/gui_client/gtk_client.c:2017
 msgid "Space"
 msgstr "Espaço"
 
-#. Caption of 'Jet' button in main window
 #: src/gui_client/gtk_client.c:2080
 msgid "_Travel!"
 msgstr ""
 
-#. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
 msgid "dopewars"
 msgstr "dopewars"
 
-#. Credits labels in GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2306
 msgid "English Translation"
 msgstr "Tradução de Portugal"
@@ -2331,49 +2137,38 @@ msgstr "Crítica Construtiva"
 msgid "Unconstructive Criticism"
 msgstr "Crítica não construtiva"
 
-#. Title of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2323
 msgid "About Church Wars"
 msgstr ""
 
-#. Main content of GTK+ 'about' dialog
 #: src/gui_client/gtk_client.c:2334
 msgid ""
-"It’s AD 1095, and the Crusades\n"
-"are about to begin. As a famed\n"
-"Trader-Saint, Pope Urban II has\n"
-"charged you with a sacred\n"
-"mission—cross the medieval world,\n"
-"trade valuable goods, and amass\n"
-"wealth to fund the Holy Christian\n"
-"Church’s coming crusade. The\n"
-"Empire of the Holy Trinity depends\n"
-"on you.\n"
-"Inspired by John E. Dell’s Drug\n"
-"Wars, Church Wars is a simulation\n"
-"of an imaginary Crusader market of\n"
-"buying, selling, and financing the\n"
-"Holy Christian Empire. Your first\n"
-"task is to clear your debt to the\n"
-"Pope’s Loan Collector in Jerusalem -\n"
-"interest grows each turn until it’s\n"
-"paid. After that, you have 30 travels\n"
-"to survive and build a fortune for\n"
-"the Kingdom.\n"
-"Clerics in the Hagia Sophia add 20\n"
-"space to your starting 40, grant one\n"
-"weapon slot, and take damage for you\n"
-"in fights. The Hall of Arms, also\n"
-"there, prepares you for battle. The\n"
-"Merchant Bank in Jerusalem keeps\n"
-"your gold safe.\n"
+"It’s AD 1095, and the Crusades are about to begin.\n"
+"As a famed Trader-Saint, Pope Urban II has\n"
+"charged you with a sacred mission—cross the medieval\n"
+"world, trade valuable goods, and amass wealth to fund\n"
+"the Holy Christian Church’s coming crusade. The Empire\n"
+"of the Holy Trinity depends on you.\n"
 "\n"
-"“Though a mighty army surrounds me,\n"
-"my heart will not be afraid!”\n"
+"Inspired by John E. Dell’s Drug Wars, Church Wars\n"
+"is a simulation of an imaginary Crusader market of\n"
+"buying, selling, and financing the Holy Christian Empire.\n"
+"Your first task is to clear your debt to\n"
+"the Pope’s Loan Collector in Jerusalem - interest\n"
+"grows each turn until it’s paid. After that, you have 30\n"
+"travels to survive and build a fortune for the Kingdom.\n"
+"\n"
+"Clerics in the Hagia Sophia add 20 space to\n"
+"your starting 40, grant one weapon slot, and\n"
+"take damage for you in fights. The Hall of Arms,\n"
+"also there, prepares you for battle. The Merchant\n"
+"Bank in Jerusalem keeps your gold safe.\n"
+"\n"
+"“Though a mighty army surrounds me, my heart will not\n"
+"be afraid!”\n"
 msgstr ""
 
-#. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2361
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2382,161 +2177,121 @@ msgstr ""
 "Versão %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "dopewars está lançado sob a GNU General Public License\n"
 
-#. Label at the bottom of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2397
-msgid ""
-"\n"
-"For information on the command line options, type dopewars -h at your\n"
-"Unix prompt. This will display a help screen, listing the available "
-"options.\n"
+#: src/gui_client/gtk_client.c:2389
+msgid "Original dopewars information here:"
 msgstr ""
-"\n"
-"Para informações sobre opções de linha de comando, digite dopewars -h no "
-"seu\n"
-"prompt Unix. Isto irá mostrar a tela de ajuda, listando as opções "
-"disponíveis.\n"
 
-#: src/gui_client/gtk_client.c:2404
-msgid "Local HTML documentation"
-msgstr "Documentação local em HTML"
-
-#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2460 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título da janela do agiota/%Tde"
 
-#. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2467 src/gui_client/gtk_client.c:2516
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título da janela do NomeDoBanco/%Tde"
 
-#: src/gui_client/gtk_client.c:2476
+#: src/gui_client/gtk_client.c:2458
 msgid "You must enter a positive amount of money!"
 msgstr "Você precisa entrar uma quantidade positiva de dinheiro!"
 
-#: src/gui_client/gtk_client.c:2479
+#: src/gui_client/gtk_client.c:2461
 msgid "There isn't that much money available..."
 msgstr "Não há todo este dinheiro no banco..."
 
-#. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2532
+#: src/gui_client/gtk_client.c:2514
 msgid "Cash: %P"
 msgstr "Dinheiro: %P"
 
-#. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2520
 msgid "Debt: %P"
 msgstr "Débito: %P"
 
-#. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2541
+#: src/gui_client/gtk_client.c:2523
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2531
 msgid "Pay back:"
 msgstr "Pagar de volta:"
 
-#. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2553
+#: src/gui_client/gtk_client.c:2535
 msgid "Deposit"
 msgstr "Depositar"
 
-#. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2559
+#: src/gui_client/gtk_client.c:2541
 msgid "Withdraw"
 msgstr "Retirar"
 
-#. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2590
+#: src/gui_client/gtk_client.c:2572
 msgid "Pay all"
 msgstr "Pagar tudo"
 
-#. Title of player list dialog
-#: src/gui_client/gtk_client.c:2621
+#: src/gui_client/gtk_client.c:2603
 msgid "Player List"
 msgstr "Lista de jogadores"
 
-#. Title of talk dialog
-#: src/gui_client/gtk_client.c:2733
+#: src/gui_client/gtk_client.c:2715
 msgid "Talk to player(s)"
 msgstr "Falar com jogador(es)"
 
-#. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2755
+#: src/gui_client/gtk_client.c:2737
 msgid "Talk to all players"
 msgstr "Falar com todos os jogadores"
 
-#. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2743
 msgid "Message:-"
 msgstr "Mensagem:-"
 
-#. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2776
+#: src/gui_client/gtk_client.c:2758
 msgid "Send"
 msgstr "Mandar"
 
-#. Column titles for display of drugs/guns carried or available for
-#. purchase
-#: src/gui_client/gtk_client.c:2857 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nome"
 
-#: src/gui_client/gtk_client.c:2858 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preço"
 
-#: src/gui_client/gtk_client.c:2859
+#: src/gui_client/gtk_client.c:2841
 msgid "Number"
 msgstr "Número"
 
-#. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2844
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2845
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2864
+#: src/gui_client/gtk_client.c:2846
 msgid "_Drop <-"
 msgstr "_Largar <-"
 
-#. Title of the display of available drugs/guns (%Tde = "Guns" or
-#. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2871
+#: src/gui_client/gtk_client.c:2853
 msgid "%Tde here"
 msgstr "%Tde aqui"
 
-#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
-#. by default)
-#: src/gui_client/gtk_client.c:2877
+#: src/gui_client/gtk_client.c:2859
 msgid "%Tde carried"
 msgstr "%Tde carregados"
 
-#. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2996
+#: src/gui_client/gtk_client.c:2978
 msgid "Change Name"
 msgstr "Mudar Nome"
 
-#. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3009
+#: src/gui_client/gtk_client.c:2991
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o:-"
 
-#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
-#. by default)
-#: src/gui_client/gtk_client.c:3054
+#: src/gui_client/gtk_client.c:3036
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/Título da janela da LojaDeArmas/%Tde"
 
-#. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3116
+#: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
 
@@ -2745,7 +2500,6 @@ msgstr "_Ajudar"
 msgid "You can't start the game without giving a name first!"
 msgstr "Você não pode iniciar um jogo antes de dar a ele um nome!"
 
-#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Novo Jogo"
@@ -2758,28 +2512,20 @@ msgstr "Status: Esperando por algo do usuário"
 msgid "Connection closed by remote host"
 msgstr "Conexão encerrada pelo host remoto"
 
-#. Error: GTK+ client could not connect to the given dopewars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Não foi possível conectar (%s)"
 
-#. Tell the user that we've successfully connected to a SOCKS server,
-#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Conectado ao servidor SOCKS %s..."
 
-#. Tell the user that the SOCKS server is asking us for a username
-#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Statis: Autenticando com o servidor SOCKS"
 
-#. Tell the user that all necessary SOCKS authentication has been
-#. completed, and now we're going to try to have it connect to
-#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2789,7 +2535,6 @@ msgstr "Status: Pedindo ao SOCKS para conectar a %s.."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Ei carinha, qual o seu _nome?"
 
-#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Iniciar jogo de um jogador"
@@ -2798,9 +2543,6 @@ msgstr "_Iniciar jogo de um jogador"
 msgid "_Select"
 msgstr "_Selecionar"
 
-#. Informational comment placed at the start of the Windows log file
-#. (this is used for messages printed during processing of the config
-#. files - under Unix these are just printed to stdout)
 #: src/winmain.c:307
 msgid ""
 "# This is the dopewars startup log, containing any\n"
@@ -2809,18 +2551,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#. Title of dopewars server window (if used)
 #: src/winmain.c:348 src/serverside.c:1621
 msgid "dopewars server"
 msgstr "servidor dopewars"
 
-#. Title of the Windows window used for AI player output
 #: src/winmain.c:369
 msgid "dopewars AI"
 msgstr "IA dopewars"
 
-#. Things that can "happen" to your spies - look for strings containing
-#. "The spy %s!" to see how these strings are used.
 #: src/serverside.c:73
 msgid "escaped"
 msgstr ""
@@ -2833,14 +2571,10 @@ msgstr ""
 msgid "was attacked"
 msgstr ""
 
-#. The two keys that are valid answers to the Attack/Evade question. If
-#. you wish to translate them, do so in the same order as they given here.
-#. You will also need to translate the answers given by the clients.
 #: src/serverside.c:79
 msgid "AE"
 msgstr ""
 
-#. Help on various general server commands
 #: src/serverside.c:129
 #, c-format
 msgid ""
@@ -2921,8 +2655,6 @@ msgstr ""
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClientes (%d) excedido - cancelando conexão"
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:398
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
@@ -2931,8 +2663,6 @@ msgstr ""
 "Desculpe, mas este servidor tem um limite de 1 jogador, ao qual foi "
 "alcançado. Por favor tente conectar mais tarde."
 
-#. Message sent to a player if the
-#. server is full
 #: src/serverside.c:405
 #, c-format
 msgid ""
@@ -2942,9 +2672,6 @@ msgstr ""
 "Desculpe, mas este servidor tem um limite de %d jogadores, ao qual foi "
 "alcançado. Por favor tente conectar mais tarde."
 
-#. A player changed their name during the game (unusual, and not
-#. really properly supported anyway) - notify all players of the
-#. change
 #: src/serverside.c:421
 #, c-format
 msgid "%s will now be known as %s"
@@ -2955,15 +2682,10 @@ msgstr "%s será conhecido como %s"
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: RECUSADO ir para local inválido %s"
 
-#. Message displayed when a player reaches their maximum number of
-#. turns
 #: src/serverside.c:455
 msgid "Your trading time is up..."
 msgstr "Seu tempo de tráfico acabou..."
 
-#. A player has tried to jet to a new location, but we don't allow
-#. them to. (e.g. they're still fighting someone, or they're
-#. supposed to be dead)
 #: src/serverside.c:474
 #, c-format
 msgid "%s: DENIED travel to %s"
@@ -3006,7 +2728,6 @@ msgstr ""
 "servidor dopewars versão %s pronto e esperando conexões\n"
 "na porta %d."
 
-#. Warning messages displayed if we fail to trap various signals
 #: src/serverside.c:784
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGUSR1!"
@@ -3049,8 +2770,6 @@ msgstr "Retirando %s\n"
 msgid "No such user!\n"
 msgstr "Este usuário não existe!\n"
 
-#. The named user has been removed from the server following
-#. a "kill" command
 #: src/serverside.c:923
 #, c-format
 msgid "%s killed\n"
@@ -3285,8 +3004,6 @@ msgstr "Você encontrou um amigo! Ele lhe dá %d %tde."
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Você encontrou um amigo! Você dá a ele %d %tde."
 
-#. Debugging message: we would normally have a random drug-related
-#. event here, but "Sanitized" mode is turned on
 #: src/serverside.c:2957
 msgid "Sanitized away a RandomOffer"
 msgstr "Sanitized away a RandomOffer"
@@ -3381,8 +3098,6 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código interno de erro %d"
 
-#. These are the explanations of the various
-#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3447,7 +3162,6 @@ msgstr "Protocolo não suportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket não suportado"
 
-#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Host não encontrado"
@@ -3640,7 +3354,6 @@ msgstr " Você roubou o corpo!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#. SOCKS version 5 error messages
 #: src/network.c:383
 msgid "SOCKS server general failure"
 msgstr ""
@@ -3689,7 +3402,6 @@ msgstr ""
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#. SOCKS version 4 error messages
 #: src/network.c:397
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
@@ -3702,7 +3414,6 @@ msgstr ""
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#. SOCKS errors due to protocol violations
 #: src/network.c:403
 msgid "Unknown SOCKS reply code"
 msgstr ""
@@ -3870,7 +3581,6 @@ msgstr "Bordel localizado em %s\n"
 msgid "Bank located at %s\n"
 msgstr "Banco localizado em %s\n"
 
-#. Random messages to send from the AI player to other players
 #: src/AIPlayer.c:671
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vocês se acham traficantes de drogas?"
@@ -3914,6 +3624,21 @@ msgid ""
 msgstr ""
 "Plugin inválido \"%s\" selecionado.\n"
 "(%s disponível; agora usando \"%s\".)"
+
+#~ msgid ""
+#~ "\n"
+#~ "For information on the command line options, type dopewars -h at your\n"
+#~ "Unix prompt. This will display a help screen, listing the available "
+#~ "options.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Para informações sobre opções de linha de comando, digite dopewars -h no "
+#~ "seu\n"
+#~ "prompt Unix. Isto irá mostrar a tela de ajuda, listando as opções "
+#~ "disponíveis.\n"
+
+#~ msgid "Local HTML documentation"
+#~ msgstr "Documentação local em HTML"
 
 #, c-format
 #~ msgid "Status: ERROR: %s"

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2297,7 +2297,7 @@ static void PackCentredURL(GtkWidget *vbox, gchar *title, gchar *target,
 void display_intro(GtkWidget *widget, gpointer data)
 {
   GtkWidget *dialog, *label, *grid, *OKButton, *vbox, *hsep, *hbbox;
-  gchar *VersionStr, *docindex;
+  gchar *VersionStr;
   const int rows = 8, cols = 3;
   int i, j;
   GtkAccelGroup *accel_group;
@@ -2386,18 +2386,7 @@ void display_intro(GtkWidget *widget, gpointer data)
   }
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
-  /* Label at the bottom of GTK+ 'about' dialog */
-  label = gtk_label_new(_("\nFor information on the command line "
-                          "options, type dopewars -h at your\n"
-                          "Unix prompt. This will display a help "
-                          "screen, listing the available options.\n"));
-  gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
-
-  docindex = GetDocIndex();
-  PackCentredURL(vbox, _("Local HTML documentation"), docindex, OurWebBrowser);
-  g_free(docindex);
-
-  PackCentredURL(vbox, "https://dopewars.sourceforge.io/",
+  PackCentredURL(vbox, _("Original dopewars information here:"),
                  "https://dopewars.sourceforge.io/", OurWebBrowser);
 
   hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);


### PR DESCRIPTION
## Summary
- Remove outdated help label and local documentation from GTK about dialog.
- Link to the original dopewars site with a translatable label.
- Regenerate translation template and update all locale files for the new string.

## Testing
- `msgfmt --check -o /tmp/$(basename $p .po).mo $p` *(silent output indicates success)*
- `gcc -c src/gui_client/gtk_client.c $(pkg-config --cflags gtk+-3.0)` *(missing gtk+-3.0 and config headers)*
- `./check-cformat.sh` *(no Makefile present)*
- `apt-get update` *(repositories are unsigned/403)*


------
https://chatgpt.com/codex/tasks/task_e_689b471d02d483269735f6166df4bc70