### PR TITLE
Remove unused variable in Curses_DoGame

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2347,7 +2347,6 @@ static void Curses_DoGame(Player *Play)
 #endif
   int MaxSock;
   char HaveWorthless;
-  Player *tmp;
   struct sigaction sact;
 
   DisplayMode = DM_NONE;


### PR DESCRIPTION
## Summary
- remove unused `tmp` variable from `Curses_DoGame`

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `gcc -Wall -c src/curses_client/curses_client.c -Isrc` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b8f7107f48326ae95d9faa978fac1