### PR TITLE
Fix plugin install Makefile tabs

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -60,11 +60,11 @@ all-local: ${PLUGINS}
 install-exec-am:
 	${mkinstalldirs} ${PLUGINDIR}
 	for plug in ${PLUGINS}; do \
-	${INSTALL} $${plug} ${PLUGINDIR}; \
+		${INSTALL} $${plug} ${PLUGINDIR}; \
 	done
 
 uninstall-local:
 	for plug in ${PLUGINS}; do \
-	/bin/rm -f ${PLUGINDIR}/`basename $${plug}`; \
+		/bin/rm -f ${PLUGINDIR}/`basename $${plug}`; \
 	done
 endif


### PR DESCRIPTION
## Summary
- ensure plugin install and uninstall recipes use tab-prefixed commands

## Testing
- `autoreconf -fi` *(fails: Can't exec "aclocal": No such file or directory)*
- `./configure` *(fails: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689b97a14a6483268cc8dfb6c736882c