### PR TITLE
docs: remove reload references

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -620,7 +620,7 @@ any drugs, and clients will display this information if available.</dd>
 <dd>Plays the sound file <i>"hit.wav"</i> when you fire a gun and hit your
 target. The sound must be installed on your system, and you must be using
 a functioning sound system, in order to hear anything. Other sounds that
-can be configured in the same way are: <b>FightMiss</b>, <b>FightReload</b>,
+can be configured in the same way are: <b>FightMiss</b>,
 <b>Jet</b>, <b>JoinGame</b>, and
 <b>LeaveGame</b>.</dd>
 

--- a/doc/protocol.html
+++ b/doc/protocol.html
@@ -356,9 +356,6 @@ attacker is<br />
 <dt>'<tt>M</tt>' (<b>F_MISS</b>)</dt>
 <dd>The "attacking" player fired on the defender, and missed</dd>
 
-<dt>'<tt>R</tt>' (<b>F_RELOAD</b>)</dt>
-<dd>The "attacking" player is ready to fire again</dd>
-
 <dt>'<tt>L</tt>' (<b>F_LEAVE</b>)</dt>
 <dd>The "attacking" player has fled the fight, but other opponents remain</dd>
 


### PR DESCRIPTION
## Summary
- drop F_RELOAD from fight protocol docs
- remove FightReload from configurable sound list
- verify no other reload mentions remain in docs

## Testing
- `pytest -q` *(fails: SystemExit 0 in test_gun_balance)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689bb30b86808326adee5136c2254aae