### PR TITLE
Include unistd.h for configfile

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -29,6 +29,9 @@
 #include <stdlib.h>             /* For atoi */
 #include <errno.h>              /* For errno */
 #include <ctype.h>              /* For isprint */
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 #include <glib.h>
 
 #include "configfile.h"


### PR DESCRIPTION
## Summary
- conditionally include `<unistd.h>` in `configfile.c` when available

## Testing
- `gcc -c src/configfile.c` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b5517495c8326b23b4a93c68e8b1c