### PR TITLE
Clean plugin Makefile indentation

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -60,11 +60,11 @@ all-local: ${PLUGINS}
 install-exec-am:
 	${mkinstalldirs} ${PLUGINDIR}
 	for plug in ${PLUGINS}; do \
-	  ${INSTALL} $${plug} ${PLUGINDIR}; \
+	${INSTALL} $${plug} ${PLUGINDIR}; \
 	done
 
 uninstall-local:
 	for plug in ${PLUGINS}; do \
-	  /bin/rm -f ${PLUGINDIR}/`basename $${plug}`; \
+	/bin/rm -f ${PLUGINDIR}/`basename $${plug}`; \
 	done
 endif


### PR DESCRIPTION
## Summary
- fix `install-exec-am` and `uninstall-local` rules so plugin commands start with a single tab

## Testing
- `autoreconf -i` *(fails: aclocal missing)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `./configure` *(fails: No such file or directory)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8f6d5ae483268aed71beaa50b24c