### PR TITLE
Rename documentation from dopewars to Church Wars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,19 +1,19 @@
-dopewars is derived from the MS-DOS game of the same name (author unknown).
+Church Wars is derived from the MS-DOS game of the same name (author unknown).
 
 This is turn was based upon the MS-DOS game "Drug Wars", by John E. Dell.
 
-dopewars is written by and is copyright of Ben Webb (benwebb@users.sf.net)
+Church Wars is written by and is copyright of Ben Webb (benwebb@users.sf.net)
 
-Pivotal to the development of dopewars were and are the following:-
+Pivotal to the development of Church Wars were and are the following:-
 
 Dan Wolf for uncountable numbers of useful suggestions for the structure of the
 multiplayer game, drawing upon a disturbing knowledge of the drugs world. He
 also undertook scary amounts of research (i.e. playing the game) to assist with
 the re-engineering of the MS-DOS version, and plays the game to an unhealthy
-extent (as is witnessed by his high scores on many dopewars servers).
+extent (as is witnessed by his high scores on many Church Wars servers).
 
 Phil Davis, Caroline Moore, Katherine Holt and Andrea Elliot-Smith for extensive
-play testing of early versions of dopewars, despite the large amounts of "real"
+play testing of early versions of Church Wars, despite the large amounts of "real"
 work which they were supposed to be doing, and despite the many dodgy bugs, as
 well as for providing suggestions, even if they were often rude. You know who
 you are.
@@ -29,5 +29,5 @@ spotting many of his own and my bugs...
 
 Matt Higgins for a couple of patches to version 1.4.4.
 
-Tony Brown for assistance with using dopewars via. enforced web proxies.
+Tony Brown for assistance with using Church Wars via. enforced web proxies.
 

--- a/INSTALL
+++ b/INSTALL
@@ -1,27 +1,27 @@
 PREREQUISITES
 =============
 
-dopewars _requires_ the GLib library for compilation, even when not using
+Church Wars _requires_ the GLib library for compilation, even when not using
 the GTK+ client. Other libraries may be required for additional features:-
 
 Unix/Linux:
    - Get GLib from http://www.gtk.org/
    - For the GTK+ client, GTK+ libraries are needed, also from
      http://www.gtk.org/ (GTK+2 and GTK+3 are supported). To actually
-     compile dopewars, you'll probably need your distribution's
+     compile Church Wars, you'll probably need your distribution's
      "gtk-devel" package.
    - For the curses client, curses, ncurses or libcurses_color libraries
      and headers are required.
 
 Windows:
-   - dopewars can be built via cross-compilation using MinGW. See
+   - Church Wars can be built via cross-compilation using MinGW. See
      the win32 directory for more information.
 
 
 INSTALLATION
 ============
 
-dopewars installation should require no more than the following:-
+Church Wars installation should require no more than the following:-
 
 	./configure
 	make
@@ -40,34 +40,34 @@ the -s option in LDFLAGS. In a Bourne-compatible shell, this can be achieved
 with a command similar to the following:-
 	LDFLAGS="-s" ./configure
 
-The dopewars high score file is written as /usr/local/var/dopewars.sco on
-Unix systems or ./dopewars.sco on Win32 systems by default. On Unix systems,
+The churchwars high score file is written as /usr/local/var/churchwars.sco on
+Unix systems or ./churchwars.sco on Win32 systems by default. On Unix systems,
 translations, documentation, sounds and graphics are installed in the
-locale, doc, dopewars and pixmaps directories respectively under
+locale, doc, churchwars and pixmaps directories respectively under
 /usr/local/share. (On Windows systems, these directories are under the
 current directory.) On Unix systems, you can move the score file with the
 --localstatedir flag to configure, the sounds with the --datadir flag, and
 the documentation with the --docdir flag. (On Win32 systems, these flags are
-ignored.) The dopewars binary can also be moved from /usr/local/bin/dopewars
+ignored.) The churchwars binary can also be moved from /usr/local/bin/churchwars
 with the --bindir flag. For example:-
 
-	./configure --bindir=/usr/bin --localstatedir=/var/lib/games
-will configure the system to write the dopewars binary as /usr/bin/dopewars
-and the high score as /var/lib/games/dopewars.sco
+        ./configure --bindir=/usr/bin --localstatedir=/var/lib/games
+will configure the system to write the churchwars binary as /usr/bin/churchwars
+and the high score as /var/lib/games/churchwars.sco
 
 Other options to ./configure include:-
 
 --enable-networking:
-	Compile dopewars with support for running as a server, and/or to
+	Compile Church Wars with support for running as a server, and/or to
 connect to existing servers over a TCP/IP network. (Without networking,
-dopewars will only be useable in single-player mode.) If this option is not
+Church Wars will only be useable in single-player mode.) If this option is not
 specified, the configure script will enable networking only if it believes
 your system has the necessary support functions (select and socket). You can
 also explicitly disable networking with --enable-networking=no or
 --disable-networking
 
 --enable-gui-client:
-	Compile a graphical dopewars client, using GTK+ on Unix systems and
+	Compile a graphical Church Wars client, using GTK+ on Unix systems and
 the standard libaries under Windows. If unspecified, this is enabled only
 if your system has the necessary libraries (e.g. GTK+) installed.
 
@@ -77,12 +77,12 @@ and the standard libraries under Windows. If unspecified, this is enabled only
 if you have ncurses (or similar) installed.
 
 --enable-gui-server:
-	Use a (very basic) graphical interface to the dopewars server. If not
+	Use a (very basic) graphical interface to the Church Wars server. If not
 specified, this is enabled under Windows and disabled under Unix (where a
 simple text-mode server is used instead).
 
 --enable-strict
-	If using gcc to compile dopewars (recommended) then this turns on
+	If using gcc to compile Church Wars (recommended) then this turns on
 extra warning messages (useful for debugging, etc.) Unfortunately a lot of
 these warnings can be safely ignored, so this is not the default.
 

--- a/NEWS
+++ b/NEWS
@@ -1,72 +1,72 @@
 26th June 2022
-     dopewars-1.6.2 released. This improves Unicode support in the text-mode
+     churchwars-1.6.2 released. This improves Unicode support in the text-mode
 client, and adds support for networking on the Haiku operating system.
 
 11th December 2020
-     dopewars-1.6.1 released. This improves the appearance of the text-mode
+     churchwars-1.6.1 released. This improves the appearance of the text-mode
 client, adds a British English translation, and fixes a bug selecting sounds
 from the options dialog of the Windows client.
 
 6th December 2020
-     dopewars-1.6.0 released. The metaserver, broken since SourceForge moved
+     churchwars-1.6.0 released. The metaserver, broken since SourceForge moved
 to HTTPS, should work again. This release also adds support for modern 64-bit
 operating systems, and newer software libraries such as GTK+3 and SDL 2.
 
 30th December 2005
-     dopewars-1.5.11 released. This is largely a security bugfix release,
+     churchwars-1.5.11 released. This is largely a security bugfix release,
 fixing a potential exploit against the Windows server when running as an
 NT serivce.
 
 24th October 2004
-     dopewars-1.5.10 released. This is largely a bugfix release, fixing a
+     churchwars-1.5.10 released. This is largely a bugfix release, fixing a
 server DOS and some minor bugs in the text-mode client.
 
 7th June 2003
-     dopewars-1.5.9 released. This is largely a bugfix release, fixing a
+     churchwars-1.5.9 released. This is largely a bugfix release, fixing a
 crash on pressing the "drop drugs" button, and adding minor improvements
 to the text-mode client.
 
 21st October 2002
-     dopewars-1.5.8 released. The Windows and GTK+2.0 builds now have fairly
+     churchwars-1.5.8 released. The Windows and GTK+2.0 builds now have fairly
 complete Unicode support. A default set of sounds is now provided, and
 Windows XP is better supported.
 
 25th June 2002
-     dopewars-1.5.7 released. There is now sound support (ESD and/or SDL
+     churchwars-1.5.7 released. There is now sound support (ESD and/or SDL
 on Unix systems, WinMM on Win32) although you have to provide your own WAVs
 (musicians take note - if you can provide suitable copyright-free sounds,
 then they can be included in future releases). Some minor bugs have been
 fixed, and overall security has been tightened up.
 
 29th April 2002
-     dopewars-1.5.6 released. This corrects some problems with the GTK+2.0
+     churchwars-1.5.6 released. This corrects some problems with the GTK+2.0
 client in non-UTF8 locales, fixes a server memory corruption bug, and adds
 extra sanity checks to the server to foil cheating clients.
 
 13th April 2002
-     dopewars-1.5.5 released. The code should now compile with GTK+2.0,
+     churchwars-1.5.5 released. The code should now compile with GTK+2.0,
 and several minor glitches have been fixed.
 
 3rd March 2002
-     dopewars-1.5.4 released. This fixes bugs observed on the PPC platform,
+     churchwars-1.5.4 released. This fixes bugs observed on the PPC platform,
 and adds a configuration file editor to the graphical client.
 
 4th February 2002
-     dopewars-1.5.3 released. This fixes several bugs and annoyances in the
+     churchwars-1.5.3 released. This fixes several bugs and annoyances in the
 Windows version, and supports running the Windows server as an "NT Service".
 The Unix server is now also more daemon-like.
 
 16th October 2001
-     dopewars-1.5.2 released. This features a new networking subsystem, with
+     churchwars-1.5.2 released. This features a new networking subsystem, with
 HTTP/1.0 and SOCKS4&5 support, and now has a familiar install/uninstall
 program for Windows systems.
 
 19th June 2001
-     dopewars-1.5.1 released. This fixes a few minor bugs, and supports the
+     churchwars-1.5.1 released. This fixes a few minor bugs, and supports the
 "new" metaserver on SourceForge.
 
 13th May 2001
-     dopewars-1.5.0 released. This improves on 1.4.8 by adding a graphical
+     churchwars-1.5.0 released. This improves on 1.4.8 by adding a graphical
 client, and features many security and usability fixes.
 
 29th April 2001
@@ -74,102 +74,102 @@ client, and features many security and usability fixes.
 with the first beta.
 
 9th April 2001
-     Beta release of the new dopewars version, 1.5.0, which features a
+     Beta release of the new Church Wars version, 1.5.0, which features a
 graphical client, internationalisation, and rewrites of many parts of the code.
 
 10th September 2000
-     The dopewars project, previously hosted solely at
-http://bellatrix.pcl.ox.ac.uk/~ben/dopewars/ now has an additional home at
+     The Church Wars project, previously hosted solely at
+http://bellatrix.pcl.ox.ac.uk/~ben/churchwars/ now has an additional home at
 SourceForge! This is to allow developers easier access to development codes
 (by CVS) and to take advantage of SourceForge's mailing lists and forums.
 Translators are particularly needed for translation of the development
-version of the dopewars code into other languages!
+version of the Church Wars code into other languages!
 
 2nd August 2000
     The German translation now has its home at
-http://www.ideenpark.de/dopewars/. This site also mirrors the original
+http://www.ideenpark.de/churchwars/. This site also mirrors the original
 English version of the program.  
 
 28th July 2000
-    A German translation of dopewars is now available, at
-http://www.rLUG.de/files/dopewars-german/.
+    A German translation of Church Wars is now available, at
+http://www.rLUG.de/files/churchwars-german/.
 
 9th July 2000
-     dopewars 1.4.8 released. This features a complete revamp of the
+     Church Wars 1.4.8 released. This features a complete revamp of the
 metaserver interface - new servers now report game data, such as current
 number of players and high scores, to the metaserver. Several bugs, mainly
 in the Win32 networking code, have been fixed.
 
 2nd July 2000
-     A mirror in the US is now available for dopewars downloads. Follow the US
+     A mirror in the US is now available for Church Wars downloads. Follow the US
 links (as opposed to the UK links) on the download page to download from this
 site.
 
 14th January 2000
-     dopewars 1.4.7 released. This now uses autoconf to build on a variety
+     Church Wars 1.4.7 released. This now uses autoconf to build on a variety
 of "odd" Unices, and also "out of the box" under Cygwin (Win32). Servers for
 which the IP is incorrectly resolved by the metaserver can now set a
 preferred hostname with the "MetaServer.LocalName" variable.
 
 31st Decemeber 1999
-     The Polish version of dopewars has moved to http://dresswars.mtl.pl/
+     The Polish version of Church Wars has moved to http://dresswars.mtl.pl/
 
 12th November 1999 
-     dopewars 1.4.6 released. This fixes a few minor bugs with 1.4.5, and is now
+     Church Wars 1.4.6 released. This fixes a few minor bugs with 1.4.5, and is now
 also available on the popular Windows platform. A Win32 binary can be downloaded
 from the download page,
-http://bellatrix.pcl.ox.ac.uk/~ben/dopewars/download.html.
+http://bellatrix.pcl.ox.ac.uk/~ben/churchwars/download.html.
 
 8th November 1999 
-     A translation of the dopewars pages and dopewars client software into
-Polish is now available at http://naboo.mtl.pl/~dopewars/.
+     A translation of the Church Wars pages and Church Wars client software into
+Polish is now available at http://naboo.mtl.pl/~churchwars/.
 
 21st October 1999 
-     dopewars 1.4.5 released. Client players can now be instructed to connect to
+     Church Wars 1.4.5 released. Client players can now be instructed to connect to
 the metaserver, to present a "nice" list of available servers for the user to
 select from; more configuration options; metaserver almost works with web
 proxies now.
 
 11th October 1999 
-     Snapshots of the latest in-development version of dopewars are now made
+     Snapshots of the latest in-development version of Church Wars are now made
 available on a semi-regular basis at the main download page. HTML documentation
 is also now available.
 
 16th September 1999 
-     dopewars 1.4.4 released. This handles connection to the new metaserver
-automatically, so that the list of dopewars servers can be easily kept up to
+     Church Wars 1.4.4 released. This handles connection to the new metaserver
+automatically, so that the list of Church Wars servers can be easily kept up to
 date. Other minor changes fix small bugs from earlier versions.
 
 15th September 1999 
      Servers can now be registered by completing the form at 
-http://bellatrix.pcl.ox.ac.uk/~ben/dopewars/serverform.html. The upcoming
-version 1.4.4 of dopewars will be able to handle the connection to the web and
+http://bellatrix.pcl.ox.ac.uk/~ben/churchwars/serverform.html. The upcoming
+version 1.4.4 of Church Wars will be able to handle the connection to the web and
 the completion of registration details automatically.
 
 23rd June 1999 
-     dopewars 1.4.3 released. This adds many new features (while hopefully not
+     Church Wars 1.4.3 released. This adds many new features (while hopefully not
 adding any new bugs) such as much better fight handling, and the ability to
-customise dopewars servers and clients.
+customise Church Wars servers and clients.
 
 16th May 1999 
-     dopewars 1.4.2 released. This version fixes numerous minor bugs and makes
+     Church Wars 1.4.2 released. This version fixes numerous minor bugs and makes
 many small improvements - most noticeable is the support for AI players in
-multiplayer games (dopewars -c).
+multiplayer games (Church Wars -c).
 
 28th April 1999 
-     Interim release of dopewars 1.4.1b, which fixes a segfault problem with the
+     Interim release of Church Wars 1.4.1b, which fixes a segfault problem with the
 server.
 
 28th April 1999 
-     Interim release of dopewars 1.4.1a, which corrects a few minor bugs in
+     Interim release of Church Wars 1.4.1a, which corrects a few minor bugs in
 "antique" mode.
 
 27th April 1999 
-     dopewars 1.4.1 released. This fixes a bug with the loan shark, which was
+     Church Wars 1.4.1 released. This fixes a bug with the loan shark, which was
 discovered by several people quick off the mark; dunno how that slipped past my
 team of beta testers here at Oxford - they're obviously too busy doing "real"
 work!
 
 27th April 1999 
-     First GPL release of dopewars (1.4.0) 
+     First GPL release of Church Wars (1.4.0) 
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Build Status](https://github.com/benmwebb/dopewars/workflows/build/badge.svg?branch=develop)](https://github.com/benmwebb/dopewars/actions?query=workflow%3Abuild)
-[![Download dopewars drug dealing game](https://img.shields.io/sourceforge/dt/dopewars.svg)](https://dopewars.sourceforge.io/download.html)
+[![Build Status](https://github.com/benmwebb/churchwars/workflows/build/badge.svg?branch=develop)](https://github.com/benmwebb/churchwars/actions?query=workflow%3Abuild)
+[![Download Church Wars drug dealing game](https://img.shields.io/sourceforge/dt/churchwars.svg)](https://churchwars.sourceforge.io/download.html)
 
-This is dopewars 1.6.2, a game simulating the life of a drug dealer in
+This is Church Wars 1.6.2, a game simulating the life of a drug dealer in
 New York. The aim of the game is to make lots and lots of money...
 unfortunately, you start the game with a hefty debt, accumulating interest,
 and the cops take a rather dim view of drug dealing...
 
 These are brief instructions; see the HTML documentation for full information.
 
-dopewars 1.6.2 servers should handle clients as old as version 1.4.3 with
+Church Wars 1.6.2 servers should handle clients as old as version 1.4.3 with
 hardly any visible problems (the reverse is also true). However, it is
 recommended that both clients and servers are upgraded to 1.6.2!
 
@@ -16,66 +16,66 @@ recommended that both clients and servers are upgraded to 1.6.2!
 
 Either...
 
-1. Get the relevant RPM from https://dopewars.sourceforge.io/
+1. Get the relevant RPM from https://churchwars.sourceforge.io/
    
 Or...
 
-1. Get the tarball `dopewars-1.6.2.tar.gz` from the same URL
-2. Extract it via `tar -xvzf dopewars-1.6.2.tar.gz`
+1. Get the tarball `churchwars-1.6.2.tar.gz` from the same URL
+2. Extract it via `tar -xvzf churchwars-1.6.2.tar.gz`
 3. Follow the instructions in the `INSTALL` file in the newly-created
-   `dopewars-1.6.2` directory
+   `churchwars-1.6.2` directory
 
-Once you're done, you can safely delete the RPM, tarball and dopewars
-directory. The dopewars binary is all you need!
+Once you're done, you can safely delete the RPM, tarball and churchwars
+directory. The churchwars binary is all you need!
 
-dopewars stores its high score files by default in `/usr/share/dopewars.sco`
+Church Wars stores its high score files by default in `/usr/share/churchwars.sco`
 This will be created by make install or by RPM installation. A different high 
 score file can be selected with the `-f` switch.
 
 ## Windows installation
 
-dopewars now compiles as a console or regular application under Win32 (Windows 7
+Church Wars now compiles as a console or regular application under Win32 (Windows 7
 or later). Almost all functionality of the standard Unix binary is retained;
 for example, all of the same command line switches are supported. However, for
 convenience, the configuration file is the more Windows-friendly
-"dopewars-config.txt".
+"churchwars-config.txt".
 
 The easiest way to install the Win32 version is to download the precompiled
 binary. To build from source, see the `win32` directory.
 
 ## Usage
 
-dopewars has built-in client-server support for multi-player games. For a
-full list of options configurable on the command line, run dopewars with
+Church Wars has built-in client-server support for multi-player games. For a
+full list of options configurable on the command line, run `churchwars` with
 the `-h` switch.
 
-`dopewars -a`  
-This is "antique" dopewars; it tries to keep to the original dopewars, based
+`churchwars -a`
+This is "antique" Church Wars; it tries to keep to the original Church Wars, based
 on the "Drug Wars" game by John E. Dell, as closely as possible.
 
-`dopewars`  
-By default, dopewars supports multi-player games. On starting a game, the
-program will attempt to connect to a dopewars server so that players can send
+`churchwars`
+By default, Church Wars supports multi-player games. On starting a game, the
+program will attempt to connect to a Church Wars server so that players can send
 messages back and forth, and shoot each other if they really want to...
 
-`dopewars -s`  
-Starts a dopewars server. This sits in the background and handles multi-player
+`churchwars -s`
+Starts a Church Wars server. This sits in the background and handles multi-player
 games. You probably want to use the `-l` command line option too to direct its
 log output to somewhere sensible.
 
-`dopewars -c`  
-Create and run a computer dopewars player. This will attempt to connect
-to a dopewars server, and if this succeeds, it will then participate in
-multi-player dopewars games.
+`churchwars -c`
+Create and run a computer Church Wars player. This will attempt to connect
+to a Church Wars server, and if this succeeds, it will then participate in
+multi-player Church Wars games.
 
 ## Configuration
 
-Most of the dopewars defaults (for example, the location of the high score file,
+Most of the Church Wars defaults (for example, the location of the high score file,
 the port and server to connect to, the names of the drugs and guns, etc.) can be
-configured by adding suitable entries to the dopewars configuration file. The
-global file `/etc/dopewars` is read first, and can then be overridden by
-the local settings in `~/.dopewars`. All of the settings here can also be
-set on the command line of an interactive dopewars server when no players
+configured by adding suitable entries to the Church Wars configuration file. The
+global file `/etc/churchwars` is read first, and can then be overridden by
+the local settings in `~/.churchwars`. All of the settings here can also be
+set on the command line of an interactive Church Wars server when no players
 are logged on. See the file "example-cfg" for an example configuration file,
 and for a brief explanation of each option, type "help" in an interactive
 server. A subset of the configuration options can also be tweaked via the
@@ -83,7 +83,7 @@ server. A subset of the configuration options can also be tweaked via the
 
 ## Playing
 
-dopewars is supposed to be fairly self-explanatory. You should be able to 
+Church Wars is supposed to be fairly self-explanatory. You should be able to 
 pick the basics up fairly quickly, but still be discovering subtleties for 
 _ages_ ;) If you're _really_ stuck, send me an email. I might even answer it!
 
@@ -93,19 +93,19 @@ and Ghetto are "special" locations. Anything more would spoil the fun. ;)
 ## Bugs
 
 Well, there are bound to be lots. Let me know if you find any by
-[opening an issue](https://github.com/benmwebb/dopewars/issues), and I'll see
+[opening an issue](https://github.com/benmwebb/churchwars/issues), and I'll see
 if I can fix 'em... of course, a
-[working patch](https://github.com/benmwebb/dopewars/pulls) would be even
+[working patch](https://github.com/benmwebb/churchwars/pulls) would be even
 nicer! ;)
 
 ## License
 
-dopewars is released under the GNU General Public License; see the text file
-LICENCE for further information. dopewars is copyright (C) Ben Webb 1998-2022.
-The dopewars icons are copyright (C) Ocelot Mantis 2001.
+Church Wars is released under the GNU General Public License; see the text file
+LICENCE for further information. Church Wars is copyright (C) Ben Webb 1998-2022.
+The Church Wars icons are copyright (C) Ocelot Mantis 2001.
 
 ## Support
 
-dopewars is written and maintained by Ben Webb <benwebb@users.sf.net>  
-Enquiries about dopewars may be sent to this address (keep them sensible 
+Church Wars is written and maintained by Ben Webb <benwebb@users.sf.net>  
+Enquiries about Church Wars may be sent to this address (keep them sensible 
 please ;) Bug fixes and reports, improvements and patches are also welcomed.

--- a/doc/aiplayer.html
+++ b/doc/aiplayer.html
@@ -13,16 +13,16 @@
 <body>
 <h1>Adding computer-controlled players</h1>
 
-<p>Multiplayer games of dopewars can be made a little more interesting by
+<p>Multiplayer games of Church Wars can be made a little more interesting by
 introducing computer-controlled, or AI, players. These players will join
-a dopewars server, and to all intents and purposes will behave like normal
+a Church Wars server, and to all intents and purposes will behave like normal
 human players - they will deal in drugs in an attempt to make a fortune,
 they will encounter the cops, you can spy on them, and they will shoot at
 you if you give them the chance!</p>
 
-<p>To start a computer-controlled player, all you need is the standard dopewars
+<p>To start a computer-controlled player, all you need is the standard Church Wars
 binary. Run it as<br />
-<tt><b>dopewars -c</b></tt><br />
+<tt><b>Church Wars -c</b></tt><br />
 and it will attempt to connect to the server and port specified in the
 <a href="configfile.html">configuration files</a> (or the local host, if none
 is specified). Alternatively, you can specify server and port with suitable
@@ -48,7 +48,7 @@ for a few seconds!</p>
 defend itself if it can, and attempt to run if necessary. During normal
 play it will also attempt to "blend in" with the other players by hurling
 rather pathetic insults at them... you are free to
-<a href="https://github.com/benmwebb/dopewars/blob/develop/src/AIPlayer.c">edit
+<a href="https://github.com/benmwebb/churchwars/blob/develop/src/AIPlayer.c">edit
 the code</a> of the AI player to give these insults a little more "punch".</p>
 
 <hr />

--- a/doc/clientplay.html
+++ b/doc/clientplay.html
@@ -6,47 +6,47 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>Playing the game: the dopewars client</title>
+<title>Playing the game: the Church Wars client</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>Playing the game: the dopewars client</h1>
+<h1>Playing the game: the Church Wars client</h1>
 
-<p>The dopewars client is the part of dopewars which most users will
-encounter most frequently. If the dopewars binary is run without the
+<p>The Church Wars client is the part of Church Wars which most users will
+encounter most frequently. If the churchwars binary is run without the
 <b>-s</b> (server) or <b>-c</b> (computer player) options (see
 <a href="commandline.html">command line options</a>) it defaults to running
-in client mode. The dopewars client handles the interaction between a
-human player and the dopewars server (but if a dopewars server is not
+in client mode. The Church Wars client handles the interaction between a
+human player and the Church Wars server (but if a Church Wars server is not
 available, a "virtual" server will be run by the client to enable a
 single-player game to be played).</p>
 
-<p>A brief description of using the client and playing dopewars is given here.
+<p>A brief description of using the client and playing Church Wars is given here.
 These instructions apply to the old-style text-mode client, but the basic
 game play is similar for the newer graphical client.
 Bear in mind that both the client and the server you are connecting to can
-be configured by means of the dopewars <a href="configfile.html">
+be configured by means of the Church Wars <a href="configfile.html">
 configuration files</a>, and so the game may differ radically from what is
 described here. It is suggested that you familiarise yourself with the game
 using the default settings before getting too adventurous!</p>
 
 <ul>
-<li><a href="#startup">Starting the dopewars client</a></li>
+<li><a href="#startup">Starting the Church Wars client</a></li>
 <li><a href="#screen">The main game screen</a></li>
-<li><a href="#server">Connecting to a dopewars server (or not)</a></li>
+<li><a href="#server">Connecting to a Church Wars server (or not)</a></li>
 <li><a href="#dealing">Dealing drugs and moving around</a></li>
 <li><a href="#finance">Your finances: loans and banks</a></li>
 <li><a href="#cops">Law enforcement and why it's a bad thing</a></li>
 <li><a href="#multiplayer">Multiplayer: interacting with other players</a></li>
 </ul>
 
-<h2><a id="startup">Starting the dopewars client</a></h2>
+<h2><a id="startup">Starting the Church Wars client</a></h2>
 <ul>
-<li>From the command prompt, run the dopewars client with the command<br />
-<tt><b>dopewars</b></tt><br />
+<li>From the command prompt, run the Church Wars client with the command<br />
+<tt><b>Church Wars</b></tt><br />
 or to run an <a href="commandline.html#antique">"antique"</a> mode game,<br />
-<tt><b>dopewars -a</b></tt></li>
+<tt><b>Church Wars -a</b></tt></li>
 
 <li>An introduction screen will appear, giving a brief description of the
 game and version and licensing information. Press any key to clear this.</li>
@@ -54,7 +54,7 @@ game and version and licensing information. Press any key to clear this.</li>
 
 <h2><a id="screen">The main game screen</a></h2>
 
-<p>The game screen is your interface with the dopewars world. At the top of the
+<p>The game screen is your interface with the Church Wars world. At the top of the
 screen, from left to right, is displayed the game date, the game location
 (you start in the Bronx), the number of clerics working for you, and the
 space you have available for drugs. Note that each drug uses up one "space",
@@ -77,15 +77,15 @@ which messages from other players (if any) will appear.</p>
 trenchcoat which can carry 80 drugs. Antique mode also disables the
 messages window.</p>
 
-<h2><a id="server">Connecting to a dopewars server (or not)</a></h2>
+<h2><a id="server">Connecting to a Church Wars server (or not)</a></h2>
 
-<p>On starting a game of dopewars, the first thing you must do is give
+<p>On starting a game of Church Wars, the first thing you must do is give
 yourself a name. This identifies you to the server and to other players. If
 you are running in <a href="commandline.html#singleplayer">single-player</a>
 or <a href="commandline.html#antique">antique</a> mode, the client will
 then start an internal "virtual" server and immediately start the game.</p>
 
-<p>In other cases, the client will attempt to connect to a dopewars server
+<p>In other cases, the client will attempt to connect to a Church Wars server
 specified in the <a href="configfile.html#Server">configuration file</a> or
 on the <a href="commandline.html#server">command line</a> (if none is
 specified, it defaults to the local host). If this connection is successful,
@@ -98,7 +98,7 @@ on <a href="configfile.html#Server">configuration files</a>.</p>
 
 <h2><a id="dealing">Dealing drugs and moving around</a></h2>
 
-<p>The New York of dopewars is divided into 8 (6 in "antique" mode) locations.
+<p>The New York of Church Wars is divided into 8 (6 in "antique" mode) locations.
 At each of these locations, a variety of drugs, with fluctuating prices, are
 on sale. Not all of the drugs are necessarily on sale at each location all
 of the time, and the normally gentle fluctuations may be affected by such
@@ -106,7 +106,7 @@ events as other dealers flooding the market with drugs, or the cops making
 a big drugs bust (which will drive the price up). On arriving at a new
 location, you will be told if any of these "special" events have occurred.</p>
 
-<p>The main way to make money in dopewars is to buy and sell drugs, buying
+<p>The main way to make money in Church Wars is to buy and sell drugs, buying
 cheaply at one location, and then moving ("jetting") to a new location (a
 process which uses up one "day" or turn), and then selling for a profit at
 this new location. When you have arrived at a location, you will be told which
@@ -184,7 +184,7 @@ or if you attack other players.</p>
 
 <h2><a id="multiplayer">Multiplayer: interacting with other players</a></h2>
 
-<p>If you log on to a dopewars server, there is the possibility of meeting other
+<p>If you log on to a Church Wars server, there is the possibility of meeting other
 players, either human or computer-controlled. When joining a game which
 already contains other players, they will be listed to you. Other players
 which join or leave the game once you are playing will announce their

--- a/doc/commandline.html
+++ b/doc/commandline.html
@@ -6,29 +6,29 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>dopewars command line options</title>
+<title>Church Wars command line options</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>dopewars command line options</h1>
+<h1>Church Wars command line options</h1>
 
-<p>Once you have <a href="installation.html">installed</a> dopewars, you should
+<p>Once you have <a href="installation.html">installed</a> Church Wars, you should
 be able to run the binary just by typing<br />
-<tt><b>dopewars</b></tt><br />
+<tt><b>Church Wars</b></tt><br />
 (unless you have installed the binary in a directory which is not in your
 path, in which case precede it with the path). Run without any options,
-the dopewars binary runs as a dopewars client.</p>
+the churchwars binary runs as a Church Wars client.</p>
 
-<p>Command line options can be used to configure common aspects of dopewars.
-More exhaustive configuration is possible by editing the dopewars
+<p>Command line options can be used to configure common aspects of churchwars.
+More exhaustive configuration is possible by editing the Church Wars
 <a href="configfile.html">configuration files</a>; note, however, that
 command line options can be used to override some of these settings (also see
 the <b>-g</b> option below).</p>
 
 <p>For a brief description of the command line options, specify the option
 <b>-h</b> with the command<br />
-<tt><b>dopewars -h</b></tt><br />
+<tt><b>Church Wars -h</b></tt><br />
 A list of all command line options is presented below. Please note that
 most options have a "short" format (e.g. <b>-p</b>) and a "long" format
 (e.g. <b>--port</b>). The "long" form is only available on systems that
@@ -36,33 +36,33 @@ have GNU getopt; this <b>excludes</b> the Windows version.</p>
 
 <dl>
 <dt><b>-b</b>, <b>--no-color</b>, <b>--no-colour</b></dt>
-<dd>"Black and white". This tells the dopewars client (if that is what
+<dd>"Black and white". This tells the Church Wars client (if that is what
 you're running) not to use coloured text (by default, colour is used if the
 terminal and curses support it).</dd>
 
 <dt><a id="singleplayer"><b>-n</b>, <b>--single-player</b></a></dt>
 <dd>If running the client, run in single-player mode. Don't try to connect
-to any available dopewars servers.</dd>
+to any available Church Wars servers.</dd>
 
 <dt><a id="antique"><b>-a</b>, <b>--antique</b></a></dt>
-<dd>Puts the client into "antique" mode; dopewars is derived from the
+<dd>Puts the client into "antique" mode; Church Wars is derived from the
 earlier game for MS-DOS of the same name, which in turn was based on
 "Drug Wars" by John E. Dell. "Antique" mode aims to follow the behaviour
-of the MS-DOS dopewars closely, and consequently this entails single-player
+of the MS-DOS Church Wars closely, and consequently this entails single-player
 mode also.</dd>
 
 <dt><a id="hiscore"><b>-f <i>file</i></b>, <b>--scorefile=<i>file</i></b>
 </a></dt>
-<dd>Specifies the path and name of the file used to store the dopewars
+<dd>Specifies the path and name of the file used to store the Church Wars
 high scores in; this can alternatively be specified in the configuration file
 with the <a href="configfile.html#HiScoreFile">HiScoreFile=<i>file</i></a>
-option. (N.B. This option cannot be used to get dopewars to open a high
+option. (N.B. This option cannot be used to get Church Wars to open a high
 score file with privilege when running setuid/setgid; all privileges are
 dropped by this point for security.)</dd>
 
 <dt><a id="server"><b>-o <i>addr</i></b>, <b>--hostname=<i>addr</i></b>
 </a></dt>
-<dd>Gives the name of the machine running a dopewars server, in human
+<dd>Gives the name of the machine running a Church Wars server, in human
 readable (e.g. "nowhere.com") or dotted quad (e.g. 127.0.0.1) form. When the
 client is started, if not in single-player mode, it automatically attempts to
 connect to this server for a multiplayer game. This can also be specified with
@@ -72,7 +72,7 @@ option.</dd>
 <dt><a id="port"><b>-p <i>port</i></b>, <b>--port=<i>port</i></b></a></dt>
 <dd>Specifies the numeric port number which the server uses. This is usually
 7902, but some servers may use other port numbers to avoid conflicts with
-other services running on the machine. If you are running the dopewars client,
+other services running on the machine. If you are running the Church Wars client,
 it will search for a server on this port; if you are running the server, it
 will bind to this port and wait for connections from clients (the clients
 must also be instructed to use this port, of course). This is equivalent to
@@ -81,18 +81,18 @@ setting the port number with the
 option.</dd>
 
 <dt><b>-s</b>, <b>--public-server</b></dt>
-<dd>Runs the <a href="server.html">dopewars server</a>. This mediates
-multiplayer games of dopewars, and keeps track of high scores. Any player
+<dd>Runs the <a href="server.html">Church Wars server</a>. This mediates
+multiplayer games of Church Wars, and keeps track of high scores. Any player
 wishing to join the game hosted
-by this server must connect to your machine using the dopewars client and the
+by this server must connect to your machine using the Church Wars client and the
 port number which you have chosen, and can then interact with other players
-who have done the same thing. By default, a dopewars server will report its
+who have done the same thing. By default, a Church Wars server will report its
 status to the <a href="metaserver.html">metaserver</a>, unless it is set
 otherwise in the <a href="configfile.html#MetaServerActive">configuration
 file</a>.</dd>
 
 <dt><a id="privateserver"><b>-S</b>, <b>--private-server</b></a></dt>
-<dd>Also runs a dopewars server, but in this case <b>does not</b> report its
+<dd>Also runs a Church Wars server, but in this case <b>does not</b> report its
 status to the metaserver. This does not stop clients from connecting to your
 server, of course (unless it is behind a firewall, or the
 <a href="configfile.html#MaxClients">maximum number of clients</a> is exceeded),
@@ -102,13 +102,13 @@ but it makes it harder to find. The connection to the
 configuration files.</dd>
 
 <dt><b>-A</b>, <b>--admin</b></dt>
-<dd>Connects to a dopewars server running on this machine, and allows
+<dd>Connects to a Church Wars server running on this machine, and allows
 <a href="servercommands.html">server commands</a> to be issued. Only the user
 that originally started the server (or the superuser) is permitted to do
 this. Only supported for the text-mode server on Unix systems.</dd>
 
 <dt><b>-g <i>file</i></b>, <b>--config-file=<i>file</i></b></dt>
-<dd>Instructs dopewars to read setup information from the
+<dd>Instructs Church Wars to read setup information from the
 <a href="configfile.html">configuration file</a> named by <b><i>file</i></b>.
 This file is read immediately - i.e. at the point at which the -g option is
 encountered - and so these settings will override any set in the default
@@ -118,38 +118,38 @@ that change these same settings, will then override them.</dd>
 
 <dt><b>-r <i>file</i></b>, <b>--pidfile=<i>file</i></b></dt>
 <dd>Maintains a pid file with the specified name while the server is running.
-The file is a one-line text file, containing the process ID of the dopewars
+The file is a one-line text file, containing the process ID of the Church Wars
 server process, and is deleted when the server quits.</dd>
 
 <dt><a id="computer"><b>-c</b>, <b>--ai-player</b></a></dt>
-<dd>Runs a computerised player. This will connect to the specifed dopewars
+<dd>Runs a computerised player. This will connect to the specifed Church Wars
 server and join in the multiplayer game going on there. When the player
 finishes the game (or is eliminated by the other players or the server) the
 program finishes.</dd>
 
 <dt><a id="gui-client"><b>-w</b>, <b>--windowed-client</b></a></dt>
-<dd>If running a dopewars client, then this forces the use of a graphical
+<dd>If running a Church Wars client, then this forces the use of a graphical
 user interface. Under Microsoft Windows, this is an "ordinary" window, while
 under Unix, this uses GTK+. If a suitable environment is not present (e.g.
 the binary was compiled without graphical support, or - in the case of GTK+ -
-you are not running X) then dopewars will quit with an error. By default,
+you are not running X) then Church Wars will quit with an error. By default,
 if neither -w or -t are specified, then a graphical user interface will be
 used where available, falling back to a text-mode client in case of error.</dd>
 
 <dt><a id="text-client"><b>-t</b>, <b>--text-client</b></a></dt>
-<dd>When running a dopewars client, forces the use of a text-mode (curses
+<dd>When running a Church Wars client, forces the use of a text-mode (curses
 or console mode) interface, even if graphics are available.</dd>
 
 <dt><b>-P <i>name</i></b>, <b>--player=<i>name</i></b></dt>
 <dd>Sets the default player name.</dd>
 
 <dt><b>-C <i>file</i></b>, <b>--convert=<i>file</i></b></dt>
-<dd>Converts a high score file from an older version of dopewars to the format
+<dd>Converts a high score file from an older version of Church Wars to the format
 used by the current version. The old high score file is replaced with a new
 file, and a backup copy of the old file is made. This conversion process is
-necessary since older versions of dopewars did not identify the high score
+necessary since older versions of Church Wars did not identify the high score
 files properly, so they cannot be automatically converted. (Such automatic
-conversion would also pose a security risk if the dopewars binary is running
+conversion would also pose a security risk if the churchwars binary is running
 setgid.)</dd>
 
 <dt><b>-u <i>name</i></b>, <b>--plugin=<i>name</i></b></dt>
@@ -164,7 +164,7 @@ option is given, the first valid sound plugin to be found is used.</dd>
 contact details.</dd>
 
 <dt><b>-v</b>, <b>--version</b></dt>
-<dd>Displays the current dopewars version number, and then exits.</dd>
+<dd>Displays the current Church Wars version number, and then exits.</dd>
 
 </dl>
 

--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -6,16 +6,16 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>dopewars configuration files</title>
+<title>Church Wars configuration files</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>dopewars configuration files</h1>
+<h1>Church Wars configuration files</h1>
 
-<p>A dopewars <a href="server.html">server</a>, or a <a href="clientplay.html">
+<p>A Church Wars <a href="server.html">server</a>, or a <a href="clientplay.html">
 client</a> (in single-player mode) can be heavily configured by the means
-of dopewars configuration files. Clients used to connect to multiplayer
+of Church Wars configuration files. Clients used to connect to multiplayer
 servers can also be configured by the same means, but almost all of these
 settings will be overridden on connecting to the server (although the server
 location settings <i>Port</i> and <i>Server</i> are still useful).</p>
@@ -27,13 +27,13 @@ location settings <i>Port</i> and <i>Server</i> are still useful).</p>
 <li><a href="example-igneous">Igneous's mod (complete)</a></li>
 </ul>
 
-<p>The order of making dopewars settings is as follows:-</p>
+<p>The order of making Church Wars settings is as follows:-</p>
 <ol>
-<li>The global configuration file (if present) <b>/etc/dopewars</b></li>
-<li>The user-specific file (if present) <b>~/.dopewars</b></li>
-<li><i>(Windows only)</i> The file <b>dopewars-config.txt</b> in the current
+<li>The global configuration file (if present) <b>/etc/churchwars</b></li>
+<li>The user-specific file (if present) <b>~/.churchwars</b></li>
+<li><i>(Windows only)</i> The file <b>churchwars-config.txt</b> in the current
 user's application data directory (e.g.
-<tt>C:\Users\foo\AppData\Local\dopewars\</tt>)</li>
+<tt>C:\Users\foo\AppData\Local\Church Wars\</tt>)</li>
 <li>Options specified on the <a href="commandline.html">command line</a></li>
 </ol>
 
@@ -84,13 +84,13 @@ locations</a></li>
 
 <dl>
 <dt><a id="Port"><b>Port=<i>7902</i></b></a></dt>
-<dd>Tells the dopewars client to look for a server on port <i>7902</i>, and
-tells the dopewars server to bind to port <i>7902</i> and wait for connections.
+<dd>Tells the Church Wars client to look for a server on port <i>7902</i>, and
+tells the Church Wars server to bind to port <i>7902</i> and wait for connections.
 This can be overridden with the -p <a href="commandline.html#port">
 command line option</a>.</dd>
 
 <dt><a id="Server"><b>Server=<i>"localhost"</i></b></a></dt>
-<dd>Tells the dopewars client to look for a server at the address
+<dd>Tells the Church Wars client to look for a server at the address
 <i>localhost</i>. Dotted quad (e.g. 127.0.0.1) addresses may also be used here.
 If this variable is set to one of the three "special" names
 <b>(MetaServer)</b>, <b>(Prompt)</b>, or <b>(Single)</b> (including the 
@@ -104,34 +104,34 @@ the name of the server that the client connects to - if you're running your
 own server it does not change the address that it binds to. For that, see
 the <b>BindAddress</b> variable.</dd>
 
-<dt><b>ServerMOTD=<i>"Welcome to my dopewars server"</i></b></dt>
+<dt><b>ServerMOTD=<i>"Welcome to my Church Wars server"</i></b></dt>
 <dd>When running a server, any client that connects displays the welcome
-"message of the day" <i>"Welcome to my dopewars server"</i>. This can
+"message of the day" <i>"Welcome to my Church Wars server"</i>. This can
 be used, for example, to inform users of any special features that the
 server has.</dd>
 
 <dt><b>BindAddress=<i>"localhost"</i></b></dt>
-<dd>Forces your dopewars server (if you run one) to accept network connections
+<dd>Forces your Church Wars server (if you run one) to accept network connections
 only on the <i>localhost</i> network interface. (This can be a host name,
 or an IP address.) If this is left blank (the default) then the server will
 accept connections coming in on any valid network interface.
 </dd>
 
 <dt><b>Socks.Active=<i>FALSE</i></b></dt>
-<dd>Instructs the dopewars client to connect directly to the given server,
+<dd>Instructs the Church Wars client to connect directly to the given server,
 without using an intermediate SOCKS server. If this is set to TRUE, all
 connections go via the SOCKS server. By default, SOCKS is not used for
 metaserver communications - see the MetaServer.UseSocks variable. N.B. You
-cannot run a dopewars server behind a SOCKS server, due to limitations in
+cannot run a Church Wars server behind a SOCKS server, due to limitations in
 the SOCKS protocol.</dd>
 
 <dt><b>Socks.NumUID=<i>FALSE</i></b></dt>
 <dd>When connecting to a SOCKS version 4 server, the protocol demands that
 the name of the current user be sent for simple authentication; the SOCKS
 server then queries identd on your machine to check if you are who you say
-you are. dopewars complies with this requirement if this variable is set to
+you are. Church Wars complies with this requirement if this variable is set to
 FALSE. However, some Unix implementations of identd send numeric user IDs
-rather than user names; dopewars will do the same if you set this variable 
+rather than user names; Church Wars will do the same if you set this variable 
 to TRUE. (N.B. Not supported on Windows systems.)</dd>
 
 <dt><b>Socks.User=<i>"fred"</i></b></dt>
@@ -160,18 +160,18 @@ the user for a username and password on each connect instead.)</dd>
 <dt><b>Socks.Auth.Password=<i>""</i></b></dt>
 <dd>The corresponding password for Socks.Auth.User, above.</dd>
 
-<dt><a id="HiScoreFile"><b>HiScoreFile=<i>"/var/lib/dopewars.sco"</i></b></a>
+<dt><a id="HiScoreFile"><b>HiScoreFile=<i>"/var/lib/churchwars.sco"</i></b></a>
 </dt>
-<dd>Tells the dopewars server (or the client, if running in single-player
-mode, not connected to a server) to use the file <i>/var/lib/dopewars.sco</i>
+<dd>Tells the Church Wars server (or the client, if running in single-player
+mode, not connected to a server) to use the file <i>/var/lib/churchwars.sco</i>
 to store high scores. This can be overridden with the -f
 <a href="commandline.html#hiscore">command line option</a>.
-(N.B. This option cannot be used to get dopewars to open a high
+(N.B. This option cannot be used to get Church Wars to open a high
 score file with privilege when running setuid/setgid; all privileges are
 dropped by this point for security.)</dd>
 
 <dt><b>MinToSysTray=<i>TRUE</i></b></dt>
-<dd>Rather than behaving as a normal window, the dopewars server window adds
+<dd>Rather than behaving as a normal window, the Church Wars server window adds
 an icon to the Windows System Tray, and, when the window is minimized, it
 vanishes completely. Clicking on the System Tray icon will restore the
 window to its normal state. If FALSE, the System Tray is not used. Only
@@ -199,27 +199,27 @@ set, and then remains in force until it is reset again.</dd>
 <h2><a id="metaserver">Metaserver configuration</a></h2>
 <dl>
 <dt><a id="MetaServerActive"><b>MetaServer.Active=<i>TRUE</i></b></a></dt>
-<dd>Tells the dopewars server to report its status to the
+<dd>Tells the Church Wars server to report its status to the
 <a href="metaserver.html">metaserver</a>. If <i>TRUE</i>
 is replaced by <i>FALSE</i> the server will not report to the metaserver.
 This setting, if set to TRUE, can be overridden by the -S
 <a href="commandline.html#privateserver">command line option</a>.</dd>
 
-<dt><b>MetaServer.URL=<i>"https://dopewars.sourceforge.io/metaserver.php"</i></b></dt>
-<dd>Tells dopewars that the metaserver PHP script is located at
-<i>https://dopewars.sourceforge.io/metaserver.php</i>. This is used for server
+<dt><b>MetaServer.URL=<i>"https://churchwars.sourceforge.io/metaserver.php"</i></b></dt>
+<dd>Tells Church Wars that the metaserver PHP script is located at
+<i>https://churchwars.sourceforge.io/metaserver.php</i>. This is used for server
 registration (server mode) or listing the available servers (client mode);
 see the <a href="metaserver.html">metaserver</a> page. If a proxy is needed to
 connect to the web server, set the
 <a href="https://curl.haxx.se/libcurl/c/libcurl-tutorial.html#Environment">https_proxy environment variable</a>.</dd>
 
-<dt><a id="MetaServerComment"><b>MetaServer.Comment=<i>"dopewars
+<dt><a id="MetaServerComment"><b>MetaServer.Comment=<i>"Church Wars
 server"</i></b></a></dt>
 <dd>Sets the comment for your server, which appears on the list of servers
-maintained by the metaserver, to <i>dopewars server</i>.</dd>
+maintained by the metaserver, to <i>Church Wars server</i>.</dd>
 
 <dt><b>MetaServer.LocalName=<i>"dope-serv.com"</i></b></dt>
-<dd>Tells the metaserver that the preferred hostname of your dopewars server
+<dd>Tells the metaserver that the preferred hostname of your Church Wars server
 machine is <i>dope-serv.com</i>. By default, the metaserver tries to ascertain
 your domain name from the connection, and this can fail if you connect via
 a proxy server, or if DNS does not properly translate your IP address to your
@@ -230,7 +230,7 @@ suitable password to identify "your" server, even if its IP changes.
 See the <a href="metaserver.html">metaserver page</a> for more details.</dd>
 
 <dt><b>MetaServer.Password=<i>"auth"</i></b></dt>
-<dd>Uses the password <i>auth</i> to authenticate your dopewars server's
+<dd>Uses the password <i>auth</i> to authenticate your Church Wars server's
 hostname (see MetaServer.LocalName above) with the metaserver.</dd>
 
 </dl>
@@ -311,7 +311,7 @@ the game.</dd>
 <i>$4,400</i>.</dd>
 
 <dt><b>Drug[<i>1</i>].Cheap=<i>TRUE</i></b></dt>
-<dd>Tells dopewars that drug <i>1</i> (by default, Acid) can occasionally
+<dd>Tells Church Wars that drug <i>1</i> (by default, Acid) can occasionally
 be especially cheap (if this is set to FALSE, this does not happen).</dd>
 
 <dt><b>Drug[<i>1</i>].CheapStr=<i>"The market is flooded with cheap
@@ -320,12 +320,12 @@ home-made acid!"</i></b></dt>
 is especially cheap.</dd>
 
 <dt><b>Drugs.CheapDivide=<i>4</i></b></dt>
-<dd>Tells dopewars that whenever a drug is "specially" cheap, divide the 
+<dd>Tells Church Wars that whenever a drug is "specially" cheap, divide the 
 normal price distribution (between Drug[x].MinPrice and Drug[x].MaxPrice) by
 <i>4</i>.</dd>
 
 <dt><b>Drug[<i>4</i>].Expensive=<i>TRUE</i></b></dt>
-<dd>Tells dopewars that drug <i>4</i> (normally Heroin) can occasionally be
+<dd>Tells Church Wars that drug <i>4</i> (normally Heroin) can occasionally be
 particuarly expensive (FALSE cancels this).</dd>
 
 <dt><b>Drugs.ExpensiveStr1=<i>"Cops made a big %tde bust! Prices are
@@ -343,7 +343,7 @@ prices!"</i></b></dt>
 time.</dd>
 
 <dt><b>Drugs.ExpensiveMultiply=<i>4</i></b></dt>
-<dd>Tells dopewars that whenever a drug is "specially" expensive, multiply the
+<dd>Tells Church Wars that whenever a drug is "specially" expensive, multiply the
 normal price distribution (between Drug[x].MinPrice and Drug[x].MaxPrice) by
 <i>4</i>.</dd>
 </dl>
@@ -365,7 +365,7 @@ Guns offered "on the street" (i.e. by random events) will be priced at about
 one half of the value set here.</dd>
 
 <dt><b>Gun[<i>3</i>].Space=<i>4</i></b></dt>
-<dd>Tells dopewars that gun number <i>3</i> uses <i>4</i> spaces in the 
+<dd>Tells Church Wars that gun number <i>3</i> uses <i>4</i> spaces in the 
 inventory - i.e. carrying one of these guns uses the same spaces as 4
 drugs.</dd>
 
@@ -451,10 +451,10 @@ etc.</dd>
 <dd>Prints Currency.Symbol in front of any price - e.g. "$1,000"; if
 FALSE, prints it after the price - e.g. "1,000 $".</dd>
 
-<dt><b>Log.File=<i>dopewars.log</i></b></dt>
+<dt><b>Log.File=<i>churchwars.log</i></b></dt>
 <dd>By default, server log messages are printed to the screen (standard
 output). By setting this variable, they will instead be written to the file
-<i>dopewars.log</i>.</dd>
+<i>churchwars.log</i>.</dd>
 
 <dt><b>Log.Level=<i>2</i></b></dt>
 <dd>Most server log messages are given a priority level, from 0 (most urgent)
@@ -478,7 +478,7 @@ from the random events. To completely remove drug references, of course, you
 must also alter the drug names above.</dd>
 
 <dt><b>DrugSortMethod=<i>1</i></b></dt>
-<dd>Tells the dopewars client how to sort the names of available drugs at
+<dd>Tells the Church Wars client how to sort the names of available drugs at
 each location for display. The default, <i>1</i>, sorts them in alphabetical
 order by their names. The choices are as follows:-
 <ul>
@@ -523,7 +523,7 @@ takes at least 5 seconds.</dd>
 
 <dt><b>Names.Bitch=<i>"bitch"</i></b></dt>
 <dd>Sets the word used to describe a single "bitch" in the game. Bitch, gun
-and drug names are automatically capitalised where necessary by the dopewars
+and drug names are automatically capitalised where necessary by the Church Wars
 code.</dd>
 
 <dt><b>Names.Bitches=<i>"bitches"</i></b></dt>
@@ -634,7 +634,7 @@ can be configured in the same way are: <b>FightMiss</b>, <b>FightReload</b>,
 <dt><b>encoding <i>"UTF-8"</i></b></dt>
 <dd>Specifies that any text following this directive (in this configuration
 file only) is in <i>"UTF-8"</i> encoding. This directive is only supported
-if dopewars is built on a Unix system and linked against GLib version 2.
+if Church Wars is built on a Unix system and linked against GLib version 2.
 If unspecifed, then it will be assumed that your configuration files are
 in the locale's default encoding - e.g. ISO-8859-1 for C or POSIX locales,
 ISO-8859-2 for pl_PL, ISO-8859-15 for es_ES@euro, or UTF-8 for en_GB.UTF-8.</dd>

--- a/doc/contribute.html
+++ b/doc/contribute.html
@@ -13,14 +13,14 @@
 <body>
 <h1>How to contribute</h1>
 
-<p>dopewars is open-source software, meaning that it is free for anybody to
+<p>Church Wars is open-source software, meaning that it is free for anybody to
 use. However, this also means that the quality of the software is dependent
 in part on <b>you</b> the user. You <b>don't</b> have to be a programmer to
-help out - in fact, dopewars currently needs people to produce sounds and
+help out - in fact, Church Wars currently needs people to produce sounds and
 graphics rather than to write code.</p>
 
 <ul>
-<li><b>Sounds</b> are needed. dopewars-1.5.7 and later support sounds, but
+<li><b>Sounds</b> are needed. churchwars-1.5.7 and later support sounds, but
 don't contain sounds for every game event. If <b>you</b> can provide
 copyright-free sounds, then short files are needed for various effects
 in the game. For example,
@@ -28,24 +28,24 @@ gunshots, bullet hits, ricochets and subway trains are obvious candidates
 for sound effects, although pretty much any event in the game that you can
 think of can conceivably have a sound (e.g. when players join or leave the
 game). These sounds should be in WAV format, and should probably be no more
-than a second or two in length. Later versions of dopewars may also be able
+than a second or two in length. Later versions of Church Wars may also be able
 to play longer repeating sounds (i.e. music) if you're interested in
 contributing this. Please open a
-<a href="https://github.com/benmwebb/dopewars/pulls">pull request</a>
-to add sound files to dopewars.
+<a href="https://github.com/benmwebb/churchwars/pulls">pull request</a>
+to add sound files to churchwars.
 <p /></li>
 
 <li><b>Suggestions</b> for future improvements are always welcomed at the
-<a href="https://github.com/benmwebb/dopewars/issues">issue tracker</a>.
+<a href="https://github.com/benmwebb/churchwars/issues">issue tracker</a>.
 These can be anything from "the game interface
 is confusing" through "more game locations are needed" to "what about a
 hospital". (I can't guarantee that such suggestions will ever make it
-into dopewars, but it's a lot easier if I know they exist! Also, it's
+into Church Wars, but it's a lot easier if I know they exist! Also, it's
 far more likely to happen if you write the code - see the
 <a href="developer.html">tips for developers</a> page.)<p /></li>
 
 <li><b>Bug reports</b> are always useful. Register them with the
-<a href="https://github.com/benmwebb/dopewars/issues">issue tracker</a>.
+<a href="https://github.com/benmwebb/churchwars/issues">issue tracker</a>.
 If I don't know the problem exists, I can't fix it...
 The more information you can give here, the better. In particular, I need
 to know your operating system - e.g. Linux or Windows. For Linux, gdb stack
@@ -54,10 +54,10 @@ traces of the core file are most useful.<p /></li>
 <li><b>Configuration files</b> can be included in future distributions. If
 you run a customised game, and think others might want to play with your
 configuration, or at least use it as an example, then post it in the
-<a href="https://github.com/benmwebb/dopewars/issues">issue tracker</a>.
+<a href="https://github.com/benmwebb/churchwars/issues">issue tracker</a>.
 <p /></li>
 
-<li><b>Translation</b> of dopewars into your language will enable you to
+<li><b>Translation</b> of Church Wars into your language will enable you to
 play the game in your native tongue, and will also help others that speak
 the same language. It's pretty easy, too - all you have to do is edit a
 simple text file! See the <a href="i18n.html">i18n pages</a>.<p /></li>

--- a/doc/credits.html
+++ b/doc/credits.html
@@ -13,25 +13,25 @@
 <body>
 <h1>Credits and acknowledgements</h1>
 
-<p>dopewars is derived from the MS-DOS game of the same name (author
+<p>Church Wars is derived from the MS-DOS game of the same name (author
 unknown).</p>
 
 <p>This is turn was based upon the MS-DOS game "Drug Wars", by John E. Dell.</p>
 
-<p>dopewars is written by and is copyright of
+<p>Church Wars is written by and is copyright of
 <a href="mailto:benwebb@users.sf.net">Ben Webb</a>.</p>
 
-<p>Pivotal to the development of dopewars were and are the following:-</p>
+<p>Pivotal to the development of Church Wars were and are the following:-</p>
 
 <p><b>Dan Wolf</b> for uncountable numbers of useful suggestions for the
 structure of the multiplayer game, drawing upon a disturbing knowledge of the
 drugs world. He also undertook scary amounts of research (i.e. playing the
 game) to assist with the re-engineering of the MS-DOS version, and plays the
 game to an unhealthy extent (as is witnessed by his high scores on many
-dopewars servers).</p>
+Church Wars servers).</p>
 
 <p><b>Phil Davis, Caroline Moore, Katherine Holt</b> and <b>Andrea
-Elliot-Smith</b> for extensive play testing of early versions of dopewars,
+Elliot-Smith</b> for extensive play testing of early versions of Church Wars,
 despite the large amounts of "real" work which they were supposed to be
 doing, and despite the many dodgy bugs, as well as for providing
 suggestions, even if they were often rude. You know who you are.</p>
@@ -47,7 +47,7 @@ as well as spotting many of his own and my bugs...</p>
 
 <p><b>Matt Higgins</b> for a couple of patches to version 1.4.4.</p>
 
-<p><b>Tony Brown</b> for assistance with using dopewars via enforced web
+<p><b>Tony Brown</b> for assistance with using Church Wars via enforced web
 proxies.</p>
 
 <p><b>Leon Breedt</b> for writing a manpage, and creating a Debian package.</p>
@@ -57,7 +57,7 @@ proxies.</p>
 <p><b>Tobias Mathes</b>, <b>Slawomir Molenda</b>, <b>Leonard</b>,
 <b>Quique</b>, <b>&Aring;smund Skj&aelig;veland</b>, <b>Hugo Cisneiros</b>,
 <b>Eric Steiner</b>, <b>François Marier</b>, <b>Benjamin Karaca</b>,
-and <b>Bruno Lopes</b> for translating dopewars into
+and <b>Bruno Lopes</b> for translating Church Wars into
 other languages.</p>
 
 <hr />

--- a/doc/developer.html
+++ b/doc/developer.html
@@ -16,26 +16,26 @@
 <p>You are free to make whatever changes to the code you wish, as long as you
 abide by the terms set out in the <a href="LICENCE">GNU General
 Public License</a>. Obviously, I only have a limited amount of time to devote
-to dopewars development, and so encourage discussion of the dopewars code,
+to Church Wars development, and so encourage discussion of the Church Wars code,
 documentation and concept, and particularly welcome suggested improvements.</p>
 
 <p>You are free to distribute modified versions of the code,
 again subject to the license, but I also welcome additions to the code
-via <a href="https://github.com/benmwebb/dopewars/pulls">pull requests</a>.
-If I choose to include this code in a new dopewars version, you will of
+via <a href="https://github.com/benmwebb/churchwars/pulls">pull requests</a>.
+If I choose to include this code in a new Church Wars version, you will of
 course be credited in the changelog (unless, of course, you don't want to
 be).</p>
 
-<p>If you wish to write your own client to connect to a dopewars server, then
-you need to understand the protocol that dopewars uses, which is
+<p>If you wish to write your own client to connect to a Church Wars server, then
+you need to understand the protocol that Church Wars uses, which is
 documented <a href="protocol.html">here</a>.</p>
 
-<p>The definitive source on the internal workings of the dopewars game code
+<p>The definitive source on the internal workings of the Church Wars game code
 is the source code itself. It is not exactly "self-documenting", but I have
 endeavoured to add sufficient documentation to the source where necessary;
 any discussion here of the internal workings, however, may be incomplete, out
 of date, and possibly misleading. Feel free to
-<a href="https://github.com/benmwebb/dopewars/issues">open an issue</a>
+<a href="https://github.com/benmwebb/churchwars/issues">open an issue</a>
 with questions on this; I might possibly even know the answers!</p>
 
 <hr />

--- a/doc/dopewars.6.in
+++ b/doc/dopewars.6.in
@@ -1,11 +1,11 @@
-.TH DOPEWARS 6
+.TH CHURCHWARS 6
 .SH NAME
-dopewars \- drug dealing game
+Church Wars \- drug dealing game
 .SH SYNOPSIS
-.B dopewars
+.B Church Wars
 .I "[OPTIONS] ..."
 .SH "DESCRIPTION"
-.B dopewars
+.B Church Wars
 is a ncurses- and GTK- based drug dealing game based in New York, with you as
 the drug dealer striving to become filthy rich. It supports network
 play and single-player games.
@@ -16,14 +16,14 @@ Valid commandline options:
 "black and white", i.e. do not use pretty colours
 .TP
 \fB\-n\fR, \fB\-\-single\-player\fR
-Do not connect to any available dopewars servers
+Do not connect to any available Church Wars servers
 .TP
 \fB\-a\fR, \fB\-\-antique\fR
-Antique dopewars; stick as close as possible to the functionality of the
+Antique Church Wars; stick as close as possible to the functionality of the
 original version.
 .TP
 \fB\-f\fR, \fB\-\-scorefile\fR=\fIFILE\fR
-Specify a file to use as high score table (defaults to @DPDATADIR@/dopewars.sco)
+Specify a file to use as high score table (defaults to @DPDATADIR@/churchwars.sco)
 .TP
 \fB\-o\fR, \fB\-\-hostname\fR=\fIADDR\fR
 Specify a multiplayer hostname
@@ -39,7 +39,7 @@ Run as a "private" server (do not report to the metaserver)
 Specify the network port to use
 .TP
 \fB\-g\fR, \fB\-\-config\-file\fR=\fIFILE\fR
-Specify the pathname of a dopewars configuration file
+Specify the pathname of a Church Wars configuration file
 .TP
 \fB\-r\fR, \fB\-\-pidfile\fR=\fIFILE\fR
 Specify the pathname of a PID file to maintain while running as a server
@@ -64,7 +64,7 @@ is used when possible)
 Sets the default player name
 .TP
 \fB\-C\fR, \fB\-\-convert\fR=\fIFILE\fR
-Convert a high score file used by dopewars-1.5.1 or earlier to the format
+Convert a high score file used by churchwars-1.5.1 or earlier to the format
 used by more recent versions
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/doc/help/cops.html
+++ b/doc/help/cops.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Cops Options</title>
+<title>Church Wars: Cops Options</title>
 </head>
 
 <body>
-<h1>dopewars: Cops Options</h1>
+<h1>Church Wars: Cops Options</h1>
 
 <ul>
 <li><b>Cop</b>: A list of all cops in the game. Use the "New"

--- a/doc/help/drugs.html
+++ b/doc/help/drugs.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Drugs Options</title>
+<title>Church Wars: Drugs Options</title>
 </head>
 
 <body>
-<h1>dopewars: Drugs Options</h1>
+<h1>Church Wars: Drugs Options</h1>
 
 <ul>
 <li><b>Drug</b>: A list of all drugs in the game. Use the "New"

--- a/doc/help/general.html
+++ b/doc/help/general.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: General Options</title>
+<title>Church Wars: General Options</title>
 </head>
 
 <body>
-<h1>dopewars: General Options</h1>
+<h1>Church Wars: General Options</h1>
 
 <ul>
 <li><b>Remove drug references</b>: Do not popup random events during the game
@@ -24,7 +24,7 @@ also need to change all the drug names in the
 this option on if you are using unusual characters (e.g. Hebrew or Cyrillic
 in the English version) as these will be otherwise lost when you save the file.
 Note that this is the default under Unix when running in UTF-8 locales. Note
-also that versions of dopewars prior to 1.5.8, or Unix versions linked against
+also that versions of Church Wars prior to 1.5.8, or Unix versions linked against
 GTK+1.x, will not be able to read UTF-8 configuration files.<p /></li>
 
 <li><b>Game length (turns)</b>: The number of days over which the game runs.

--- a/doc/help/guns.html
+++ b/doc/help/guns.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Guns Options</title>
+<title>Church Wars: Guns Options</title>
 </head>
 
 <body>
-<h1>dopewars: Guns Options</h1>
+<h1>Church Wars: Guns Options</h1>
 
 <ul>
 <li><b>Gun</b>: A list of all guns in the game. Use the "New"

--- a/doc/help/locations.html
+++ b/doc/help/locations.html
@@ -6,11 +6,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Location Options</title>
+<title>Church Wars: Location Options</title>
 </head>
 
 <body>
-<h1>dopewars: Location Options</h1>
+<h1>Church Wars: Location Options</h1>
 
 <ul>
 <li><b>Location</b>: A list of all locations in the game. Use the "New"

--- a/doc/help/server.html
+++ b/doc/help/server.html
@@ -6,16 +6,16 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Server Options</title>
+<title>Church Wars: Server Options</title>
 </head>
 
 <body>
-<h1>dopewars: Server Options</h1>
+<h1>Church Wars: Server Options</h1>
 
 <ul>
 <li><b>Server reports to metaserver</b>: If checked, then when running the
-dopewars server, it will report to the metaserver so that players can find
-your server from the dopewars website or from the New Game dialog's Metaserver
+Church Wars server, it will report to the metaserver so that players can find
+your server from the Church Wars website or from the New Game dialog's Metaserver
 tab. (If not checked, its existence will not be advertised, but people can
 still connect to your server if they know the hostname and port number.)
 <p /></li>
@@ -23,13 +23,13 @@ still connect to your server if they know the hostname and port number.)
 <li><b>Minimize to System Tray</b>: (Windows only) When running the
 graphical server, and it is minimized, do not show the window in the normal
 window list, but in the System Tray (the collection of small icons in the
-bottom right of the screen). Clicking on the dopewars icon in the Tray will
+bottom right of the screen). Clicking on the Church Wars icon in the Tray will
 restore the window to its normal state.<p /></li>
 
 <li><b>Metaserver URL</b>: The full URL for the metaserver script, used by
 both the server and client. You should not normally need to alter this.<p /></li>
 
-<li><b>Comment</b>: A description of your dopewars server, which is sent to
+<li><b>Comment</b>: A description of your Church Wars server, which is sent to
 the metaserver and can be used to tell potential clients the rough rules of
 your game.<p /></li>
 

--- a/doc/help/sounds.html
+++ b/doc/help/sounds.html
@@ -6,13 +6,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<title>dopewars: Sounds Options</title>
+<title>Church Wars: Sounds Options</title>
 </head>
 
 <body>
-<h1>dopewars: Sounds Options</h1>
+<h1>Church Wars: Sounds Options</h1>
 
-<p>This tab allows you to configure the sounds played by dopewars during the
+<p>This tab allows you to configure the sounds played by Church Wars during the
 game. To change a sound, first select it from the list. Then type the full
 path and name of a .WAV file into the "Sound file" box, or use the Browse
 button to find it on your computer. You can use the Play button to hear the

--- a/doc/i18n.html
+++ b/doc/i18n.html
@@ -13,36 +13,36 @@
 <body>
 <h1>Internationalization</h1>
 
-<p>dopewars uses the <a href="http://www.gnu.org/manual/gettext/">GNU
+<p>Church Wars uses the <a href="http://www.gnu.org/manual/gettext/">GNU
 gettext</a> utilities for internationalization (i18n) support. This allows the
-software to be translated into the local language at runtime - run dopewars in
+software to be translated into the local language at runtime - run Church Wars in
 the UK and it'll talk to you in English, but run it in Germany and it'll talk
 to you in German. This relies on translators to translate the program's output
 into each language beforehand, of course, and so native language speakers to
 carry out this task are always needed!</p>
 
 <ul>
-<li><a href="#running">Running dopewars with i18n support</a></li>
+<li><a href="#running">Running Church Wars with i18n support</a></li>
 <li><a href="#adding">Adding a new translation</a></li>
-<li><a href="#dopespec">dopewars specifics</a></li>
-<li><a href="#updating">Updating a translation for a new dopewars
+<li><a href="#dopespec">Church Wars specifics</a></li>
+<li><a href="#updating">Updating a translation for a new Church Wars
 version</a></li>
 <li><a href="#current">Currently available translations</a></li>
 </ul>
 
-<h2><a id="running">Running dopewars with i18n support</a></h2>
-<p>i18n is only included in versions of dopewars later than 1.4.8. By default,
+<h2><a id="running">Running Church Wars with i18n support</a></h2>
+<p>i18n is only included in versions of Church Wars later than 1.4.8. By default,
 "Native Language Support" is compiled in; binary installations should be
-already set up for i18n. When compiling dopewars from source code, the
+already set up for i18n. When compiling Church Wars from source code, the
 <tt>configure</tt> script should detect whether your system can support
 GNU gettext. To disable i18n,
 pass the <tt>--disable-nls</tt> option to the <tt>configure</tt> script.</p>
 
-<p>When you run your installed copy of dopewars, it should detect your "locale"
+<p>When you run your installed copy of Church Wars, it should detect your "locale"
 automatically and talk to you in your native language. If this does not happen,
 the following are some possible explanations:-</p>
 <ul>
-<li>dopewars cannot find the locale-specific language file - by default, stored
+<li>Church Wars cannot find the locale-specific language file - by default, stored
 under /usr/local/share/locale/</li>
 <li>Your language is not yet supported - why not add it yourself?</li>
 <li>Your system does not have locale support.</li>
@@ -52,12 +52,12 @@ under Windows is only supported by version 1.5.3 and later.</li>
 <li>You haven't set an environment variable to specify your locale (usually
 this is done automatically). For example, if you're using the <tt>bash</tt>
 shell and want a German translation, the command "<tt>export LANG=de_DE</tt>"
-should ensure that dopewars (and all other i18n-aware programs launched from
+should ensure that Church Wars (and all other i18n-aware programs launched from
 this shell) will use the German language.</li>
 </ul>
 
 <h2><a id="adding">Adding a new translation</a></h2>
-<p>Translation files are kept in the subdirectory <tt>po/</tt> of the dopewars
+<p>Translation files are kept in the subdirectory <tt>po/</tt> of the Church Wars
 source code distribution. They are named by
 <a href="http://userpage.chemie.fu-berlin.de/diverse/doc/ISO_639.html">
 2-letter language codes</a> followed by the <tt>.po</tt> extension - for
@@ -67,17 +67,17 @@ They are simple text files, consisting of lists of the original English string
 "msgstr").</p>
 
 <p>To add a new translation, first
-<a href="installation.html">install dopewars from source code</a>. This will
-generate the reference file <tt>dopewars.pot</tt> in the <tt>po</tt>
-subdirectory. Then, copy <tt>dopewars.pot</tt> to your language-specific
+<a href="installation.html">install Church Wars from source code</a>. This will
+generate the reference file <tt>churchwars.pot</tt> in the <tt>po</tt>
+subdirectory. Then, copy <tt>churchwars.pot</tt> to your language-specific
 <tt>.po</tt> file in the
 <tt>po/</tt> directory, and fill in the "msgstr" entries. Once this is done,
-edit the <tt>configure.ac</tt> file in the top dopewars directory to add your
+edit the <tt>configure.ac</tt> file in the top churchwars directory to add your
 language code to the <tt>ALL_LINGUAS</tt> variable. Then run <tt>autoconf</tt>
-to rebuild the <tt>configure</tt> script, before making and installing dopewars
+to rebuild the <tt>configure</tt> script, before making and installing Church Wars
 as usual. The new translation should now be available. Once this is complete,
-please <a href="https://github.com/benmwebb/dopewars/pulls">open a pull
-request</a> to have the translation included in the next dopewars version.</p>
+please <a href="https://github.com/benmwebb/churchwars/pulls">open a pull
+request</a> to have the translation included in the next Church Wars version.</p>
 
 <p>Please note that some strings are <b>format strings</b> containing the %
 character. These are used in the program code for substituting numbers and
@@ -96,7 +96,7 @@ probably crash the program on running! To fix this, use the special notation<br 
 (i.e. replace <b>%x</b> with <b>%n$x</b> where <b>n</b> is the index that the
 format specifier "should" have, starting from 1.)</p>
 
-<h2><a id="dopespec">dopewars specifics</a></h2>
+<h2><a id="dopespec">Church Wars specifics</a></h2>
 <ul>
 <li>When questions are asked in the curses (text mode) client, the keys that
 you are allowed to press in reply are stored in a string. This should be
@@ -104,9 +104,9 @@ translated to suitable keys in your language, in the <b>same</b> order as
 the original - e.g. "<tt>YN</tt>" (for Yes/No) could be translated in German
 to "<tt>JN</tt>" (for Ja/Nein).<p /></li>
 
-<li>When a dopewars server asks a client a question, the valid replies are
+<li>When a Church Wars server asks a client a question, the valid replies are
 sent at the start of the message, followed by a "<tt>^</tt>" character. These
-replies define the dopewars protocol, and so should <b>not</b> be
+replies define the Church Wars protocol, and so should <b>not</b> be
 translated - they will prevent clients and servers from talking to each other
 properly. So for example, the string "<tt>YN^Would you like to visit %s?</tt>"
 should be translated as you wish, but with the "<tt>YN^</tt>" at the start
@@ -122,9 +122,9 @@ free to translate <tt>%txx</tt> to use the most appropriate form of the word.
 If you wish to capitalise the first letter of the word (as used in English for
 titles, etc.) then use "<tt>%T</tt>" rather than "<tt>%t</tt>".<p />
 
-<p>Obviously dopewars cannot guess what your "alternative forms" are; you must
-specify them yourself. Essentially, when setting a string in a dopewars
-configuration file (or the defaults, which are set in dopewars.c) alternative
+<p>Obviously Church Wars cannot guess what your "alternative forms" are; you must
+specify them yourself. Essentially, when setting a string in a Church Wars
+configuration file (or the defaults, which are set in churchwars.c) alternative
 forms can be added by alternating two-letter codes and alternative forms after
 the original word, separating them by _ (underline) symbols. For example,<br />
 <tt>Names.Bitch = "bitch_no_bitcho_ac_bitche"</tt><br />
@@ -141,7 +141,7 @@ different two-letter codes as you want to.</p>
 <p>For a good working example of the "<tt>%tde</tt>" notation, see the
 Norwegian Nynorsk translation (<tt>nn.po</tt>).</p>
 
-<p>Additionally, prices in dopewars are automatically formatted into strings by
+<p>Additionally, prices in Church Wars are automatically formatted into strings by
 means of the %P notation, and comments can be introduced into format strings
 by means of the %/.../ notation. Everything between the two / characters is
 not printed. This is used to "qualify" some strings for translation, and the
@@ -151,25 +151,25 @@ not need to be translated).</p>
 
 </ul>
 
-<h2><a id="updating">Updating a translation for a new dopewars
+<h2><a id="updating">Updating a translation for a new Church Wars
 version</a></h2>
 
-<p>New versions of dopewars will often change what is printed to the user, and
+<p>New versions of Church Wars will often change what is printed to the user, and
 so may may require changes to the translation. To update an existing
-translation, change into the <tt>po</tt> subdirectory of the dopewars
-source code, and do a "<tt>make dopewars.pot</tt>". This creates the
-<tt>dopewars.pot</tt> file, which lists the strings that need translating.
+translation, change into the <tt>po</tt> subdirectory of the Church Wars
+source code, and do a "<tt>make churchwars.pot</tt>". This creates the
+<tt>churchwars.pot</tt> file, which lists the strings that need translating.
 Next, create a new translation file from your "old" translation file (we'll
-assume it's called <tt>de.po</tt>) and <tt>dopewars.pot</tt> with the
+assume it's called <tt>de.po</tt>) and <tt>churchwars.pot</tt> with the
 <tt>msgmerge</tt> command:-<br />
-<tt>msgmerge -o newfile de.po dopewars.pot</tt><br />
+<tt>msgmerge -o newfile de.po churchwars.pot</tt><br />
 Examine this new file <tt>newfile</tt> for translations that need updating
 (a search for "fuzzy" should find most of them) and then overwrite your old
 translation with the new one:<br />
 <tt>mv newfile de.po</tt><br />
-Rebuild and reinstall dopewars, and the new translations should become
+Rebuild and reinstall Church Wars, and the new translations should become
 available. Again, it is deeply appreciated if such updated files are
-contributed to the main dopewars distribution!</p>
+contributed to the main Church Wars distribution!</p>
 
 <h2><a id="current">Currently available translations</a></h2>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -12,12 +12,12 @@ col.linklist    { width: 35% }
 td.linklist     { vertical-align: top }
 -->
 </style>
-<title>dopewars 1.6.2: Main Index</title>
+<title>Church Wars 1.6.2: Main Index</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>dopewars 1.6.2: Main Index</h1>
+<h1>Church Wars 1.6.2: Main Index</h1>
 
 <table>
 <col class="linklist" />
@@ -25,39 +25,39 @@ td.linklist     { vertical-align: top }
 
 <tr>
 <td class="linklist">
-<a href="installation.html">Obtaining and installing dopewars</a><br />
-<a href="commandline.html">dopewars command line options</a><br />
-<a href="clientplay.html">Playing the game: the dopewars client</a><br />
-<a href="server.html">Setting up and running a dopewars server</a><br />
+<a href="installation.html">Obtaining and installing Church Wars</a><br />
+<a href="commandline.html">Church Wars command line options</a><br />
+<a href="clientplay.html">Playing the game: the Church Wars client</a><br />
+<a href="server.html">Setting up and running a Church Wars server</a><br />
 <a href="aiplayer.html">Adding computer-controlled players</a><br />
-<a href="configfile.html">dopewars configuration files</a><br />
-<a href="metaserver.html">The dopewars metaserver</a><br />
+<a href="configfile.html">Church Wars configuration files</a><br />
+<a href="metaserver.html">The Church Wars metaserver</a><br />
 <a href="i18n.html">Internationalization (i18n)</a><br />
-<a href="windows.html">dopewars and Microsoft Windows</a><br />
+<a href="windows.html">Church Wars and Microsoft Windows</a><br />
 <a href="contribute.html">How to contribute</a><br />
 <a href="developer.html">Notes for developers</a><br />
 <a href="credits.html">Credits and acknowledgements</a><br />
 </td>
 
 <td valign="top">
-<p>dopewars is a game simulating the life of a drug dealer in 1984 New York,
+<p>Church Wars is a game simulating the life of a drug dealer in 1984 New York,
 based upon the MS-DOS game of the same name, in turn derived from "Drug
 Wars" by John E. Dell. The aim of the game is to make lots and lots of
 money, but unfortunately you start the game with a hefty debt to the loan
 shark (who charges equally hefty interest) and the cops take a rather dim
 view of drug dealing...</p>
 
-<p>dopewars expands upon the MS-DOS version by introducing multiplayer
-functions. With the aid of dopewars servers, several players (computer or
+<p>Church Wars expands upon the MS-DOS version by introducing multiplayer
+functions. With the aid of Church Wars servers, several players (computer or
 human) can roam New York (or some other city, chosen by the operator of the
 server) and attempt to shoot other players and steal their lucrative drugs.</p>
 
-<p>dopewars is written on the RedHat Linux platform, and should run on most
+<p>Church Wars is written on the RedHat Linux platform, and should run on most
 varieties of Unix, as well as under Microsoft Windows. The source code is
 freely available under the <a href="LICENCE">GNU General Public License</a>.</p>
 
-<p>For more information on the current state of dopewars, check out the
-<a href="https://dopewars.sourceforge.io/">webpage</a>.</p>
+<p>For more information on the current state of Church Wars, check out the
+<a href="https://churchwars.sourceforge.io/">webpage</a>.</p>
 </td>
 
 </tr>

--- a/doc/installation.html
+++ b/doc/installation.html
@@ -6,17 +6,17 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>Obtaining and installing dopewars</title>
+<title>Obtaining and installing Church Wars</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>Obtaining and installing dopewars</h1>
+<h1>Obtaining and installing Church Wars</h1>
 
-<p>The dopewars source code and precompiled binaries (in RPM format) are
-available from the main dopewars web page,
-at <a href="https://dopewars.sourceforge.io/">
-https://dopewars.sourceforge.io/</a>. Just follow the link from
+<p>The Church Wars source code and precompiled binaries (in RPM format) are
+available from the main Church Wars web page,
+at <a href="https://churchwars.sourceforge.io/">
+https://churchwars.sourceforge.io/</a>. Just follow the link from
 there to the download section. "rpm" is the RedHat Package Manager, a program
 for simplifying installation and upgrade of programs, and is part of the
 RedHat Linux distribution. If you are using a different distribution, it
@@ -24,7 +24,7 @@ may be still be included, however. If you do not want to use "rpm", or the
 installation fails, then you can obtain the source code tarball and recompile
 the code from scratch.</p>
 
-<p><b>Prerequisites:</b> dopewars relies on the GLib library for all builds;
+<p><b>Prerequisites:</b> Church Wars relies on the GLib library for all builds;
 this library is used for parsing the configuration files, network and string
 handling, and many other purposes. On a Windows system, this is the only
 prequisite; the standard Windows libraries are used for everything else. On a
@@ -42,7 +42,7 @@ equivalent, such as ncurses or cur_colr) for the text-mode client, and the
 <h2><a id="win32">Windows installation</a></h2>
 <p>The easiest way to install the Windows version is to download the Windows
 installer program from the
-<a href="https://dopewars.sourceforge.io/download.html">download page</a>, and
+<a href="https://churchwars.sourceforge.io/download.html">download page</a>, and
 run it (either instruct your web browser to "run from the current location",
 or save it to somewhere obvious like the Desktop and then double-click on its
 icon later). This should install all relevant files, and set up Start Menu
@@ -57,16 +57,16 @@ crash with mysterious segmentation faults due to library conflicts.</p>
 
 <ol>
 <li>Download the 
-<a href="http://prdownloads.sourceforge.net/dopewars/dopewars-1.6.2-1.el7.x86_64.rpm">
+<a href="http://prdownloads.sourceforge.net/churchwars/churchwars-1.6.2-1.el7.x86_64.rpm">
 x86_64 (64-bit Intel for RedHat Enterprise 7)</a> RPM with your web browser.</li>
 
 <li>Become root on your Unix box (if you cannot become root, then you will
 probably not be able to use RPM installation, depending on how "rpm" is set
 up).</li>
 
-<li>Change to the directory containing the dopewars rpm, and install it with
+<li>Change to the directory containing the Church Wars rpm, and install it with
 the command<br />
-<tt><b>rpm -Uvh dopewars-1.6.2-1.el7.x86_64.rpm</b></tt><br /> This will replace any
+<tt><b>rpm -Uvh churchwars-1.6.2-1.el7.x86_64.rpm</b></tt><br /> This will replace any
 already-installed earlier version.</li>
 </ol>
 
@@ -78,13 +78,13 @@ building the binaries from it on your system.</p>
 
 <ol>
 <li>Download the
-<a href="http://prdownloads.sourceforge.net/dopewars/dopewars-1.6.2-1.el7.src.rpm">
+<a href="http://prdownloads.sourceforge.net/churchwars/churchwars-1.6.2-1.el7.src.rpm">
 source code RPM</a>.</li>
 
 <li>Become root and change to the directory containing the new rpm.</li>
 
 <li>Build a binary rpm with the command<br />
-<tt><b>rpmbuild --rebuild dopewars-1.6.2-1.el7.src.rpm</b></tt></li>
+<tt><b>rpmbuild --rebuild churchwars-1.6.2-1.el7.src.rpm</b></tt></li>
 
 <li>Change to the directory which the binary rpm has been written to (check
 the output of the above - usually /usr/src/redhat/RPMS/<i>xxx</i>, where
@@ -92,7 +92,7 @@ the output of the above - usually /usr/src/redhat/RPMS/<i>xxx</i>, where
 "alpha" on Alphas, "x86_64" on AMD64 or EM64T machines)</li>
 
 <li>Install the binary rpm with the command<br />
-<tt><b>rpm -Uvh dopewars-1.6.2-1.el7.<i>xxx</i>.rpm</b></tt></li>
+<tt><b>rpm -Uvh churchwars-1.6.2-1.el7.<i>xxx</i>.rpm</b></tt></li>
 </ol>
 
 <h2><a id="tarball">Tarball installation</a></h2>
@@ -104,21 +104,21 @@ your Unix box, or if you wish to build the Windows version from source code.</p>
 <p>Before beginning, you should ensure that you have all the necessary
 prequisites (see above). To compile on a Windows system, you will need
 the MinGW compiler and libraries; see the
-<a href="https://github.com/benmwebb/dopewars/tree/develop/win32">Windows-specific
+<a href="https://github.com/benmwebb/churchwars/tree/develop/win32">Windows-specific
 build page</a> for more information.
 </p>
 
 <ol>
 <li>Download the
-<a href="http://prdownloads.sourceforge.net/dopewars/dopewars-1.6.2.tar.gz">
+<a href="http://prdownloads.sourceforge.net/churchwars/churchwars-1.6.2.tar.gz">
 source code tarball</a>.</li>
 
 <li>Change to the directory containing the tarball and extract the contents
 with the command <br />
-<tt><b>tar -xvzf dopewars-1.6.2.tar.gz</b></tt><br />
+<tt><b>tar -xvzf churchwars-1.6.2.tar.gz</b></tt><br />
 (or similar).</li>
 
-<li>Change into the dopewars-1.6.2 directory, and read all the important
+<li>Change into the churchwars-1.6.2 directory, and read all the important
 documentation in there ;) Most notably, the INSTALL file gives more details
 on setup and installation.</li>
 
@@ -126,17 +126,17 @@ on setup and installation.</li>
 <tt><b>./configure</b><br />
 <b>make</b></tt></li>
 
-<li>Become root and install the dopewars files with<br />
+<li>Become root and install the Church Wars files with<br />
 <tt><b>make install</b></tt><br />
-<p>The configure script will test your system and set up dopewars so that it
+<p>The configure script will test your system and set up Church Wars so that it
 should compile cleanly.  The configure script supports a number of
 configurable options; for more details, read the INSTALL file in the
-dopewars-1.6.2 directory.</p>
+churchwars-1.6.2 directory.</p>
 
 <p>If you cannot become root, run the configure script specifying directories
-for which you have write access for the dopewars files, with a command
+for which you have write access for the Church Wars files, with a command
 such as<br />
-<tt><b>./configure --prefix=/home/user/dopewars</b></tt></p></li>
+<tt><b>./configure --prefix=/home/user/churchwars</b></tt></p></li>
 </ol>
 
 <hr />

--- a/doc/metaserver.html
+++ b/doc/metaserver.html
@@ -6,18 +6,18 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>The dopewars metaserver</title>
+<title>The Church Wars metaserver</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>The dopewars metaserver</h1>
+<h1>The Church Wars metaserver</h1>
 
-<p>Every dopewars <a href="server.html">server</a> is different, due to their
+<p>Every Church Wars <a href="server.html">server</a> is different, due to their
 differing locations and configurations. Thus some centralised system for
 listing the currently available servers and displaying some sort of comment
 about the games running on them is necessary, to enable client players to
-pick the game that most suits them. This is the function of the dopewars
+pick the game that most suits them. This is the function of the Church Wars
 <b>metaserver</b>.</p>
 
 <ul>
@@ -34,14 +34,14 @@ pick the game that most suits them. This is the function of the dopewars
 <h2><a id="location">Metaserver location</a></h2>
 <p>The metaserver is a <a href="https://www.php.net/">PHP</a> script which lives
 at <a href="https://sourceforge.net/">SourceForge</a>. It is accessed by both
-dopewars servers and clients via TCP connection to port 443, by standard
+Church Wars servers and clients via TCP connection to port 443, by standard
 encrypted HTTPS.</p>
 
 <h2><a id="client">Using the metaserver from the client</a></h2>
 <p>Players who want to use the metaserver to list the currently available
 servers should go to
-<a href="https://dopewars.sourceforge.io/metaserver.php?getlist=2">this
-link</a>, or just follow the "Active servers" link from the main dopewars web
+<a href="https://churchwars.sourceforge.io/metaserver.php?getlist=2">this
+link</a>, or just follow the "Active servers" link from the main Church Wars web
 page. It cannot be guaranteed that all the listed servers are functional - they
 may, for example, have been registered in error, or a server may have crashed
 since being added to the list - but the list is checked daily for service,
@@ -62,7 +62,7 @@ which <b>do</b> register their details can have their accompanying comment
 set with the <a href="configfile.html#MetaServerComment">
 MetaServer.Comment</a> configuration file setting.</p>
 
-<p>Each dopewars server notifies the metaserver of its current status, and
+<p>Each Church Wars server notifies the metaserver of its current status, and
 sends this data on startup and shutdown, and when players leave or join the
 game. See the <a href="server.html">server page</a> for more details.</p>
 
@@ -76,7 +76,7 @@ address of your server and not its domain name, or that it gets the domain
 name wrong. This is usually because your DNS is not set up to translate
 your IP into a domain name, or because you have multiple domain names for
 the one IP, and can be remedied by specifying the hostname with the
-MetaServer.LocalName variable in your dopewars
+MetaServer.LocalName variable in your Church Wars
 <a href="configfile.html">configuration file</a>. For security reasons,
 the metaserver will only accept this given name if it in turn maps to your
 IP address.</p>
@@ -90,21 +90,21 @@ password from the metaserver maintainer to authenticate your chosen hostname.
 <a href="mailto:benwebb@users.sf.net">Email</a> the maintainer, giving
 the exact hostname you want to use (be aware that this is case-sensitive) and
 you will be given a password. Specify this password with the MetaServer.Password
-variable in the dopewars configuration file.</p>
+variable in the Church Wars configuration file.</p>
 
 <p>For example, if you wish your server to be known as <b>dope-serv.com</b> and
 you have emailed the maintainer, receiving the password <b>Dope-Auth</b>, then
-add the following to the dopewars configuration file:-<br />
+add the following to the Church Wars configuration file:-<br />
 <b>MetaServer.LocalName="dope-serv.com"<br />
 MetaServer.Password="Dope-Auth"</b></p>
 
-<p>Restart your dopewars server, or send it a SIGUSR1 signal, for changes
+<p>Restart your Church Wars server, or send it a SIGUSR1 signal, for changes
 to these variables to take effect.</p>
 
 <h3><a id="dynamicip">But my server has a dynamic IP...</a></h3>
 <p>Finally, your server's IP may be resolved happily, but you may have a
 connection to the internet which assigns you a dynamic IP. Consider what
-happens if your connection is broken before the dopewars server exits; the
+happens if your connection is broken before the Church Wars server exits; the
 metaserver will list the IP of the "old" server, and you will now have no way
 of removing that entry when your connection comes back up, as your IP will be
 different. In this case, you can

--- a/doc/protocol.html
+++ b/doc/protocol.html
@@ -6,12 +6,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>The dopewars network protocol</title>
+<title>The Church Wars network protocol</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>The dopewars network protocol</h1>
+<h1>The Church Wars network protocol</h1>
 
 <ul>
 <li><a href="#syntax">Syntax used in this document</a></li>
@@ -43,7 +43,7 @@ the message exactly as printed here.</p>
 
 <h2><a id="format">General message format</a></h2>
 
-<p>dopewars clients communicate with the dopewars server by means of a TCP/IP
+<p>Church Wars clients communicate with the Church Wars server by means of a TCP/IP
 connection. Messages are sent in plain text, are of variable length, and
 are always terminated by a linefeed character ('\n', ASCII code 10)</p>
 
@@ -81,12 +81,12 @@ servers may not send all the fields, so if fewer fields than expected are
 received, the client should substitute default values.</p>
 
 <p>Message codes are shown below, together with the symbolic constants used in
-the dopewars code for clarity (e.g. the 'A' code is represented by
+the Church Wars code for clarity (e.g. the 'A' code is represented by
 C_PRINTMESSAGE)</p>
 
 <p>For the AI codes, see the AICode type in src/message.h</p>
 
-<p><a id="oldprotocol">N.B. Older versions of dopewars used a less
+<p><a id="oldprotocol">N.B. Older versions of Church Wars used a less
 sophisticated protocol:-</a></p>
 
 <dl>
@@ -114,7 +114,7 @@ listen for incoming messages, and respond appropriately.</p>
 
 <h2><a id="refserver">Server to client message reference</a></h2>
 
-<p>The messages listed below may be sent from a dopewars server to the client.
+<p>The messages listed below may be sent from a Church Wars server to the client.
 Most of these messages require some kind of processing to be done, and may
 require a response. The client cannot safely ignore such messages, as the
 server will not "retry" if the client does not respond.</p>
@@ -181,7 +181,7 @@ loan shark, in the bank<br />
 <tt>coatsize</tt> = amount of space available for drugs/guns<br />
 <tt>locn</tt> = zero-based game location<br />
 <tt>turn</tt> = turn number<br />
-<tt>flags</tt> = player status flags - see PlayerFlags in src/dopewars.h for
+<tt>flags</tt> = player status flags - see PlayerFlags in src/churchwars.h for
 the individual binary bits. The only one currently used is SPYINGON (16) which
 is set if the player is currently spying on one or more other players<br />
 <tt>GUNS</tt> = the numbers of each gun carried, separated by ^ characters
@@ -278,7 +278,7 @@ e.g. "1^AbFred"<br />
 <dt><b>C_INIT</b> ('<tt>k</tt>')</dt>
 <dd>Tells the client about various global game settings<br />
 <tt>data</tt> = <tt>"version"^&lt;numloc&gt;^&lt;numgun&gt;^&lt;numdrug&gt;^"bitch"^"bitches"^"gun"^"guns"^"drug"^"drugs"^"date"^&lt;ID&gt;^"loanshark"^"bank"^"gunshop"^"pub"^(prefix)"currency"</tt><br />
-<tt>version</tt> = dopewars version of the server - e.g. "1.5.2"<br />
+<tt>version</tt> = Church Wars version of the server - e.g. "1.5.2"<br />
 <tt>numloc</tt> = the number of locations in the game<br />
 <tt>numgun</tt> = the number of guns in the game<br />
 <tt>numdrug</tt> = the number of drugs in the game<br />
@@ -397,35 +397,35 @@ server have exchanged C_ABILITIES messages the server will "talk" using the old
 protocol. Thus, the C_ABILITIES message itself from the client, and any
 succeeding messages sent before the server sends C_ABILITIES back, must be
 sent using the old protocol. "Old" servers will ignore the C_ABILITIES
-message.) Ability name in dopewars code: <b>A_PLAYERID</b></p>
+message.) Ability name in Church Wars code: <b>A_PLAYERID</b></p>
 
 <p><a id="drugvalue"><tt>drugvalue</tt></a> = '1' if the server should keep
 track of how much players paid for their drugs, so that they can see whether
 they're getting a good deal when they come to sell them ('0' otherwise).
-Ability name in dopewars code: <b>A_DRUGVALUE</b></p>
+Ability name in Church Wars code: <b>A_DRUGVALUE</b></p>
 
 <p><a id="newfight"><tt>newfight</tt></a> = '1' if we use the "new" fighting
-interface (documented here). Highly recommended. Ability name in dopewars
+interface (documented here). Highly recommended. Ability name in Church Wars
 code: <b>A_NEWFIGHT</b></p>
 
 <p><a id="tstring"><tt>tstring</tt></a> = '1' if names of drugs etc. should be
 sent in the <a href="i18n.html">translated string</a> (tstring) notation;
 only necessary if you are supporting non-English languages. Ability name
-in dopewars code: <b>A_TSTRING</b></p>
+in Church Wars code: <b>A_TSTRING</b></p>
 
 <p><a id="donefight"><tt>donefight</tt></a> = '1' if, when a fight finishes,
 the client is expected to send a C_DONE message to instruct the server to
 move on. (This is to allow the user to close the fight dialog before any
-new dialogs pop up.) Ability name in dopewars code: <b>A_DONEFIGHT</b></p>
+new dialogs pop up.) Ability name in Church Wars code: <b>A_DONEFIGHT</b></p>
 
 <p><a id="utf8"><tt>utf8</tt></a> = '1' if all strings are sent over the
 network in UTF-8 (Unicode) encoding, rather than an encoding specific to
-the locale of the server or client. Ability name in dopewars code:
+the locale of the server or client. Ability name in Church Wars code:
 <b>A_UTF8</b></p>
 
 <p><a id="date"><tt>date</tt></a> = '1' if the C_INIT message sends/receives
 the Names.Date variable, rather than Names.Month and Names.Year as older
-versions used to. Ability name in dopewars code: <b>A_DATE</b></p>
+versions used to. Ability name in Church Wars code: <b>A_DATE</b></p>
 
 <p><b>N.B.</b> Only seven abilities are listed here. Older servers or clients
 may not only not support some of these abilities, they may not even know

--- a/doc/server.html
+++ b/doc/server.html
@@ -6,26 +6,26 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>Setting up and running a dopewars server</title>
+<title>Setting up and running a Church Wars server</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>Setting up and running a dopewars server</h1>
+<h1>Setting up and running a Church Wars server</h1>
 
-<p>Multiplayer games of dopewars require a running dopewars server; this
+<p>Multiplayer games of Church Wars require a running Church Wars server; this
 mediates the interactions between each player (each player runs a
 <a href="clientplay.html">client</a> which connects to this server). The server
 runs the game, generating drug prices and the like, and instructs the clients
 accordingly. The server can be run on any machine that can be reached over
 the network by clients (so you don't have to run it on the same machine that
-you run your client on, for example, unless your firewall blocks the dopewars
+you run your client on, for example, unless your firewall blocks the Church Wars
 port).</p>
 
 <p>Single player games do not require a server (although you can still connect
-to one if you like) as a "virtual server" is run by the dopewars client.</p>
+to one if you like) as a "virtual server" is run by the Church Wars client.</p>
 
-<p>The dopewars server can be heavily customised by means of the
+<p>The Church Wars server can be heavily customised by means of the
 <a href="configfile.html">configuration files</a>. For example, you can
 change the names of all the game locations so that the game is set in your
 home city rather than New York. Any players that then connect to your
@@ -35,12 +35,12 @@ customised server will play this customised game.</p>
 <li><a href="#server">Running a server</a></li>
 <li><a href="#interact">Interacting with the text-mode server</a></li>
 <li><a href="#ntservice">Running as an NT service</a></li>
-<li><a href="#metaserver">Private and public: the dopewars metaserver</a></li>
+<li><a href="#metaserver">Private and public: the Church Wars metaserver</a></li>
 </ul>
 
 <h2><a id="server">Running a server</a></h2>
 
-<p>All the code for the dopewars server is included in the same binary as the
+<p>All the code for the Church Wars server is included in the same binary as the
 standard client. To run the binary in server mode, specify the <b>-s</b> or
 <b>-S</b> <a href="commandline.html">command line option</a>. The type of
 server that runs depends on how you configured the binary; by default, on
@@ -53,9 +53,9 @@ accepts no input ("noninteractive") is used.</p>
 
 <p>Once started, the text-mode server does not accept commands directly. This
 is problematic if you want to adjust settings, eject players, etc. To send
-commands to a running server, run dopewars with the <b>-A</b>
+commands to a running server, run Church Wars with the <b>-A</b>
 <a href="commandline.html">command line option</a>. (This should only work
-from the machine running the dopewars server, not over the network, and only
+from the machine running the Church Wars server, not over the network, and only
 for the user that started the server, as it uses a Unix-domain socket for the
 communication.) Also, by default the text-mode server sends its log output to
 standard output; you may wish to instead log to a file with the <b>-l</b>
@@ -65,26 +65,26 @@ option.</p>
 
 <p>On Windows systems, the graphical server has one major drawback; it can
 only run while you are logged on. As soon as you log out, the server is
-killed. To get around this limitation, dopewars
+killed. To get around this limitation, Church Wars
 <a href="windows.html">supports being run</a> as a "Windows Service".
 The disadvantage of the server in this configuration is that server commands
 cannot be issued once the server is running. This limitation should be
-fixed in a future release of dopewars.</p>
+fixed in a future release of churchwars.</p>
 
-<h2><a id="metaserver">Private and public: the dopewars metaserver</a></h2>
+<h2><a id="metaserver">Private and public: the Church Wars metaserver</a></h2>
 
-<p>By default, a server reports its status to the dopewars
+<p>By default, a server reports its status to the Church Wars
 <a href="metaserver.html">metaserver</a>. It does this on startup and
 shutdown, and whenever players join or leave the game. In addition, you
-can force a report (under Unix systems) by sending the dopewars server
+can force a report (under Unix systems) by sending the Church Wars server
 process a SIGUSR1 signal. The server will "remind" the metaserver that it
 exists by ensuring that a report is sent at least once every 3 hours or so,
 regardless. A "status report" comprises contact details for the server,
 a count of the number of active players, and current high scores.</p>
 
-<p>The metaserver also has a web interface, which is used by dopewars clients to
+<p>The metaserver also has a web interface, which is used by Church Wars clients to
 obtain the list of servers, and can also be viewed with a web browser
-<a href="https://dopewars.sourceforge.io/metaserver.php?getlist=2">here</a>.</p>
+<a href="https://churchwars.sourceforge.io/metaserver.php?getlist=2">here</a>.</p>
 
 <p>Whether your server connects to the metaserver can be configured with the
 <a href="configfile.html#MetaServerActive">MetaServer.Active</a> configuration

--- a/doc/servercommands.html
+++ b/doc/servercommands.html
@@ -48,8 +48,8 @@ to this server.</dd>
 <dt><b>save <i>my-conf</i></b></dt>
 <dd>Saves the current configuration (names of drugs, locations, etc.) to
 the file <i>my-conf</i>. If no file name is given, the configuration is
-written to the local configuration file - usually <tt>~/.dopewars</tt> on
-Unix systems and <tt>dopewars-config.txt</tt> on Windows.</dd>
+written to the local configuration file - usually <tt>~/.churchwars</tt> on
+Unix systems and <tt>churchwars-config.txt</tt> on Windows.</dd>
 
 <dt><b>quit</b></dt>
 <dd>Politely quit, by asking all clients to leave, and then terminating once
@@ -63,7 +63,7 @@ command).</dd>
 <ul>
 <li><a href="index.html">Main index</a>
    <ul>
-   <li><a href="server.html">Setting up and running a dopewars server</a></li>
+   <li><a href="server.html">Setting up and running a Church Wars server</a></li>
    </ul>
 </li>
 </ul>

--- a/doc/windows.html
+++ b/doc/windows.html
@@ -6,44 +6,44 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-<title>dopewars and Microsoft Windows</title>
+<title>Church Wars and Microsoft Windows</title>
 <meta charset="utf-8"/>
 </head>
 
 <body>
-<h1>dopewars and Microsoft Windows</h1>
+<h1>Church Wars and Microsoft Windows</h1>
 
-<p>dopewars runs natively on Win32 systems (Windows 7 or later). It runs by
-default as a dopewars client, using the familiar Windows interface, but
+<p>Church Wars runs natively on Win32 systems (Windows 7 or later). It runs by
+default as a Church Wars client, using the familiar Windows interface, but
 the traditional text-mode client is also available on Windows, as well as
-the dopewars server and AI players.
+the Church Wars server and AI players.
 </p>
 
 <p>Binaries can be obtained from the main
-<a href="https://dopewars.sourceforge.io/download.html">download site</a>, or
-dopewars can be
-<a href="https://github.com/benmwebb/dopewars/blob/develop/win32/README.md">built
+<a href="https://churchwars.sourceforge.io/download.html">download site</a>, or
+Church Wars can be
+<a href="https://github.com/benmwebb/churchwars/blob/develop/win32/README.md">built
 from source code</a>.</p>
 
-<p>In virtually all respects, the Unix and Win32 versions of dopewars should be
+<p>In virtually all respects, the Unix and Win32 versions of Church Wars should be
 identical. Both will accept the same command line parameters and configuration
 options. However, since the standard Unix paths for the high score file and
 configuration files do not translate well to Windows, by default the program
-will look for the high score file <b>dopewars.sco</b> in the current
+will look for the high score file <b>churchwars.sco</b> in the current
 user's application data directory (e.g. 
-<tt>C:\Users\foo\AppData\Local\dopewars\</tt>), and will read a global
-configuration file <b>dopewars-config.txt</b> from the directory in which the
-dopewars binary was installed, followed by a per-user configuration file of
+<tt>C:\Users\foo\AppData\Local\Church Wars\</tt>), and will read a global
+configuration file <b>churchwars-config.txt</b> from the directory in which the
+churchwars binary was installed, followed by a per-user configuration file of
 the same name in the AppData directory.</p>
 
-<p>The dopewars server can function as a
+<p>The Church Wars server can function as a
 <a href="https://docs.microsoft.com/en-us/dotnet/framework/windows-services/introduction-to-windows-service-applications">Windows service</a> when run with
 the <tt>-N</tt> flag. One way to set this up is to use the
 <a href="https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-create">sc create</a> utility from a command prompt, e.g.</p>
 
-<p><tt>sc create dopewars binpath= "C:\Program Files\dopewars-1.6.2\dopewars.exe -N"</tt></p>
+<p><tt>sc create Church Wars binpath= "C:\Program Files\churchwars-1.6.2\churchwars.exe -N"</tt></p>
 
-<p>Note that this will run dopewars as the Local System user, so will look for
+<p>Note that this will run Church Wars as the Local System user, so will look for
 high score/config files (and create a log file) in the corresponding AppData
 directory, e.g. <tt>C:\Windows\System32\config\systemprofile\AppData\Local</tt>.</p>
 


### PR DESCRIPTION
## Summary
- rename project references from dopewars to Church Wars across README, NEWS, AUTHORS, INSTALL and HTML help
- update hyperlinks and paths to use the new churchwars naming

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `sudo apt-get update` *(fails: repository not signed)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689b7e806d30832680a00515149718e8