### PR TITLE
Replace sprintf with snprintf and add error checks

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -560,7 +560,11 @@ void AIJet(Player *AIPlay)
   }
   while (NewLocation == AIPlay->IsAt)
     NewLocation = brandom(0, NumLocation);
-  sprintf(text, "%d", NewLocation);
+  int ret = snprintf(text, sizeof(text), "%d", NewLocation);
+  if (ret < 0 || ret >= (int)sizeof(text)) {
+    g_warning("AIJet: failed to format new location");
+    text[sizeof(text) - 1] = '\0';
+  }
   SendClientMessage(AIPlay, C_NONE, C_REQUESTJET, NULL, text);
 }
 

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -1110,10 +1110,17 @@ gchar *FormatPrice(price_t price)
   } else
     absprice = price;
   while (First || absprice > 0) {
+    int ret;
     if (absprice >= 1000)
-      sprintf(thou, "%03d", (int)(absprice % 1000l));
+      ret = snprintf(thou, sizeof(thou), "%03d",
+                     (int)(absprice % 1000l));
     else
-      sprintf(thou, "%d", (int)(absprice % 1000l));
+      ret = snprintf(thou, sizeof(thou), "%d",
+                     (int)(absprice % 1000l));
+    if (ret < 0 || ret >= (int)sizeof(thou)) {
+      g_warning("FormatPrice: failed to format price chunk");
+      thou[sizeof(thou) - 1] = '\0';
+    }
     absprice /= 1000l;
     if (!First)
       g_string_prepend_c(PriceStr, ',');


### PR DESCRIPTION
## Summary
- guard against buffer overflows in AIJet by using `snprintf` with return-value checks
- safely format thousand chunks in `FormatPrice` via `snprintf` and warn on formatting issues

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `./autogen.sh` *(fails: automake not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c5cdb548326afeb1009942b674f