### PR TITLE
Increase Gold price range above Food

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -723,7 +723,7 @@ struct DRUG DefaultDrug[] = {
   {N_("True Cross splinters"), 1000, 2500, FALSE, FALSE, ""},
   {N_("Food"), 220, 700, FALSE, FALSE, ""},
   {N_("Silk"), 630, 1300, FALSE, FALSE, ""},
-  {N_("Gold"), 90, 250, FALSE, TRUE, ""},
+  {N_("Gold"), 800, 1600, FALSE, TRUE, ""},
   {N_("Holy Scriptures"), 315, 890, TRUE, FALSE,
    N_("Alexandrian scholars have sent parchments! "
       "Scripture prices have bottomed out!")}


### PR DESCRIPTION
## Summary
- raise Gold's default price range to 800–1600 so it exceeds Food's 220–700 range

## Testing
- `gcc -Isrc $(pkg-config --cflags glib-2.0) tests/test_socks5.c src/network.c src/util.c -o tests/test_socks5 $(pkg-config --libs glib-2.0)` *(fails: glib-2.0 not installed)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689baeccf2808326beb13fb549dd1f6b