### PR TITLE
Rebalance default gun costs and combat docs

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -359,8 +359,8 @@ players.)</dd>
 <dt><b>Gun[<i>3</i>].Name=<i>"Ruger"</i></b></dt>
 <dd>Sets the name of the <i>3rd</i> gun to <i>Ruger</i>.</dd>
 
-<dt><b>Gun[<i>3</i>].Price=<i>2900</i></b></dt>
-<dd>Sets the price in the gun shop of the <i>3rd</i> gun to <i>$2,900</i>.
+<dt><b>Gun[<i>3</i>].Price=<i>4500</i></b></dt>
+<dd>Sets the price in the gun shop of the <i>3rd</i> gun to <i>$4,500</i>.
 Guns offered "on the street" (i.e. by random events) will be priced at about
 one half of the value set here.</dd>
 
@@ -369,8 +369,8 @@ one half of the value set here.</dd>
 inventory - i.e. carrying one of these guns uses the same spaces as 4
 drugs.</dd>
 
-<dt><b>Gun[<i>3</i>].Damage=<i>4</i></b></dt>
-<dd>Defines gun number <i>3</i> to do up to <i>4</i> points of damage.</dd>
+<dt><b>Gun[<i>3</i>].Damage=<i>7</i></b></dt>
+<dd>Defines gun number <i>3</i> to do up to <i>7</i> points of damage.</dd>
 
 <dt><b>PlayerArmor=<i>100</i></b> or <b>PlayerArmour=<i>100</i></b></dt>
 <dd>Sets the percentage armor rating of each player to <i>100</i> - this

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -698,9 +698,9 @@ struct COP DefaultCop[] = {
 struct GUN DefaultGun[] = {
   /* The names of the default guns */
   {N_("Mace"), 3000, 4, 5},
-  {N_("Crossbow"), 3500, 4, 9},
-  {N_("Spear"), 2900, 4, 4},
-  {N_("Battle Axe"), 3100, 4, 7}
+  {N_("Crossbow"), 6000, 4, 9},
+  {N_("Spear"), 2500, 4, 4},
+  {N_("Battle Axe"), 4500, 4, 7}
 };
 
 struct DRUG DefaultDrug[] = {

--- a/tests/test_gun_balance.py
+++ b/tests/test_gun_balance.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+import sys
+
+# Read gun definitions from source file
+src = Path(__file__).resolve().parents[1] / 'src' / 'dopewars.c'
+text = src.read_text()
+
+# Extract tuples of (name, price, damage)
+pattern = re.compile(r'\{N_\("([^"]+)"\),\s*(\d+),\s*\d+,\s*(\d+)\}')
+guns = [(n, int(p), int(d)) for n, p, d in pattern.findall(text)]
+
+if len(guns) < 2:
+    print("Not enough gun definitions found")
+    sys.exit(1)
+
+# Sort guns by price and verify damage increases with price
+sorted_guns = sorted(guns, key=lambda g: g[1])
+price_damage_ok = all(sorted_guns[i][2] <= sorted_guns[i+1][2]
+                      for i in range(len(sorted_guns)-1))
+
+if not price_damage_ok:
+    print("Gun damage does not scale with price", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
## Summary
- widen default gun price gaps and align damage to match cost
- document new gun shop values in configuration guide
- add test ensuring gun damage increases with price

## Testing
- `python3 tests/test_gun_balance.py`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689bb08403bc8326b8f200cce3805a45