### PR TITLE
Rebrand user-facing text to Church Wars

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * AIPlayer.c     Code for dopewars computer players                    *
+ * AIPlayer.c     Code for Church Wars computer players                 *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -73,7 +73,7 @@ static void AIConnectFailed(NetworkBuffer *netbuf)
   if (netbuf->error)
     g_string_assign_error(errstr, netbuf->error);
   g_log(NULL, G_LOG_LEVEL_CRITICAL,
-        _("Could not connect to dopewars server\n(%s)\n"
+        _("Could not connect to Church Wars server\n(%s)\n"
           "AI Player terminating abnormally."), errstr->str);
   g_string_free(errstr, TRUE);
 }
@@ -659,7 +659,7 @@ void AIHandleQuestion(char *Data, AICode AI, Player *AIPlay, Player *From)
 }
 
 /* 
- * Sends a random message to all other dopewars players.
+ * Sends a random message to all other Church Wars players.
  */
 void AISendRandomMessage(Player *AIPlay)
 {

--- a/src/AIPlayer.h
+++ b/src/AIPlayer.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * AIPlayer.h     Header file for dopewars computer player code         *
+ * AIPlayer.h     Header file for Church Wars computer player code      *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/admin.c
+++ b/src/admin.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * admin.c        dopewars server administration                        *
+ * admin.c        Church Wars server administration                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -49,7 +49,7 @@ static int OpenSocket(void)
 
   sockname = GetLocalSocket();
 
-  g_print(_("Attempting to connect to local dopewars server via "
+  g_print(_("Attempting to connect to local Church Wars server via "
             "Unix domain\n socket %s...\n"), sockname);
   sock = socket(PF_UNIX, SOCK_STREAM, 0);
   if (sock == -1) {

--- a/src/admin.h
+++ b/src/admin.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * admin.h        Header file for dopewars server administration        *
+ * admin.h        Header file for Church Wars server administration     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * configfile.c   Functions for dealing with dopewars config files      *
+ * configfile.c   Functions for dealing with Church Wars config files   *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -232,7 +232,7 @@ gboolean UpdateConfigFile(const gchar *cfgfile, gboolean ForceUTF8)
   gchar *defaultfile;
   static gchar *header =
       "\n### Everything from here on is written automatically by\n"
-      "### the dopewars program; you can edit it manually, but any\n"
+      "### the Church Wars program; you can edit it manually, but any\n"
       "### formatting (comments, etc.) will be lost at the next rewrite.\n\n";
 
   defaultfile = GetLocalConfigFile();

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * configfile.h   Functions for dealing with dopewars config files      *
+ * configfile.h   Functions for dealing with Church Wars config files   *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/convert.c
+++ b/src/convert.c
@@ -2,7 +2,7 @@
  * convert.c      Codeset conversion functions                          *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/convert.h
+++ b/src/convert.h
@@ -2,7 +2,7 @@
  * convert.h      Header file for codeset conversion functions          *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * curses_client.c  dopewars client using the (n)curses console library *
+ * curses_client.c  Church Wars client using the (n)curses console library *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -319,7 +319,7 @@ static void mvaddfixwidstr(const int row, const int col, const int wid,
 }
 
 /* 
- * Displays a dopewars introduction screen.
+ * Displays a Church Wars introduction screen.
  */
 void display_intro(void)
 {
@@ -371,7 +371,7 @@ void display_intro(void)
   mvaddstr(19, 7, _("Unconstructive Criticism      R Batstone"));
 
   mvaddcentstr(21, _("For information on the command line options, type "
-                     "dopewars -h at your"));
+                     "Church Wars -h at your"));
   mvaddcentstr(22, _("Unix prompt. This will display a help screen, listing "
                      "the available options."));
 
@@ -398,7 +398,7 @@ static void SelectServerManually(void)
   mvaddstr(top + 1, 1,
            /* Prompts for hostname and port when selecting a server
               manually */
-           _("Please enter the hostname and port of a dopewars server:-"));
+           _("Please enter the hostname and port of a Church Wars server:-"));
   text = nice_input(_("Hostname: "), top + 2, 1, FALSE, ServerName, '\0');
   AssignName(&ServerName, text);
   g_free(text);
@@ -410,7 +410,7 @@ static void SelectServerManually(void)
 }
 
 /* 
- * Contacts the dopewars metaserver, and obtains a list of valid
+ * Contacts the Church Wars metaserver, and obtains a list of valid
  * server/port pairs, one of which the user should select.
  * Returns TRUE on success; on failure FALSE is returned, and
  * errstr is assigned an error message.
@@ -663,7 +663,7 @@ static gboolean DoConnect(Player *Play, GString *errstr)
 }
 
 /* 
- * Connects to a dopewars server. Prompts the user to select a server
+ * Connects to a Church Wars server. Prompts the user to select a server
  * if necessary. Returns TRUE, unless the user elected to quit the
  * program rather than choose a valid server.
  */
@@ -696,7 +696,7 @@ static gboolean ConnectToServer(Player *Play)
     clear_bottom();
     if (MetaOK && !firstrun) {
       mvaddstr(top + 1, 1, _("Please wait... attempting to contact "
-                             "dopewars server..."));
+                             "Church Wars server..."));
       refresh();
       NetOK = DoConnect(Play, errstr);
     }
@@ -711,10 +711,10 @@ static gboolean ConnectToServer(Player *Play)
         mvaddstr(top + 1, 1, text);
         g_free(text);
       } else if (!NetOK) {
-        /* Display of an error message while trying to contact a dopewars
+        /* Display of an error message while trying to contact a Church Wars
            server (the error message itself is displayed on the next
            screen line) */
-        mvaddstr(top, 1, _("Could not start multiplayer dopewars"));
+        mvaddstr(top, 1, _("Could not start multiplayer Church Wars"));
         text = g_strdup_printf("   (%s)",
                                errstr->str[0] ? errstr->str
                                   : _("connection to server failed"));
@@ -724,13 +724,13 @@ static gboolean ConnectToServer(Player *Play)
       MetaOK = NetOK = TRUE;
       attrset(PromptAttr);
       mvaddstr(top + 2, 1,
-               _("Will you... C>onnect to a named dopewars server"));
+               _("Will you... C>onnect to a named Church Wars server"));
       mvaddstr(top + 3, 1,
                _("            L>ist the servers on the metaserver, and "
                  "select one"));
       mvaddstr(top + 4, 1,
                _("            Q>uit (where you can start a server "
-                 "by typing \"dopewars -s\")"));
+                 "by typing \"Church Wars -s\")"));
       mvaddstr(top + 5, 1, _("         or P>lay single-player ? "));
       attrset(TextAttr);
 
@@ -992,7 +992,7 @@ static void DealDrugs(Player *Play, gboolean Buy)
 }
 
 /* 
- * Asks the user if he/she _really_ wants to quit dopewars.
+ * Asks the user if he/she _really_ wants to quit Church Wars.
  */
 static int want_to_quit(void)
 {
@@ -2105,7 +2105,7 @@ void DisplaySpyReports(char *Data, Player *From, Player *To)
 
 /* 
  * Displays the "Prompt" if non-NULL, and then lists all clients
- * currently playing dopewars, other than the current player "Play".
+ * currently playing Church Wars, other than the current player "Play".
  * If "Select" is TRUE, gives each player a letter and asks the user
  * to select one, which is returned by the function.
  */
@@ -2326,7 +2326,7 @@ static void DisplayDrugsHere(Player *Play)
 /* 
  * Loop which handles the user playing an interactive game (i.e. "Play"
  * is a client connected to a server, either locally or remotely)
- * dopewars is essentially server-driven, so this loop simply has to
+ * Church Wars is essentially server-driven, so this loop simply has to
  * make the screen look pretty, respond to user keypresses, and react
  * to messages from the server.
  */
@@ -2679,7 +2679,7 @@ void CursesLoop(struct CMDLINE *cmdline)
   WantNetwork = cmdline->network;
 
   /* Save the configuration, so we can restore those elements that get
-   * overwritten when we connect to a dopewars server */
+   * overwritten when we connect to a Church Wars server */
   BackupConfig();
 
   start_curses();

--- a/src/curses_client/curses_client.h
+++ b/src/curses_client/curses_client.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * curses_client.h  dopewars client using the (n)curses console library *
+ * curses_client.h  Church Wars client using the (n)curses console library *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/cursesport/cursesport.c
+++ b/src/cursesport/cursesport.c
@@ -3,7 +3,7 @@
  *                     to be built on Win32 systems                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/cursesport/cursesport.h
+++ b/src/cursesport/cursesport.h
@@ -3,7 +3,7 @@
  *                     to be built on Win32 systems                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * dopewars.c     dopewars - general purpose routines and init          *
+ * dopewars.c     Church Wars - general purpose routines and init       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -70,12 +70,12 @@
 int ClientSock, ListenSock;
 gboolean Network, Client, Server, WantAntique = FALSE, UseSounds = TRUE;
 
-/* 
- * dopewars acting as standalone TCP server:
+/*
+ * Church Wars acting as standalone TCP server:
  *           Network=Server=TRUE   Client=FALSE
- * dopewars acting as client, connecting to standalone server:
+ * Church Wars acting as client, connecting to standalone server:
  *           Network=Client=TRUE   Server=FALSE
- * dopewars in single-player or antique mode:
+ * Church Wars in single-player or antique mode:
  *           Network=Server=Client=FALSE
  */
 int Port = 7902;
@@ -96,7 +96,7 @@ gboolean Daemonize = TRUE;
 #ifdef CYGWIN
 #define SNDPATH "sounds\\19.5degs\\"
 #else
-#define SNDPATH DPDATADIR"/dopewars/"
+#define SNDPATH DPDATADIR"/churchwars/"
 #endif
 
 gchar *OurWebBrowser = NULL;
@@ -176,7 +176,7 @@ struct NAMES DefaultNames = {
      "bitch" depending on where in the sentence it occurs (e.g. subject or
      object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
      This notation can be used for most of the translatable strings in
-     dopewars. */
+     Church Wars. */
   N_("cleric"),
   /* Word used for two or more bitches */
   N_("clerics"),
@@ -217,8 +217,8 @@ struct METASERVER MetaServer = {
 };
 
 struct METASERVER DefaultMetaServer = {
-  TRUE, "https://dopewars.sourceforge.io/metaserver.php", "",
-  "", "dopewars server"
+  TRUE, "https://churchwars.sourceforge.io/metaserver.php", "",
+  "", "Church Wars server"
 };
 
 SocksServer Socks = { NULL, 0, 0, FALSE, NULL, NULL, NULL };
@@ -233,7 +233,7 @@ struct LOG Log;
 
 struct GLOBALS Globals[] = {
   /* The following strings are the helptexts for all the options that can
-     be set in a dopewars configuration file, or in the server. See
+     be set in a Church Wars configuration file, or in the server. See
      doc/configfile.html for more detailed explanations. */
   {&Port, NULL, NULL, NULL, NULL, "Port", N_("Network port to connect to"),
    NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 65535},
@@ -2273,15 +2273,15 @@ gchar *GetGlobalConfigFile(void)
 #ifdef CYGWIN
   gchar *bindir, *conf = NULL;
 
-  /* Global configuration is in the same directory as the dopewars binary */
+  /* Global configuration is in the same directory as the Church Wars binary */
   bindir = GetBinaryDir();
   if (bindir) {
-    conf = g_strdup_printf("%s/dopewars-config.txt", bindir);
+    conf = g_strdup_printf("%s/churchwars-config.txt", bindir);
     g_free(bindir);
   }
   return conf;
 #else
-  return g_strdup("/etc/dopewars");
+  return g_strdup("/etc/churchwars");
 #endif
 }
 
@@ -2293,7 +2293,7 @@ gchar *GetGlobalConfigFile(void)
 gchar *GetLocalConfigFile(void)
 {
 #ifdef CYGWIN
-  return g_strdup_printf("%s/dopewars-config.txt",
+  return g_strdup_printf("%s/churchwars-config.txt",
                          appdata_path ? appdata_path : ".");
 #else
   gchar *home, *conf = NULL;
@@ -2301,7 +2301,7 @@ gchar *GetLocalConfigFile(void)
   /* Local config is in the user's home directory */
   home = getenv("HOME");
   if (home) {
-    conf = g_strdup_printf("%s/.dopewars", home);
+    conf = g_strdup_printf("%s/.churchwars", home);
   }
   return conf;
 #endif
@@ -2466,32 +2466,32 @@ static void PluginHelp(void)
 
 void HandleHelpTexts(gboolean fullhelp)
 {
-  g_print(_("dopewars version %s\n"), VERSION);
+  g_print(_("Church Wars version %s\n"), VERSION);
   if (!fullhelp) {
     return;
   }
 
   g_print(
 #ifdef HAVE_GETOPT_LONG
-           /* Usage information, printed when the user runs "dopewars -h"
+           /* Usage information, printed when the user runs "Church Wars -h"
               (version with support for GNU long options) */
-           _("Usage: dopewars [OPTION]...\n\
+           _("Usage: Church Wars [OPTION]...\n\
 Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -b, --no-color,         \"black and white\" - i.e. do not use pretty colors\n\
       --no-colour           (by default colors are used where available)\n\
-  -n, --single-player     be boring and don't connect to any available dopewars\n\
+  -n, --single-player     be boring and don't connect to any available Church Wars\n\
                             servers (i.e. single player mode)\n\
-  -a, --antique           \"antique\" dopewars - keep as closely to the original\n\
+  -a, --antique           \"antique\" Church Wars - keep as closely to the original\n\
                             version as possible (no networking)\n\
   -f, --scorefile=FILE    specify a file to use as the high score table (by\n\
-                            default %s/dopewars.sco is used)\n\
+                            default %s/churchwars.sco is used)\n\
   -o, --hostname=ADDR     specify a hostname where the server for multiplayer\n\
-                            dopewars can be found\n\
+                            Church Wars can be found\n\
   -s, --public-server     run in server mode (note: see the -A option for\n\
                             configuring a server once it\'s running)\n\
   -S, --private-server    run a \"private\" server (do not notify the metaserver)\n\
   -p, --port=PORT         specify the network port to use (default: 7902)\n\
-  -g, --config-file=FILE  specify the pathname of a dopewars configuration file;\n\
+  -g, --config-file=FILE  specify the pathname of a Church Wars configuration file;\n\
                             this file is read immediately when the -g option\n\
                             is encountered\n\
   -r, --pidfile=FILE      maintain pid file \"FILE\" while running the server\n\
@@ -2510,25 +2510,25 @@ Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
 Church Wars is Copyright (C) O Batstone 2024, and released under the GNU GPL\n\
 Report bugs to the author at benwebb@users.sf.net\n"));
 #else
-           /* Usage information, printed when the user runs "dopewars -h"
+           /* Usage information, printed when the user runs "Church Wars -h"
               (short options only version) */
-           _("Usage: dopewars [OPTION]...\n\
+           _("Usage: Church Wars [OPTION]...\n\
 Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -b       \"black and white\" - i.e. do not use pretty colors\n\
               (by default colors are used where the terminal supports them)\n\
-  -n       be boring and don't connect to any available dopewars servers\n\
+  -n       be boring and don't connect to any available Church Wars servers\n\
               (i.e. single player mode)\n\
-  -a       \"antique\" dopewars - keep as closely to the original version as\n\
+  -a       \"antique\" Church Wars - keep as closely to the original version as\n\
               possible (no networking)\n\
   -f file  specify a file to use as the high score table\n\
-              (by default %s/dopewars.sco is used)\n\
-  -o addr  specify a hostname where the server for multiplayer dopewars\n\
+              (by default %s/churchwars.sco is used)\n\
+  -o addr  specify a hostname where the server for multiplayer Church Wars\n\
               can be found\n\
   -s       run in server mode (note: see the -A option for configuring a\n\
               server once it\'s running)\n\
   -S       run a \"private\" server (i.e. do not notify the metaserver)\n\
   -p port  specify the network port to use (default: 7902)\n\
-  -g file  specify the pathname of a dopewars configuration file; this file\n\
+  -g file  specify the pathname of a Church Wars configuration file; this file\n\
               is read immediately when the -g option is encountered\n\
   -r file  maintain pid file \"file\" while running the server\n\
   -l file  write log information to \"file\"\n\
@@ -2699,10 +2699,10 @@ struct CMDLINE *GeneralStartup(int argc, char *argv[])
   /* First, open the hard-coded high score file with possibly
    * elevated privileges */
 #ifdef CYGWIN
-  priv_hiscore = g_strdup_printf("%s/dopewars.sco",
+  priv_hiscore = g_strdup_printf("%s/churchwars.sco",
                                  appdata_path ? appdata_path : DPSCOREDIR);
 #else
-  priv_hiscore = g_strdup_printf("%s/dopewars.sco", DPSCOREDIR);
+  priv_hiscore = g_strdup_printf("%s/churchwars.sco", DPSCOREDIR);
 #endif
   HiScoreFile = g_strdup(priv_hiscore);
   OpenHighScoreFile();

--- a/src/dopewars.h
+++ b/src/dopewars.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * dopewars.h     Common structures and stuff for dopewars              *
+ * dopewars.h     Common structures and stuff for Church Wars           *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/dopewars.manifest
+++ b/src/dopewars.manifest
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <assemblyIdentity
-    name="dopewars"
+    name="churchwars"
     processorArchitecture="*"
     version="1.0.0.0"
     type="win32"/>
-<description>dopewars drug dealing game</description>
+<description>Church Wars drug dealing game</description>
 <dependency>
     <dependentAssembly>
         <assemblyIdentity

--- a/src/error.c
+++ b/src/error.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * error.c        Error-handling routines for dopewars                  *
+ * error.c        Error-handling routines for Church Wars               *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/error.h
+++ b/src/error.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * error.h        Header file for dopewars error-handling routines      *
+ * error.h        Header file for Church Wars error-handling routines   *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/gtkenums.h
+++ b/src/gtkport/gtkenums.h
@@ -2,7 +2,7 @@
  * gtkenums.h     Enumerated types for gtkport code                     *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/gtkport.c
+++ b/src/gtkport/gtkport.c
@@ -2,7 +2,7 @@
  * gtkport.c      Portable "almost-GTK+" for Unix/Win32                 *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -5475,7 +5475,7 @@ void DisplayHTML(GtkWidget *parent, const gchar *bin, const gchar *target)
       pid = fork();
       if (pid == 0) {
         execv(bin, args);
-        g_print("dopewars: cannot execute %s\n", bin);
+        g_print("Church Wars: cannot execute %s\n", bin);
         _exit(EXIT_FAILURE);
       } else {
         _exit(EXIT_SUCCESS);

--- a/src/gtkport/gtkport.h
+++ b/src/gtkport/gtkport.h
@@ -2,7 +2,7 @@
  * gtkport.h      Portable "almost-GTK+" for Unix/Win32                 *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/gtktypes.h
+++ b/src/gtkport/gtktypes.h
@@ -2,7 +2,7 @@
  * gtktypes.h     Custom types for gtkport code                         *
  * Copyright (C)  2002-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/itemfactory.c
+++ b/src/gtkport/itemfactory.c
@@ -2,7 +2,7 @@
  * itemfactory.c  GtkItemFactory and friends for Unix/Win32             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/itemfactory.h
+++ b/src/gtkport/itemfactory.h
@@ -2,7 +2,7 @@
  * itemfactory.h  GtkItemFactory and friends for Unix/Win32             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * When using GTK+3, which has removed GtkItemFactory, or Win32,        *
  * provide our own implementation; on GTK+2, use the implementation in  *

--- a/src/gtkport/treeview.c
+++ b/src/gtkport/treeview.c
@@ -2,7 +2,7 @@
  * treeview.c     GtkTreeView (and friends) implementation for gtkport  *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/treeview.h
+++ b/src/gtkport/treeview.h
@@ -2,7 +2,7 @@
  * treeview.h     GtkTreeView (and friends) implementation for gtkport  *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/unicodewrap.c
+++ b/src/gtkport/unicodewrap.c
@@ -2,7 +2,7 @@
  * unicodewrap.c  Unicode wrapper functions for Win32                   *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gtkport/unicodewrap.h
+++ b/src/gtkport/unicodewrap.h
@@ -2,7 +2,7 @@
  * unicodewrap.h  Unicode wrapper functions for Win32                   *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * gtk_client.c   dopewars client using the GTK+ toolkit                *
+ * gtk_client.c   Church Wars client using the GTK+ toolkit             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -200,7 +200,7 @@ GtkWidget *my_hbbox_new(void)
 void my_gtk_box_pack_start_defaults(GtkBox *box, GtkWidget *child)
 {
 #ifdef CYGWIN
-  /* For compatibility with older dopewars */
+  /* For compatibility with older Church Wars */
   gtk_box_pack_start(box, child, FALSE, FALSE, 0);
 #else
   gtk_box_pack_start(box, child, TRUE, TRUE, 0);
@@ -255,7 +255,7 @@ void NewGame(GtkWidget *widget, gpointer data)
   }
 
   /* Save the configuration, so we can restore those elements that get
-   * overwritten when we connect to a dopewars server */
+   * overwritten when we connect to a Church Wars server */
   BackupConfig();
 
 #ifdef NETWORKING
@@ -2164,7 +2164,7 @@ gboolean GtkLoop(int *argc, char **argv[],
   window = MainWindow = ClientData.window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
   /* Title of main window in GTK+ client */
-  gtk_window_set_title(GTK_WINDOW(window), _("dopewars"));
+  gtk_window_set_title(GTK_WINDOW(window), _("Church Wars"));
   gtk_window_set_default_size(GTK_WINDOW(window), 450, 390);
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(MainDelete), NULL);
@@ -2388,7 +2388,7 @@ void display_intro(GtkWidget *widget, gpointer data)
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
   PackCentredURL(vbox, _("Original Dopewars information here"),
-                 "https://dopewars.sourceforge.io/", OurWebBrowser);
+                 "https://churchwars.sourceforge.io/", OurWebBrowser);
 
   hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start(GTK_BOX(vbox), hsep, FALSE, FALSE, 0);

--- a/src/gui_client/gtk_client.h
+++ b/src/gui_client/gtk_client.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * gtk_client.h   dopewars client using the GTK+ toolkit                *
+ * gtk_client.h   Church Wars client using the GTK+ toolkit             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/newgamedia.c
+++ b/src/gui_client/newgamedia.c
@@ -2,7 +2,7 @@
  * newgamedia.c   New game dialog                                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -93,7 +93,7 @@ static void ConnectError(void)
     g_string_assign(neterr, _("Connection closed by remote host"));
   }
 
-  /* Error: GTK+ client could not connect to the given dopewars server */
+  /* Error: GTK+ client could not connect to the given Church Wars server */
   text = g_strdup_printf(_("Status: Could not connect (%s)"), neterr->str);
 
   SetStartGameStatus(text);

--- a/src/gui_client/newgamedia.h
+++ b/src/gui_client/newgamedia.h
@@ -2,7 +2,7 @@
  * newgamedia.h   New game dialog                                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/optdialog.c
+++ b/src/gui_client/optdialog.c
@@ -2,7 +2,7 @@
  * optdialog.c    Configuration file editing dialog                     *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/optdialog.h
+++ b/src/gui_client/optdialog.h
@@ -2,7 +2,7 @@
  * optdialog.c    Configuration file editing dialog                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/log.c
+++ b/src/log.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * log.c          dopewars - logging functions                          *
+ * log.c          Church Wars - logging functions                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/log.h
+++ b/src/log.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * log.h          Logging functions for dopewars                        *
+ * log.h          Logging functions for Church Wars                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/mac_helpers.h
+++ b/src/mac_helpers.h
@@ -2,7 +2,7 @@
  * mac_helpers.h  Helper functions for Mac builds                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/mac_helpers.m
+++ b/src/mac_helpers.m
@@ -2,7 +2,7 @@
  * mac_helpers.m  Helper functions for Mac builds                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/magic
+++ b/src/magic
@@ -1,11 +1,11 @@
 #------------------------------------------------------------------------------
-# dopewars:  file(1) magic for dopewars high score files
+# Church Wars:  file(1) magic for Church Wars high score files
 #
 # From <benwebb@users.sf.net>
-# dopewars is a drug dealing game found at http://dopewars.sf.net/.
+# Church Wars is a drug dealing game found at http://churchwars.sf.net.
 # The version reported is that of the high score file, not of the
 # program itself.
 
-0	string		DOPEWARS\ SCORES\ V.	dopewars high score file
+0	string		DOPEWARS\ SCORES\ V.    Church Wars high score file
 >&0	string		>\0			(version %s)
 

--- a/src/message.c
+++ b/src/message.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * message.c      Message-handling routines for dopewars                *
+ * message.c      Message-handling routines for Church Wars             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -53,7 +53,7 @@
 #define MAXWRITEBUF  (65536)
 
 /* *INDENT-OFF* */
-/* dopewars is built around a client-server model. Each client handles the
+/* Church Wars is built around a client-server model. Each client handles the
    user interface, but all the important calculation and processing is
    handled by the server. All communication is conducted via. TCP by means
    of plain text newline-delimited messages.

--- a/src/message.h
+++ b/src/message.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * message.h      Header file for dopewars message-handling routines    *
+ * message.h      Header file for Church Wars message-handling routines *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/network.c
+++ b/src/network.c
@@ -2,7 +2,7 @@
  * network.c      Low-level networking routines                         *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -1246,7 +1246,7 @@ static gboolean SetCaInfo(CurlConnection *conn, GError **err)
   gchar *bindir, *cainfo;
   gboolean ret;
 
-  /* Point to a .crt file in the same directory as dopewars.exe */
+  /* Point to a .crt file in the same directory as churchwars.exe */
   bindir = GetBinaryDir();
   cainfo = g_strdup_printf("%s\\ca-bundle.crt", bindir);
   g_free(bindir);

--- a/src/network.h
+++ b/src/network.h
@@ -2,7 +2,7 @@
  * network.h      Header file for low-level networking routines         *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/nls.h
+++ b/src/nls.h
@@ -2,7 +2,7 @@
  * nls.h          Header file for NLS (internationalization) defines    *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_cocoa.m
+++ b/src/plugins/sound_cocoa.m
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_cocoa.m  Implementation of dopewars sound system (Cocoa driver)*
+ * sound_cocoa.m  Implementation of Church Wars sound system (Cocoa driver)*
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_esd.c
+++ b/src/plugins/sound_esd.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_esd.c    dopewars sound system (ESD/esound driver)             *
+ * sound_esd.c    Church Wars sound system (ESD/esound driver)             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_esd.h
+++ b/src/plugins/sound_esd.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_esd.h    Header file for dopewars sound system (ESD driver)    *
+ * sound_esd.h    Header file for Church Wars sound system (ESD driver)    *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_pulseaudio.c
+++ b/src/plugins/sound_pulseaudio.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_pulseaudio.c    dopewars sound system (PulseAudio driver)      *
+ * sound_pulseaudio.c    Church Wars sound system (PulseAudio driver)      *
  * Copyright (C)  1998-2024  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_pulseaudio.h
+++ b/src/plugins/sound_pulseaudio.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_pulseaudio.h  Header file for dopewars sound system (PulseAudio driver)
+ * sound_pulseaudio.h  Header file for Church Wars sound system (PulseAudio driver)
  * Copyright (C)  1998-2024  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_sdl.c
+++ b/src/plugins/sound_sdl.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_sdl.c    dopewars sound system (SDL driver)                    *
+ * sound_sdl.c    Church Wars sound system (SDL driver)                    *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_sdl.h
+++ b/src/plugins/sound_sdl.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_sdl.h    Header file for dopewars sound system (SDL driver)    *
+ * sound_sdl.h    Header file for Church Wars sound system (SDL driver)    *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_winmm.c
+++ b/src/plugins/sound_winmm.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_winmm.c  dopewars sound system (Windows MM driver)             *
+ * sound_winmm.c  Church Wars sound system (Windows MM driver)             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/plugins/sound_winmm.h
+++ b/src/plugins/sound_winmm.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound_winmm.h  Header file for dopewars sound system (WinMM driver)  *
+ * sound_winmm.h  Header file for Church Wars sound system (WinMM driver)  *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * serverside.c   Handles the server side of dopewars                   *
+ * serverside.c   Handles the server side of Church Wars                *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -298,7 +298,7 @@ void RemoteVersionCheck(Player *Play)
         _("You appear to be using an extremely old (version 1.4.x) client.^"
           "While this will probably work, many of the newer features^"
           "will be unsupported. Get the latest version from the^"
-          "dopewars website, https://dopewars.sourceforge.io/."));
+          "Church Wars website, https://churchwars.sourceforge.io/."));
 
   /* The client has a smaller value of A_NUM; this means that not only does
    * it not support some features, it doesn't even know they might exist. */
@@ -306,8 +306,8 @@ void RemoteVersionCheck(Player *Play)
     SendPrintMessage(NULL, C_VERSIONCHECK, Play,
         _("Warning: your client is too old to support all of this^"
           "server's features. For the full \"experience\", get^"
-          "the latest version of dopewars from the^"
-          "website, https://dopewars.sourceforge.io/."));
+          "the latest version of Church Wars from the^"
+          "website, https://churchwars.sourceforge.io/."));
   }
 
   /* Otherwise, the client is either the same version as the server, or
@@ -555,7 +555,7 @@ void CleanUpServer()
 
 /* 
  * Responds to a SIGUSR1 signal, and requests the main event loop to
- * reregister the server with the dopewars metaserver.
+ * reregister the server with the Church Wars metaserver.
  */
 void ReregisterHandle(int sig)
 {
@@ -572,7 +572,7 @@ void RelogHandle(int sig)
 }
 
 /* 
- * Traps an attempt by the user to send dopewars a SIGTERM or SIGINT
+ * Traps an attempt by the user to send Church Wars a SIGTERM or SIGINT
  * (e.g. pressing Ctrl-C) and signals for a "nice" shutdown. Restores
  * the default signal action (to terminate without cleanup) so that
  * the user can still close the program easily if this cleanup code
@@ -966,7 +966,7 @@ void RemovePlayerFromServer(Player *Play)
 }
 
 #ifndef CYGWIN
-static gchar sockpref[] = "/tmp/.dopewars";
+static gchar sockpref[] = "/tmp/.churchwars";
 
 static gchar *GetLocalSockDir(void)
 {
@@ -1218,7 +1218,7 @@ void ServerLoop(struct CMDLINE *cmdline)
       BindNetworkBufferToSocket(netbuf, newlocal);
       localconn = g_slist_append(localconn, netbuf);
       oldprint = StartServerReply(netbuf);
-      g_print(_("dopewars server version %s ready for admin commands; "
+      g_print(_("Church Wars server version %s ready for admin commands; "
                 "try \"help\" for help"), VERSION);
       FinishServerReply(oldprint);
       dopelog(1, LF_SERVER, _("New admin connection"));
@@ -1500,7 +1500,7 @@ static VOID WINAPI ServiceHandler(DWORD control)
 
 static VOID WINAPI ServiceInit(DWORD argc, LPTSTR * argv)
 {
-  scHandle = RegisterServiceCtrlHandler("dopewars-server", ServiceHandler);
+  scHandle = RegisterServiceCtrlHandler("churchwars-server", ServiceHandler);
   if (!scHandle) {
     dopelog(0, LF_SERVER, _("Failed to register service handler"));
     return;
@@ -1521,7 +1521,7 @@ static VOID WINAPI ServiceInit(DWORD argc, LPTSTR * argv)
 void ServiceMain(struct CMDLINE *cmdline)
 {
   SERVICE_TABLE_ENTRY services[] = {
-    {"dopewars-server", ServiceInit},
+    {"churchwars-server", ServiceInit},
     {NULL, NULL}
   };
 
@@ -1573,7 +1573,7 @@ static void SetupTaskBarIcon(GtkWidget *widget)
     nid.uCallbackMessage = MYWM_TASKBAR;
     nid.hIcon = mainIcon;
     /* NOTIFYICONDATA::szTip is limited (typically 128 chars including NUL). */
-    snprintf(nid.szTip, sizeof(nid.szTip), "dopewars server - running");
+    snprintf(nid.szTip, sizeof(nid.szTip), "Church Wars server - running");
     systray = Shell_NotifyIcon(NIM_ADD, &nid);
   } else {
     systray = FALSE;
@@ -1604,8 +1604,8 @@ void GuiServerLoop(struct CMDLINE *cmdline, gboolean is_service)
                    G_CALLBACK(GuiRequestDelete), NULL);
   gtk_window_set_default_size(GTK_WINDOW(window), 500, 250);
 
-  /* Title of dopewars server window (if used) */
-  gtk_window_set_title(GTK_WINDOW(window), _("dopewars server"));
+  /* Title of Church Wars server window (if used) */
+  gtk_window_set_title(GTK_WINDOW(window), _("Church Wars server"));
 
   gtk_container_set_border_width(GTK_CONTAINER(window), 7);
 
@@ -1739,7 +1739,7 @@ void CloseHighScoreFile()
 
 /* 
  * If we're running setuid/setgid, drop down to the privilege level of the
- * user that started the dopewars process.
+ * user that started the Church Wars process.
  */
 void DropPrivileges()
 {
@@ -1888,9 +1888,9 @@ static FILE *OpenHighScoreAppData(int *error, gboolean *empty)
         GString *str = g_string_sized_new(keylen + 40);
         g_string_assign(str, keyval);
         g_free(keyval);
-        g_string_append(str, "\\dopewars");
+        g_string_append(str, "\\churchwars");
         CreateDirectory(str->str, NULL);
-        g_string_append(str, "\\dopewars.sco");
+        g_string_append(str, "\\churchwars.sco");
         fp = fopen(str->str, "r+");
         if (!fp) {
           fp = fopen(str->str, "w+");
@@ -1978,8 +1978,8 @@ gboolean CheckHighScoreFileConfig(void)
     g_log(NULL, G_LOG_LEVEL_CRITICAL,
           _("%s does not appear to be a valid\n"
             "high score file - please check it. If it is a high score file\n"
-            "from an older version of dopewars, then first convert it to the\n"
-            "new format by running \"dopewars -C %s\"\n"
+            "from an older version of Church Wars, then first convert it to the\n"
+            "new format by running \"Church Wars -C %s\"\n"
             "from the command line."), HiScoreFile, HiScoreFile);
     return FALSE;
   }
@@ -1989,7 +1989,7 @@ gboolean CheckHighScoreFileConfig(void)
     g_warning(_("Errors were encountered during the reading of the "
                 "configuration file.\nAs as result, some settings may not "
                 "work as expected. Please consult the\n"
-                "file \"dopewars-log.txt\" for further details."));
+                "file \"churchwars-log.txt\" for further details."));
 #else
     g_warning(_("Errors were encountered during the reading of the "
                 "configuration\nfile. As a result, some settings may not "

--- a/src/serverside.h
+++ b/src/serverside.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * serverside.h   Server-side parts of dopewars                         *
+ * serverside.h   Server-side parts of Church Wars                      *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/sound.c
+++ b/src/sound.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound.c        dopewars sound system                                 *
+ * sound.c        Church Wars sound system                              *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/sound.h
+++ b/src/sound.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * sound.h        Header file for dopewars sound system                 *
+ * sound.h        Header file for Church Wars sound system              *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/tstring.c
+++ b/src/tstring.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * tstring.c      "Translated string" wrappers for dopewars             *
+ * tstring.c      "Translated string" wrappers for Church Wars          *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/tstring.h
+++ b/src/tstring.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * tstring.h      "Translated string" wrappers for dopewars             *
+ * tstring.h      "Translated string" wrappers for Church Wars          *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/util.c
+++ b/src/util.c
@@ -2,7 +2,7 @@
  * util.c         Miscellaneous utility and portability functions       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/util.h
+++ b/src/util.h
@@ -2,7 +2,7 @@
  * util.h         Miscellaneous utility and portability functions       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/                 *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -2,7 +2,7 @@
  * winmain.c      Startup code and support for the Win32 platform       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -97,7 +97,7 @@ static void WindowPrintFunc(const gchar *string)
 
 static void WindowPrintEnd()
 {
-  MessageBox(NULL, TextOutput->str, "dopewars",
+  MessageBox(NULL, TextOutput->str, "Church Wars",
              MB_OK | MB_ICONINFORMATION);
   g_string_free(TextOutput, TRUE);
   TextOutput = NULL;
@@ -109,13 +109,13 @@ gchar *appdata_path = NULL;
 
 static void GetAppDataPath()
 {
-  appdata_path = g_strdup_printf("%s/dopewars", g_get_user_config_dir());
+  appdata_path = g_strdup_printf("%s/churchwars", g_get_user_config_dir());
   mkdir(appdata_path);
 }
 
 static void LogFileStart()
 {
-  char *logfile = g_strdup_printf("%s/dopewars-log.txt",
+  char *logfile = g_strdup_printf("%s/churchwars-log.txt",
                                   appdata_path ? appdata_path : ".");
   LogFile = fopen(logfile, "w");
   g_free(logfile);
@@ -316,7 +316,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   /* Informational comment placed at the start of the Windows log file
      (this is used for messages printed during processing of the config
      files - under Unix these are just printed to stdout) */
-  g_print(_("# This is the dopewars startup log, containing any\n"
+  g_print(_("# This is the Church Wars startup log, containing any\n"
             "# informative messages resulting from configuration\n"
             "# file processing and the like.\n\n"));
 
@@ -357,7 +357,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       GuiServerLoop(cmdline, FALSE);
 #else
       AllocConsole();
-      SetConsoleTitle(_("dopewars server"));
+      SetConsoleTitle(_("Church Wars server"));
       g_log_set_handler(NULL,
                         LogMask() | G_LOG_LEVEL_MESSAGE |
                         G_LOG_LEVEL_WARNING, ServerLogMessage, NULL);
@@ -378,7 +378,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       AllocConsole();
 
       /* Title of the Windows window used for AI player output */
-      SetConsoleTitle(_("dopewars AI"));
+      SetConsoleTitle(_("Church Wars AI"));
 
       g_log_set_handler(NULL,
                         LogMask() | G_LOG_LEVEL_MESSAGE |
@@ -390,7 +390,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       case CLIENT_AUTO:
         if (!GtkLoop(hInstance, hPrevInstance, cmdline, TRUE)) {
           AllocConsole();
-          SetConsoleTitle(_("dopewars"));
+          SetConsoleTitle(_("Church Wars"));
           CursesLoop(cmdline);
         }
         break;
@@ -399,7 +399,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
         break;
       case CLIENT_CURSES:
         AllocConsole();
-        SetConsoleTitle(_("dopewars"));
+        SetConsoleTitle(_("Church Wars"));
         CursesLoop(cmdline);
         break;
       }

--- a/src/winmain.h
+++ b/src/winmain.h
@@ -2,7 +2,7 @@
  * winmain.h      Startup code and support for the Win32 platform       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *


### PR DESCRIPTION
## Summary
- Replace Dope Wars names and messages with Church Wars across server, client, and utility code
- Update manifests and configuration paths to the new Church Wars branding
- Refresh documentation comments and URLs to point at Church Wars

## Testing
- `autoreconf -i` *(fails: Can't exec "aclocal": No such file or directory)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b7e7e57ec8326958395f46f1e8bfe