### PR TITLE
Validate PulseAudio WAV sizes before allocation

### DIFF
--- a/src/plugins/sound_pulseaudio.c
+++ b/src/plugins/sound_pulseaudio.c
@@ -34,6 +34,7 @@
 #include "../sound.h"
 
 #define MAXCACHE 6
+#define MAX_WAV_DATA_LEN (16 * 1024 * 1024)
 
 struct SoundCache {
   gchar *name;
@@ -78,6 +79,21 @@ static gboolean LoadWav(const gchar *fname, pa_sample_spec *spec,
   }
 
   datalen = hdr[40] | (hdr[41] << 8) | (hdr[42] << 16) | (hdr[43] << 24);
+  if (fseek(f, 0, SEEK_END) != 0) {
+    fclose(f);
+    return FALSE;
+  }
+  long filesize = ftell(f);
+  if (filesize < (long)sizeof(hdr) ||
+      datalen > (guint32)(filesize - sizeof(hdr)) ||
+      datalen > MAX_WAV_DATA_LEN) {
+    fclose(f);
+    return FALSE;
+  }
+  if (fseek(f, sizeof(hdr), SEEK_SET) != 0) {
+    fclose(f);
+    return FALSE;
+  }
   *data = g_malloc(datalen);
   if (fread(*data, 1, datalen, f) != datalen) {
     g_free(*data);


### PR DESCRIPTION
## Summary
- prevent PulseAudio WAV loader from allocating huge buffers by checking WAV data length against file size and a 16MB limit

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `gcc -c -DHAVE_PULSEAUDIO -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include src/plugins/sound_pulseaudio.c` *(fails: fatal error: pulse/simple.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c5d92d8832690eed8eea9a12281