### PR TITLE
Simplify GString cleanup in nice_input

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2282,8 +2282,7 @@ char *nice_input(char *prompt, int sy, int sx, gboolean digitsonly,
   } while (c != '\n' && c != KEY_ENTER);
   curs_set(0);
   move(sy, x);
-  ReturnString = text->str;
-  g_string_free(text, FALSE);   /* Leave the buffer to return */
+  ReturnString = g_string_free(text, FALSE);   /* Leave the buffer to return */
   return ReturnString;
 }
 


### PR DESCRIPTION
## Summary
- avoid referencing internal GString buffer after freeing in `nice_input`

## Testing
- `gcc -Wall -Wextra -c src/curses_client/curses_client.c \`pkg-config --cflags glib-2.0 ncursesw 2>/dev/null\` -I src -I src/curses_client -I src/cursesport` *(fails: fatal error: glib.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689b8b1743bc83269a1251a9511b4201