### PR TITLE
Use system default browser for documentation links

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -99,7 +99,6 @@ gboolean Daemonize = TRUE;
 #define SNDPATH DPDATADIR"/dopewars/"
 #endif
 
-gchar *OurWebBrowser = NULL;
 gint ConfigErrors = 0;
 gboolean LocaleIsUTF8 = FALSE;
 
@@ -299,9 +298,6 @@ struct GLOBALS Globals[] = {
 #else
   {NULL, &Daemonize, NULL, NULL, NULL, "Daemonize",
    N_("If TRUE, the server runs in the background"),
-   NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 0},
-  {NULL, NULL, NULL, &OurWebBrowser, NULL, "WebBrowser",
-   N_("The command used to start your web browser"),
    NULL, NULL, 0, "", NULL, NULL, FALSE, 0, 0},
 #endif
   {&NumTurns, NULL, NULL, NULL, NULL, "NumTurns",
@@ -2333,7 +2329,6 @@ static void SetupParameters(GSList *extraconfigs, gboolean antique)
   AssignName(&ServerName, "localhost");
   AssignName(&ServerMOTD, "");
   AssignName(&BindAddress, "");
-  AssignName(&OurWebBrowser, "/usr/bin/firefox");
 
   AssignName(&Sounds.FightHit, SNDPATH"colt.wav");
   AssignName(&Sounds.EnemyBitchKilled, SNDPATH"shotdown.wav");

--- a/src/dopewars.h
+++ b/src/dopewars.h
@@ -180,7 +180,6 @@ extern gboolean MinToSysTray;
 #else
 extern gboolean Daemonize;
 #endif
-extern gchar *OurWebBrowser;
 extern int LoanSharkLoc, BankLoc, GunShopLoc, RoughPubLoc;
 extern int DrugSortMethod, FightTimeout, IdleTimeout, ConnectTimeout;
 extern int MaxClients, AITurnPause;

--- a/src/gtkport/gtkport.c
+++ b/src/gtkport/gtkport.c
@@ -24,14 +24,6 @@
 #include <config.h>
 #endif
 
-#ifndef CYGWIN
-#include <sys/types.h>          /* For pid_t (fork) */
-#include <sys/wait.h>           /* For wait */
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>             /* For fork and execv */
-#endif
-#endif /* !CYGWIN */
-
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -842,7 +834,7 @@ LRESULT CALLBACK GtkPanedProc(HWND hwnd, UINT msg, WPARAM wParam,
   return FALSE;
 }
 
-void DisplayHTML(GtkWidget *parent, const gchar *bin, const gchar *target)
+void DisplayHTML(GtkWidget *parent, const gchar *target)
 {
   ShellExecute(parent->hWnd, "open", target, NULL, NULL, 0);
 }
@@ -875,7 +867,7 @@ LRESULT CALLBACK GtkUrlProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
   } else if (msg == WM_LBUTTONUP) {
     widget = GTK_WIDGET(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
 
-    DisplayHTML(widget, NULL, GTK_URL(widget)->target);
+    DisplayHTML(widget, GTK_URL(widget)->target);
     return FALSE;
   } else
     return DefWindowProcW(hwnd, msg, wParam, lParam);
@@ -1886,8 +1878,7 @@ GtkWidget *gtk_label_new(const gchar *text)
   return GTK_WIDGET(label);
 }
 
-GtkWidget *gtk_url_new(const gchar *text, const gchar *target,
-                       const gchar *bin)
+GtkWidget *gtk_url_new(const gchar *text, const gchar *target)
 {
   GtkUrl *url;
 
@@ -1895,8 +1886,6 @@ GtkWidget *gtk_url_new(const gchar *text, const gchar *target,
 
   GTK_LABEL(url)->text = g_strdup(text);
   url->target = g_strdup(target);
-
-  /* N.B. "bin" argument is ignored under Win32 */
 
   return GTK_WIDGET(url);
 }
@@ -5454,39 +5443,24 @@ gint GtkMessageBox(GtkWidget *parent, const gchar *Text,
   return retval;
 }
 
-void DisplayHTML(GtkWidget *parent, const gchar *bin, const gchar *target)
+void DisplayHTML(GtkWidget *parent, const gchar *target)
 {
 #ifdef APPLE
   mac_open_url(target);
-#elif defined(HAVE_FORK)
-  char *args[3];
-  pid_t pid;
-  int status;
-
-  if (target && target[0] && bin && bin[0]) {
-    args[0] = (char *)bin;
-    args[1] = (char *)target;
-    args[2] = NULL;
-    /* Fork twice so that the spawned process gets init as its parent */
-    pid = fork();
-    if (pid > 0) {
-      wait(&status);
-    } else if (pid == 0) {
-      pid = fork();
-      if (pid == 0) {
-        execv(bin, args);
-        g_print("Church Wars: cannot execute %s\n", bin);
-        _exit(EXIT_FAILURE);
-      } else {
-        _exit(EXIT_SUCCESS);
-      }
+#else
+  if (target && *target) {
+    GError *error = NULL;
+    gtk_show_uri_on_window(GTK_WINDOW(parent), target, GDK_CURRENT_TIME,
+                           &error);
+    if (error) {
+      g_warning("Church Wars: cannot open %s: %s", target, error->message);
+      g_error_free(error);
     }
   }
 #endif
 }
 
-GtkWidget *gtk_url_new(const gchar *text, const gchar *target,
-                       const gchar *bin)
+GtkWidget *gtk_url_new(const gchar *text, const gchar *target)
 {
   GtkWidget *button;
   button = gtk_link_button_new(text);

--- a/src/gtkport/gtkport.h
+++ b/src/gtkport/gtkport.h
@@ -641,11 +641,10 @@ GtkWidget *gtk_scrolled_text_view_new(GtkWidget **pack_widg);
 void TextViewAppend(GtkTextView *textview, const gchar *text,
                     const gchar *tagname, gboolean scroll);
 void TextViewClear(GtkTextView *textview);
-GtkWidget *gtk_url_new(const gchar *text, const gchar *target,
-                       const gchar *bin);
+GtkWidget *gtk_url_new(const gchar *text, const gchar *target);
 gchar *GtkGetFile(const GtkWidget *parent, const gchar *oldname,
                   const gchar *title);
-void DisplayHTML(GtkWidget *parent, const gchar *bin, const gchar *target);
+void DisplayHTML(GtkWidget *parent, const gchar *target);
 GtkWidget *gtk_scrolled_tree_view_new(GtkWidget **pack_widg);
 
 /* GtkTable is used in GTK2 (and early GTK3) but GtkGrid is used in later

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2283,8 +2283,7 @@ gboolean GtkLoop(int *argc, char **argv[],
   return TRUE;
 }
 
-static void PackCentredURL(GtkWidget *vbox, gchar *title, gchar *target,
-                           gchar *browser)
+static void PackCentredURL(GtkWidget *vbox, gchar *title, gchar *target)
 {
   GtkWidget *hbox, *label, *url;
 
@@ -2294,7 +2293,7 @@ static void PackCentredURL(GtkWidget *vbox, gchar *title, gchar *target,
   label = gtk_label_new("");
   gtk_box_pack_start(GTK_BOX(hbox), label, TRUE, TRUE, 0);
 
-  url = gtk_url_new(title, target, browser);
+  url = gtk_url_new(title, target);
   gtk_box_pack_start(GTK_BOX(hbox), url, FALSE, FALSE, 0);
 
   label = gtk_label_new("");
@@ -2395,7 +2394,7 @@ void display_intro(GtkWidget *widget, gpointer data)
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
   PackCentredURL(vbox, _("Original Church Wars information here"),
-                 "https://churchwars.sourceforge.io/", OurWebBrowser);
+                 "https://churchwars.sourceforge.io/");
 
   hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start(GTK_BOX(vbox), hsep, FALSE, FALSE, 0);

--- a/src/gui_client/optdialog.c
+++ b/src/gui_client/optdialog.c
@@ -651,7 +651,7 @@ static void HelpCallback(GtkWidget *widget, GtkWidget *notebook)
   gchar *help;
 
   help = GetHelpPage(pagehelp[page]);
-  DisplayHTML(widget, OurWebBrowser, help);
+  DisplayHTML(widget, help);
   g_free(help);
 }
 


### PR DESCRIPTION
## Summary
- Replace manual fork/exec HTML handling with `gtk_show_uri_on_window()` to use the system browser.
- Drop `OurWebBrowser` configuration and hard-coded `/usr/bin/firefox` fallback.
- Simplify URL helpers and help dialog to rely on default browser.

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: repository is not signed)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689bad199dc08326a7af42cdc1f46853