### PR TITLE
Preserve writefds across bselect loops

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -155,7 +155,7 @@ int bselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 {
   int retval;
   struct timeval tv, *tp;
-  fd_set localread, localexcept;
+  fd_set localread, localwrite, localexcept;
   char CheckKbHit = 0;
 
   if (nfds == 0 && tm) {
@@ -176,6 +176,8 @@ int bselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 
     if (readfds)
       memcpy(&localread, readfds, sizeof(fd_set));
+    if (writefds)
+      memcpy(&localwrite, writefds, sizeof(fd_set));
     if (exceptfds)
       memcpy(&localexcept, exceptfds, sizeof(fd_set));
     if (CheckKbHit && kbhit())
@@ -201,6 +203,8 @@ int bselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
     }
     if (readfds)
       memcpy(readfds, &localread, sizeof(fd_set));
+    if (writefds)
+      memcpy(writefds, &localwrite, sizeof(fd_set));
     if (exceptfds)
       memcpy(exceptfds, &localexcept, sizeof(fd_set));
   }


### PR DESCRIPTION
## Summary
- maintain a temporary copy of writefds in bselect for Win32/Cygwin builds, mirroring localread and localexcept handling

## Testing
- `make test` (fails: No rule to make target 'test')
- `make check` (fails: No rule to make target 'check')


------
https://chatgpt.com/codex/tasks/task_e_689b5c606e9c8326b333a92b2e318dfd