### PR TITLE
Cache string length in PrintEscaped

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -46,8 +46,9 @@ gchar *LocalCfgEncoding = NULL;
 static void PrintEscaped(FILE *fp, gchar *str)
 {
   guint i;
+  guint len = strlen(str);
 
-  for (i = 0; i < strlen(str); i++) {
+  for (i = 0; i < len; i++) {
     int ch = (int)(guchar)str[i];
     switch(ch) {
     case '"':


### PR DESCRIPTION
## Summary
- cache `strlen(str)` result in `PrintEscaped` to avoid repeated calls

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `./autogen.sh` *(fails: automake not installed)*
- `gcc -c src/configfile.c -I./src` *(fails: glib.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b551ddc288326897780cce4ee8b63