### PR TITLE
Guard fd_set operations in bselect

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -141,7 +141,7 @@ int bselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
     Sleep(tm->tv_sec * 1000 + tm->tv_usec / 1000);
     return 0;
   }
-  if (FD_ISSET(0, readfds)) {
+  if (readfds && FD_ISSET(0, readfds)) {
     if (nfds == 1)
       return 1;
     tp = &tv;
@@ -164,7 +164,8 @@ int bselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
       return retval;
     if (CheckKbHit && kbhit()) {
       retval++;
-      FD_SET(0, readfds);
+      if (readfds)
+        FD_SET(0, readfds);
     }
     if (retval > 0 || !CheckKbHit)
       break;


### PR DESCRIPTION
## Summary
- avoid FD_* macros on NULL readfds in bselect to prevent invalid pointer access

## Testing
- `autogen.sh` *(fails: You must have automake installed)*
- `gcc -Wall -Wextra -pedantic -std=c99 -c src/util.c -I src` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b5518bcb48326a8fd7647bd203b30