### PR TITLE
Handle busy SDL mixer channels and add stress test

### DIFF
--- a/src/plugins/sound_sdl.c
+++ b/src/plugins/sound_sdl.c
@@ -88,7 +88,21 @@ static void SoundPlay_SDL(const gchar *snd)
 
   chan_num = Mix_PlayChannel(-1, chunk, 0);
   if (chan_num < 0) {
-    g_warning("Mix_PlayChannel failed for %s: %s", snd, Mix_GetError());
+    int total_channels = Mix_AllocateChannels(-1);
+    int i;
+    for (i = 0; i < total_channels; i++) {
+      if (Mix_Playing(i)) {
+        Mix_HaltChannel(i);
+        chan_num = Mix_PlayChannel(-1, chunk, 0);
+        if (chan_num >= 0) {
+          g_message("Recovered playback for %s by halting channel %d", snd, i);
+          break;
+        }
+      }
+    }
+    if (chan_num < 0) {
+      g_warning("Mix_PlayChannel failed for %s: %s", snd, Mix_GetError());
+    }
   }
 }
 

--- a/tests/test_sound.c
+++ b/tests/test_sound.c
@@ -36,5 +36,17 @@ int main(void) {
   SoundOpen("failing-driver");
   assert(IsSoundEnabled() == FALSE);
 
+  /* Stress test rapid playback to ensure busy channels recover. */
+  SoundInit();
+  SoundOpen(NULL);
+  if (IsSoundEnabled()) {
+    int i;
+    for (i = 0; i < 100; i++) {
+      SoundPlay("sounds/19.5degs/gun.wav");
+    }
+  }
+  SoundClose();
+  assert(IsSoundEnabled() == FALSE);
+
   return 0;
 }


### PR DESCRIPTION
## Summary
- Retry SDL playback when no channel is free by halting a busy channel
- Add a stress test that rapidly plays sounds to exercise channel recovery

## Testing
- `gcc tests/test_sound.c src/sound.c src/plugins/sound_sdl.c -I src -I src/plugins -I tests -DHAVE_SDL_MIXER -lSDL_mixer -lSDL -lglib-2.0 -o test_sound` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b4c2f06bc8326aedc5613917e632e