### PR TITLE
Use bounded copy for tray tooltip

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -1586,7 +1586,8 @@ static void SetupTaskBarIcon(GtkWidget *widget)
     nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
     nid.uCallbackMessage = MYWM_TASKBAR;
     nid.hIcon = mainIcon;
-    strcpy(nid.szTip, "dopewars server - running");
+    /* NOTIFYICONDATA::szTip is limited (typically 128 chars including NUL). */
+    snprintf(nid.szTip, sizeof(nid.szTip), "dopewars server - running");
     systray = Shell_NotifyIcon(NIM_ADD, &nid);
   } else {
     systray = FALSE;


### PR DESCRIPTION
## Summary
- replace unsafe `strcpy` with `snprintf` for system tray tooltip
- note the limited length of `NOTIFYICONDATA::szTip`

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `gcc -c src/serverside.c` *(fails: glib.h: No such file or directory)*
- `apt-get update` *(fails: repository not signed / 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c5b66848326baf76a642d7a7fc0