### PR TITLE
Handle existing socket directory on startup

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -1018,8 +1018,10 @@ static int SetupLocalSocket(void)
 
   sockname = GetLocalSocket();
   sockdir = GetLocalSockDir();
-  if (mkdir(sockdir, S_IRUSR | S_IWUSR | S_IXUSR) == -1)
-    return -1;
+  if (mkdir(sockdir, S_IRUSR | S_IWUSR | S_IXUSR) == -1) {
+    if (errno != EEXIST)
+      return -1;
+  }
 
   addr.sun_family = AF_UNIX;
   strncpy(addr.sun_path, sockname, sizeof(addr.sun_path));


### PR DESCRIPTION
## Summary
- Ignore `EEXIST` when creating the server socket directory so startup continues if the directory already exists

## Testing
- `make test` (fails: No rule to make target 'test')
- `make check` (fails: No rule to make target 'check')
- `make` (fails: No targets specified and no makefile found)
- `gcc -c src/serverside.c -I./src -I.` (fails: glib.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689b8e3e7cc8832694be6d836c57224e