### PR TITLE
Remove unused FightReload sound

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -165,7 +165,7 @@ struct NAMES Names = {
 };
 struct SOUNDS Sounds = {
   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-  NULL, NULL, NULL, NULL, NULL, NULL, NULL
+  NULL, NULL, NULL, NULL, NULL
 };
 
 /* N.B. The slightly over-enthusiastic comments here are for the benefit
@@ -385,9 +385,6 @@ struct GLOBALS Globals[] = {
    NULL, NULL, FALSE, 0, 0},
   {NULL, NULL, NULL, &Sounds.FightMiss, NULL, "Sounds.FightMiss",
    N_("Sound file played for a gun \"miss\""), NULL, NULL, 0, "",
-   NULL, NULL, FALSE, 0, 0},
-  {NULL, NULL, NULL, &Sounds.FightReload, NULL, "Sounds.FightReload",
-   N_("Sound file played when guns are reloaded"), NULL, NULL, 0, "",
    NULL, NULL, FALSE, 0, 0},
   {NULL, NULL, NULL, &Sounds.EnemyBitchKilled, NULL, "Sounds.EnemyBitchKilled",
    N_("Sound file played when an enemy bitch/deputy is killed"),

--- a/src/dopewars.h
+++ b/src/dopewars.h
@@ -90,7 +90,7 @@ struct NAMES {
 };
 
 struct SOUNDS {
-  gchar *FightHit, *FightMiss, *FightReload, *Jet, *CoinBuy;
+  gchar *FightHit, *FightMiss, *Jet, *CoinBuy;
   gchar *JoinGame, *LeaveGame, *StartGame, *EndGame;
   gchar *EnemyBitchKilled, *BitchKilled, *EnemyKilled, *Killed;
   gchar *EnemyFailFlee, *FailFlee, *EnemyFlee, *Flee;

--- a/src/message.c
+++ b/src/message.c
@@ -1110,11 +1110,6 @@ gboolean HandleGenericClientMessage(Player *From, AICode AI, MsgCode Code,
   return TRUE;
 }
 
-void SendFightReload(Player *To)
-{
-  SendFightMessage(To, NULL, 0, F_RELOAD, (price_t)0, FALSE, NULL);
-}
-
 void SendOldCanFireMessage(Player *To, GString *text)
 {
   if (To->EventNum == E_FIGHT) {
@@ -1203,9 +1198,6 @@ void ReceiveFightMessage(gchar *Data, gchar **AttackName,
     break;
   case F_MISS:
     SoundPlay(Sounds.FightMiss);
-    break;
-  case F_RELOAD:
-    SoundPlay(Sounds.FightReload);
     break;
   case F_FAILFLEE:
     SoundPlay(*AttackName[0] ? Sounds.EnemyFailFlee : Sounds.FailFlee);

--- a/src/message.h
+++ b/src/message.h
@@ -136,7 +136,6 @@ void ReceiveAbilities(Player *Play, gchar *Data);
 void CombineAbilities(Player *Play);
 void SetAbility(Player *Play, gint Type, gboolean Set);
 gboolean HaveAbility(Player *Play, gint Type);
-void SendFightReload(Player *To);
 void SendOldCanFireMessage(Player *To, GString *text);
 void SendOldFightPrint(Player *To, GString *text, gboolean FightOver);
 void SendFightLeave(Player *Play, gboolean FightOver);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3613,7 +3613,7 @@ GSList *HandleTimeouts(GSList *First)
       if (IsCop(Play))
         Fire(Play);
       else
-        SendFightReload(Play);
+        SendFightMessage(Play, NULL, 0, F_RELOAD, (price_t)0, FALSE, NULL);
     }
     list = nextlist;
   }


### PR DESCRIPTION
## Summary
- drop `FightReload` from sound settings and config
- remove reload sound hooks and send reload messages directly

## Testing
- `python3 tests/test_gun_balance.py`
- `./autogen.sh` *(fails: You must have automake installed)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689bb2e523f88326b29f4046e02bbb8f