### PR TITLE
Rename Dopewars references to Church Wars

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * gtk_client.c   dopewars client using the GTK+ toolkit                *
+ * gtk_client.c   Church Wars client using the GTK+ toolkit             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -200,7 +200,7 @@ GtkWidget *my_hbbox_new(void)
 void my_gtk_box_pack_start_defaults(GtkBox *box, GtkWidget *child)
 {
 #ifdef CYGWIN
-  /* For compatibility with older dopewars */
+  /* For compatibility with older Church Wars */
   gtk_box_pack_start(box, child, FALSE, FALSE, 0);
 #else
   gtk_box_pack_start(box, child, TRUE, TRUE, 0);
@@ -255,7 +255,7 @@ void NewGame(GtkWidget *widget, gpointer data)
   }
 
   /* Save the configuration, so we can restore those elements that get
-   * overwritten when we connect to a dopewars server */
+   * overwritten when we connect to a Church Wars server */
   BackupConfig();
 
 #ifdef NETWORKING
@@ -2129,6 +2129,8 @@ gboolean GtkLoop(int *argc, char **argv[],
     gtk_init(argc, argv);
 #endif
 
+  g_set_application_name(_("Church Wars"));
+
   /* GTK+2 (and the GTK emulation code on WinNT systems) expects all
    * strings to be UTF-8, so we force gettext to return all translations
    * in this encoding here. */
@@ -2387,8 +2389,8 @@ void display_intro(GtkWidget *widget, gpointer data)
   }
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
-  PackCentredURL(vbox, _("Original Dopewars information here"),
-                 "https://dopewars.sourceforge.io/", OurWebBrowser);
+  PackCentredURL(vbox, _("Original Church Wars information here"),
+                 "https://churchwars.sourceforge.io/", OurWebBrowser);
 
   hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start(GTK_BOX(vbox), hsep, FALSE, FALSE, 0);

--- a/src/gui_client/gtk_client.h
+++ b/src/gui_client/gtk_client.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * gtk_client.h   dopewars client using the GTK+ toolkit                *
+ * gtk_client.h   Church Wars client using the GTK+ toolkit             *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/newgamedia.c
+++ b/src/gui_client/newgamedia.c
@@ -2,7 +2,7 @@
  * newgamedia.c   New game dialog                                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -93,7 +93,7 @@ static void ConnectError(void)
     g_string_assign(neterr, _("Connection closed by remote host"));
   }
 
-  /* Error: GTK+ client could not connect to the given dopewars server */
+  /* Error: GTK+ client could not connect to the given Church Wars server */
   text = g_strdup_printf(_("Status: Could not connect (%s)"), neterr->str);
 
   SetStartGameStatus(text);

--- a/src/gui_client/newgamedia.h
+++ b/src/gui_client/newgamedia.h
@@ -2,7 +2,7 @@
  * newgamedia.h   New game dialog                                       *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/optdialog.c
+++ b/src/gui_client/optdialog.c
@@ -2,7 +2,7 @@
  * optdialog.c    Configuration file editing dialog                     *
  * Copyright (C)  2002-2004  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/gui_client/optdialog.h
+++ b/src/gui_client/optdialog.h
@@ -2,7 +2,7 @@
  * optdialog.c    Configuration file editing dialog                     *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -1,8 +1,8 @@
 /************************************************************************
- * serverside.c   Handles the server side of dopewars                   *
+ * serverside.c   Handles the server side of Church Wars                *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *
@@ -298,7 +298,7 @@ void RemoteVersionCheck(Player *Play)
         _("You appear to be using an extremely old (version 1.4.x) client.^"
           "While this will probably work, many of the newer features^"
           "will be unsupported. Get the latest version from the^"
-          "Church Wars website, https://dopewars.sourceforge.io/."));
+          "Church Wars website, https://churchwars.sourceforge.io/."));
 
   /* The client has a smaller value of A_NUM; this means that not only does
    * it not support some features, it doesn't even know they might exist. */
@@ -307,7 +307,7 @@ void RemoteVersionCheck(Player *Play)
         _("Warning: your client is too old to support all of this^"
           "server's features. For the full \"experience\", get^"
           "the latest version of Church Wars from the^"
-          "website, https://dopewars.sourceforge.io/."));
+          "website, https://churchwars.sourceforge.io/."));
   }
 
   /* Otherwise, the client is either the same version as the server, or
@@ -555,7 +555,7 @@ void CleanUpServer()
 
 /* 
  * Responds to a SIGUSR1 signal, and requests the main event loop to
- * reregister the server with the dopewars metaserver.
+ * reregister the server with the Church Wars metaserver.
  */
 void ReregisterHandle(int sig)
 {
@@ -572,7 +572,7 @@ void RelogHandle(int sig)
 }
 
 /* 
- * Traps an attempt by the user to send dopewars a SIGTERM or SIGINT
+ * Traps an attempt by the user to send Church Wars a SIGTERM or SIGINT
  * (e.g. pressing Ctrl-C) and signals for a "nice" shutdown. Restores
  * the default signal action (to terminate without cleanup) so that
  * the user can still close the program easily if this cleanup code
@@ -1599,12 +1599,13 @@ void GuiServerLoop(struct CMDLINE *cmdline, gboolean is_service)
     InitConfiguration(cmdline);
   }
 
+  g_set_application_name(_("Church Wars server"));
   window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(GuiRequestDelete), NULL);
   gtk_window_set_default_size(GTK_WINDOW(window), 500, 250);
 
-  /* Title of dopewars server window (if used) */
+  /* Title of Church Wars server window (if used) */
   gtk_window_set_title(GTK_WINDOW(window), _("Church Wars server"));
 
   gtk_container_set_border_width(GTK_CONTAINER(window), 7);
@@ -1739,7 +1740,7 @@ void CloseHighScoreFile()
 
 /* 
  * If we're running setuid/setgid, drop down to the privilege level of the
- * user that started the dopewars process.
+ * user that started the Church Wars process.
  */
 void DropPrivileges()
 {
@@ -1989,7 +1990,7 @@ gboolean CheckHighScoreFileConfig(void)
     g_warning(_("Errors were encountered during the reading of the "
                 "configuration file.\nAs as result, some settings may not "
                 "work as expected. Please consult the\n"
-                "file \"dopewars-log.txt\" for further details."));
+                "file \"churchwars-log.txt\" for further details."));
 #else
     g_warning(_("Errors were encountered during the reading of the "
                 "configuration\nfile. As a result, some settings may not "

--- a/src/serverside.h
+++ b/src/serverside.h
@@ -1,8 +1,8 @@
 /************************************************************************
- * serverside.h   Server-side parts of dopewars                         *
+ * serverside.h   Server-side parts of Church Wars                      *
  * Copyright (C)  1998-2022  Ben Webb                                   *
  *                Email: benwebb@users.sf.net                           *
- *                WWW: https://dopewars.sourceforge.io/                 *
+ *                WWW: https://churchwars.sourceforge.io/               *
  *                                                                      *
  * This program is free software; you can redistribute it and/or        *
  * modify it under the terms of the GNU General Public License          *


### PR DESCRIPTION
## Summary
- Rebrand GTK client strings and headers from Dopewars to Church Wars
- Refresh server messages and log references for Church Wars
- Update GUI dialog headers to point at the new churchwars.sourceforge.io site
- Set application name so window titles show Church Wars

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b86f65cf08326aab123dc1b34ff79