### PR TITLE
Rebalance default espionage and hire costs

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -563,18 +563,18 @@ current game turn.</dd>
 <dd>Sets the price to pay a bitch to spy on another player to be
 <i>$20,000</i>.</dd>
 
-<dt><b>Prices.Tipoff=<i>10000</i></b></dt>
+<dt><b>Prices.Tipoff=<i>20000</i></b></dt>
 <dd>Sets the price to pay a bitch to tip off the cops to another player to be
-<i>$10,000</i>.</dd>
+<i>$20,000</i>.</dd>
 
-<dt><b>Bitch.MinPrice=<i>40000</i></b></dt>
-<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$40,000</i>.
+<dt><b>Bitch.MinPrice=<i>20000</i></b></dt>
+<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$20,000</i>.
 Note that prices for bitches "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal bitch price
-distribution by 3, i.e. about one-third of the shop price range (~$13,000–$40,000 by default).</dd>
+distribution by 3, i.e. about one-third of the shop price range (~$6,700–$13,300 by default).</dd>
 
-<dt><b>Bitch.MaxPrice=<i>120000</i></b></dt>
-<dd>Sets the maximum price for a bitch to <i>$120,000</i>.</dd>
+<dt><b>Bitch.MaxPrice=<i>40000</i></b></dt>
+<dd>Sets the maximum price for a bitch to <i>$40,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -203,11 +203,11 @@ struct CURRENCY Currency = {
 };
 
 struct PRICES Prices = {
-  20000, 10000
+  20000, 20000
 };
 
 struct BITCH Bitch = {
-  40000, 120000
+  20000, 40000
 };
 
 #ifdef NETWORKING


### PR DESCRIPTION
## Summary
- Align spy/tipoff actions with starting cash by setting both costs to $20k
- Lower bitch hiring range to $20k–$40k so costs scale with initial funds
- Update configuration documentation to reflect new default pricing

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb0166b048326a2a1449d77b12d58