### PR TITLE
Handle app data directory creation errors

### DIFF
--- a/src/winmain.c
+++ b/src/winmain.c
@@ -31,6 +31,7 @@
 #include <windows.h>
 #include <commctrl.h>
 #include <glib.h>
+#include <errno.h>
 #include <stdlib.h>
 
 #include "dopewars.h"
@@ -110,7 +111,10 @@ gchar *appdata_path = NULL;
 static void GetAppDataPath()
 {
   appdata_path = g_strdup_printf("%s/dopewars", g_get_user_config_dir());
-  mkdir(appdata_path);
+  if (g_mkdir_with_parents(appdata_path, 0700) != 0) {
+    g_warning("Could not create directory %s: %s", appdata_path,
+              g_strerror(errno));
+  }
 }
 
 static void LogFileStart()


### PR DESCRIPTION
## Summary
- log failures to create the application data directory on startup
- include errno to report why the directory could not be created

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `gcc -c src/winmain.c -I./src -DCYGWIN` *(fails: fatal error: direct.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e3fea0c8326a815a1d8bed5cbd9