### PR TITLE
Replace dopewars branding with Church Wars

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -73,7 +73,7 @@ static void AIConnectFailed(NetworkBuffer *netbuf)
   if (netbuf->error)
     g_string_assign_error(errstr, netbuf->error);
   g_log(NULL, G_LOG_LEVEL_CRITICAL,
-        _("Could not connect to dopewars server\n(%s)\n"
+        _("Could not connect to Church Wars server\n(%s)\n"
           "AI Player terminating abnormally."), errstr->str);
   g_string_free(errstr, TRUE);
 }

--- a/src/admin.c
+++ b/src/admin.c
@@ -49,7 +49,7 @@ static int OpenSocket(void)
 
   sockname = GetLocalSocket();
 
-  g_print(_("Attempting to connect to local dopewars server via "
+  g_print(_("Attempting to connect to local Church Wars server via "
             "Unix domain\n socket %s...\n"), sockname);
   sock = socket(PF_UNIX, SOCK_STREAM, 0);
   if (sock == -1) {

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -232,7 +232,7 @@ gboolean UpdateConfigFile(const gchar *cfgfile, gboolean ForceUTF8)
   gchar *defaultfile;
   static gchar *header =
       "\n### Everything from here on is written automatically by\n"
-      "### the dopewars program; you can edit it manually, but any\n"
+      "### the Church Wars program; you can edit it manually, but any\n"
       "### formatting (comments, etc.) will be lost at the next rewrite.\n\n";
 
   defaultfile = GetLocalConfigFile();

--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -371,7 +371,7 @@ void display_intro(void)
   mvaddstr(19, 7, _("Unconstructive Criticism      R Batstone"));
 
   mvaddcentstr(21, _("For information on the command line options, type "
-                     "dopewars -h at your"));
+                     "Church Wars -h at your"));
   mvaddcentstr(22, _("Unix prompt. This will display a help screen, listing "
                      "the available options."));
 
@@ -398,7 +398,7 @@ static void SelectServerManually(void)
   mvaddstr(top + 1, 1,
            /* Prompts for hostname and port when selecting a server
               manually */
-           _("Please enter the hostname and port of a dopewars server:-"));
+           _("Please enter the hostname and port of a Church Wars server:-"));
   text = nice_input(_("Hostname: "), top + 2, 1, FALSE, ServerName, '\0');
   AssignName(&ServerName, text);
   g_free(text);
@@ -696,7 +696,7 @@ static gboolean ConnectToServer(Player *Play)
     clear_bottom();
     if (MetaOK && !firstrun) {
       mvaddstr(top + 1, 1, _("Please wait... attempting to contact "
-                             "dopewars server..."));
+                             "Church Wars server..."));
       refresh();
       NetOK = DoConnect(Play, errstr);
     }
@@ -714,7 +714,7 @@ static gboolean ConnectToServer(Player *Play)
         /* Display of an error message while trying to contact a dopewars
            server (the error message itself is displayed on the next
            screen line) */
-        mvaddstr(top, 1, _("Could not start multiplayer dopewars"));
+        mvaddstr(top, 1, _("Could not start multiplayer Church Wars"));
         text = g_strdup_printf("   (%s)",
                                errstr->str[0] ? errstr->str
                                   : _("connection to server failed"));
@@ -724,13 +724,13 @@ static gboolean ConnectToServer(Player *Play)
       MetaOK = NetOK = TRUE;
       attrset(PromptAttr);
       mvaddstr(top + 2, 1,
-               _("Will you... C>onnect to a named dopewars server"));
+               _("Will you... C>onnect to a named Church Wars server"));
       mvaddstr(top + 3, 1,
                _("            L>ist the servers on the metaserver, and "
                  "select one"));
       mvaddstr(top + 4, 1,
                _("            Q>uit (where you can start a server "
-                 "by typing \"dopewars -s\")"));
+                 "by typing \"Church Wars -s\")"));
       mvaddstr(top + 5, 1, _("         or P>lay single-player ? "));
       attrset(TextAttr);
 

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -218,7 +218,7 @@ struct METASERVER MetaServer = {
 
 struct METASERVER DefaultMetaServer = {
   TRUE, "https://dopewars.sourceforge.io/metaserver.php", "",
-  "", "dopewars server"
+  "", "Church Wars server"
 };
 
 SocksServer Socks = { NULL, 0, 0, FALSE, NULL, NULL, NULL };
@@ -2466,7 +2466,7 @@ static void PluginHelp(void)
 
 void HandleHelpTexts(gboolean fullhelp)
 {
-  g_print(_("dopewars version %s\n"), VERSION);
+  g_print(_("Church Wars version %s\n"), VERSION);
   if (!fullhelp) {
     return;
   }
@@ -2475,23 +2475,23 @@ void HandleHelpTexts(gboolean fullhelp)
 #ifdef HAVE_GETOPT_LONG
            /* Usage information, printed when the user runs "dopewars -h"
               (version with support for GNU long options) */
-           _("Usage: dopewars [OPTION]...\n\
+           _("Usage: Church Wars [OPTION]...\n\
 Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -b, --no-color,         \"black and white\" - i.e. do not use pretty colors\n\
       --no-colour           (by default colors are used where available)\n\
-  -n, --single-player     be boring and don't connect to any available dopewars\n\
+  -n, --single-player     be boring and don't connect to any available Church Wars\n\
                             servers (i.e. single player mode)\n\
-  -a, --antique           \"antique\" dopewars - keep as closely to the original\n\
+  -a, --antique           \"antique\" Church Wars - keep as closely to the original\n\
                             version as possible (no networking)\n\
   -f, --scorefile=FILE    specify a file to use as the high score table (by\n\
                             default %s/dopewars.sco is used)\n\
   -o, --hostname=ADDR     specify a hostname where the server for multiplayer\n\
-                            dopewars can be found\n\
+                            Church Wars can be found\n\
   -s, --public-server     run in server mode (note: see the -A option for\n\
                             configuring a server once it\'s running)\n\
   -S, --private-server    run a \"private\" server (do not notify the metaserver)\n\
   -p, --port=PORT         specify the network port to use (default: 7902)\n\
-  -g, --config-file=FILE  specify the pathname of a dopewars configuration file;\n\
+  -g, --config-file=FILE  specify the pathname of a Church Wars configuration file;\n\
                             this file is read immediately when the -g option\n\
                             is encountered\n\
   -r, --pidfile=FILE      maintain pid file \"FILE\" while running the server\n\
@@ -2512,23 +2512,23 @@ Report bugs to the author at benwebb@users.sf.net\n"));
 #else
            /* Usage information, printed when the user runs "dopewars -h"
               (short options only version) */
-           _("Usage: dopewars [OPTION]...\n\
+           _("Usage: Church Wars [OPTION]...\n\
 Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -b       \"black and white\" - i.e. do not use pretty colors\n\
               (by default colors are used where the terminal supports them)\n\
-  -n       be boring and don't connect to any available dopewars servers\n\
+  -n       be boring and don't connect to any available Church Wars servers\n\
               (i.e. single player mode)\n\
-  -a       \"antique\" dopewars - keep as closely to the original version as\n\
+  -a       \"antique\" Church Wars - keep as closely to the original version as\n\
               possible (no networking)\n\
   -f file  specify a file to use as the high score table\n\
               (by default %s/dopewars.sco is used)\n\
-  -o addr  specify a hostname where the server for multiplayer dopewars\n\
+  -o addr  specify a hostname where the server for multiplayer Church Wars\n\
               can be found\n\
   -s       run in server mode (note: see the -A option for configuring a\n\
               server once it\'s running)\n\
   -S       run a \"private\" server (i.e. do not notify the metaserver)\n\
   -p port  specify the network port to use (default: 7902)\n\
-  -g file  specify the pathname of a dopewars configuration file; this file\n\
+  -g file  specify the pathname of a Church Wars configuration file; this file\n\
               is read immediately when the -g option is encountered\n\
   -r file  maintain pid file \"file\" while running the server\n\
   -l file  write log information to \"file\"\n\

--- a/src/gtkport/gtkport.c
+++ b/src/gtkport/gtkport.c
@@ -5475,7 +5475,7 @@ void DisplayHTML(GtkWidget *parent, const gchar *bin, const gchar *target)
       pid = fork();
       if (pid == 0) {
         execv(bin, args);
-        g_print("dopewars: cannot execute %s\n", bin);
+        g_print("Church Wars: cannot execute %s\n", bin);
         _exit(EXIT_FAILURE);
       } else {
         _exit(EXIT_SUCCESS);

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2164,7 +2164,7 @@ gboolean GtkLoop(int *argc, char **argv[],
   window = MainWindow = ClientData.window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 
   /* Title of main window in GTK+ client */
-  gtk_window_set_title(GTK_WINDOW(window), _("dopewars"));
+  gtk_window_set_title(GTK_WINDOW(window), _("Church Wars"));
   gtk_window_set_default_size(GTK_WINDOW(window), 450, 390);
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(MainDelete), NULL);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -298,7 +298,7 @@ void RemoteVersionCheck(Player *Play)
         _("You appear to be using an extremely old (version 1.4.x) client.^"
           "While this will probably work, many of the newer features^"
           "will be unsupported. Get the latest version from the^"
-          "dopewars website, https://dopewars.sourceforge.io/."));
+          "Church Wars website, https://dopewars.sourceforge.io/."));
 
   /* The client has a smaller value of A_NUM; this means that not only does
    * it not support some features, it doesn't even know they might exist. */
@@ -306,7 +306,7 @@ void RemoteVersionCheck(Player *Play)
     SendPrintMessage(NULL, C_VERSIONCHECK, Play,
         _("Warning: your client is too old to support all of this^"
           "server's features. For the full \"experience\", get^"
-          "the latest version of dopewars from the^"
+          "the latest version of Church Wars from the^"
           "website, https://dopewars.sourceforge.io/."));
   }
 
@@ -1218,7 +1218,7 @@ void ServerLoop(struct CMDLINE *cmdline)
       BindNetworkBufferToSocket(netbuf, newlocal);
       localconn = g_slist_append(localconn, netbuf);
       oldprint = StartServerReply(netbuf);
-      g_print(_("dopewars server version %s ready for admin commands; "
+      g_print(_("Church Wars server version %s ready for admin commands; "
                 "try \"help\" for help"), VERSION);
       FinishServerReply(oldprint);
       dopelog(1, LF_SERVER, _("New admin connection"));
@@ -1500,7 +1500,7 @@ static VOID WINAPI ServiceHandler(DWORD control)
 
 static VOID WINAPI ServiceInit(DWORD argc, LPTSTR * argv)
 {
-  scHandle = RegisterServiceCtrlHandler("dopewars-server", ServiceHandler);
+  scHandle = RegisterServiceCtrlHandler("churchwars-server", ServiceHandler);
   if (!scHandle) {
     dopelog(0, LF_SERVER, _("Failed to register service handler"));
     return;
@@ -1521,7 +1521,7 @@ static VOID WINAPI ServiceInit(DWORD argc, LPTSTR * argv)
 void ServiceMain(struct CMDLINE *cmdline)
 {
   SERVICE_TABLE_ENTRY services[] = {
-    {"dopewars-server", ServiceInit},
+    {"churchwars-server", ServiceInit},
     {NULL, NULL}
   };
 
@@ -1573,7 +1573,7 @@ static void SetupTaskBarIcon(GtkWidget *widget)
     nid.uCallbackMessage = MYWM_TASKBAR;
     nid.hIcon = mainIcon;
     /* NOTIFYICONDATA::szTip is limited (typically 128 chars including NUL). */
-    snprintf(nid.szTip, sizeof(nid.szTip), "dopewars server - running");
+    snprintf(nid.szTip, sizeof(nid.szTip), "Church Wars server - running");
     systray = Shell_NotifyIcon(NIM_ADD, &nid);
   } else {
     systray = FALSE;
@@ -1605,7 +1605,7 @@ void GuiServerLoop(struct CMDLINE *cmdline, gboolean is_service)
   gtk_window_set_default_size(GTK_WINDOW(window), 500, 250);
 
   /* Title of dopewars server window (if used) */
-  gtk_window_set_title(GTK_WINDOW(window), _("dopewars server"));
+  gtk_window_set_title(GTK_WINDOW(window), _("Church Wars server"));
 
   gtk_container_set_border_width(GTK_CONTAINER(window), 7);
 
@@ -1978,8 +1978,8 @@ gboolean CheckHighScoreFileConfig(void)
     g_log(NULL, G_LOG_LEVEL_CRITICAL,
           _("%s does not appear to be a valid\n"
             "high score file - please check it. If it is a high score file\n"
-            "from an older version of dopewars, then first convert it to the\n"
-            "new format by running \"dopewars -C %s\"\n"
+            "from an older version of Church Wars, then first convert it to the\n"
+            "new format by running \"Church Wars -C %s\"\n"
             "from the command line."), HiScoreFile, HiScoreFile);
     return FALSE;
   }

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -97,7 +97,7 @@ static void WindowPrintFunc(const gchar *string)
 
 static void WindowPrintEnd()
 {
-  MessageBox(NULL, TextOutput->str, "dopewars",
+  MessageBox(NULL, TextOutput->str, "Church Wars",
              MB_OK | MB_ICONINFORMATION);
   g_string_free(TextOutput, TRUE);
   TextOutput = NULL;
@@ -316,7 +316,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   /* Informational comment placed at the start of the Windows log file
      (this is used for messages printed during processing of the config
      files - under Unix these are just printed to stdout) */
-  g_print(_("# This is the dopewars startup log, containing any\n"
+  g_print(_("# This is the Church Wars startup log, containing any\n"
             "# informative messages resulting from configuration\n"
             "# file processing and the like.\n\n"));
 
@@ -357,7 +357,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       GuiServerLoop(cmdline, FALSE);
 #else
       AllocConsole();
-      SetConsoleTitle(_("dopewars server"));
+      SetConsoleTitle(_("Church Wars server"));
       g_log_set_handler(NULL,
                         LogMask() | G_LOG_LEVEL_MESSAGE |
                         G_LOG_LEVEL_WARNING, ServerLogMessage, NULL);
@@ -378,7 +378,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       AllocConsole();
 
       /* Title of the Windows window used for AI player output */
-      SetConsoleTitle(_("dopewars AI"));
+      SetConsoleTitle(_("Church Wars AI"));
 
       g_log_set_handler(NULL,
                         LogMask() | G_LOG_LEVEL_MESSAGE |
@@ -390,7 +390,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
       case CLIENT_AUTO:
         if (!GtkLoop(hInstance, hPrevInstance, cmdline, TRUE)) {
           AllocConsole();
-          SetConsoleTitle(_("dopewars"));
+          SetConsoleTitle(_("Church Wars"));
           CursesLoop(cmdline);
         }
         break;
@@ -399,7 +399,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
         break;
       case CLIENT_CURSES:
         AllocConsole();
-        SetConsoleTitle(_("dopewars"));
+        SetConsoleTitle(_("Church Wars"));
         CursesLoop(cmdline);
         break;
       }


### PR DESCRIPTION
## Summary
- Rename user-facing strings from "dopewars" to "Church Wars" across clients and server
- Update command-line help and configuration headers to reflect Church Wars branding

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689b82f3f25483268ebb919d5cdc407a