### PR TITLE
Replace derogatory term in documentation

### DIFF
--- a/doc/clientplay.html
+++ b/doc/clientplay.html
@@ -154,8 +154,8 @@ any guns, you must answer Y (yes) or N (no) to the question "Do you run?"
 If you are lucky, you'll get away - otherwise, the cops may shoot you. The
 more deputies are accompanying Hardass, the worse the damage is likely to be.
 If you take enough damage for your health to drop to zero, you will lose a
-bitch (and, possibly, some drugs and a gun, if the bitch was carrying them).
-If you have no bitches, you will die, and the game will end! The more
+cleric (and, possibly, some drugs and a gun, if the cleric was carrying them).
+If you have no clerics, you will die, and the game will end! The more
 successful your drug dealing is (i.e. the more money you have made) the
 more aggressive the cops will be.</p>
 
@@ -173,7 +173,7 @@ again later on, they will be lead by his replacement, Officer Bob, who is
 tougher. If you then kill him too, you'll meet tougher opposition in future -
 so it's often wise to run from the cops!</p>
 
-<p>If you lose bitches, or simply want to acquire more, you can visit the pub
+<p>If you lose clerics, or simply want to acquire more, you can visit the pub
 in the Ghetto to hire them, or they may offer their services to you at
 bargain rates randomly.</p>
 
@@ -215,12 +215,12 @@ return to the fight, and conclude it before continuing on your way.</p>
 "S" key, you can shoot back with the "F" key, or you can run from the fight
 with the "R" key. Be aware that if you fail to shoot back at your enemy
 within five seconds, they can fire at you again (otherwise, shots alternate
-between you and your enemy). If you kill an enemy bitch, you
+between you and your enemy). If you kill an enemy cleric, you
 are awarded a bounty from the cops for killing such a dangerous criminal; if
-you kill an enemy player (after you've killed all of their bitches) you
+you kill an enemy player (after you've killed all of their clerics) you
 receive their total assets - their cash and bank balance minus any debt. In
 either case you can loot the body and pick up any guns or drugs which the
-bitch or player was carrying.</p>
+cleric or player was carrying.</p>
 
 <hr />
 <ul>

--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -276,7 +276,7 @@ Bronx).</dd>
 Ghetto).</dd>
 
 <dt><b>RoughPub=<i>2</i></b></dt>
-<dd>Players can visit the rough pub to hire bitches in location number
+<dd>Players can visit the rough pub to hire clerics in location number
 <i>2</i>.</dd>
 
 <dt><b>LoanSharkName=<i>"the Loan Shark"</i></b></dt>
@@ -378,10 +378,10 @@ defines the amount of health that you lose when you are successfully hit.
 If 100, you lose the same number of health points as the gun's damage.
 If more than 100, you lose fewer health points, and if less than 100, you lose
 <b>more</b> health points than the gun's damage. This rating applies only
-when you have no bitches.</dd>
+when you have no clerics.</dd>
 
-<dt><b>BitchArmor=<i>50</i></b> or <b>BitchArmour=<i>50</i></b></dt>
-<dd>Sets the percentage armor rating of each bitch to <i>50</i>.</dd>
+<dt><b>ClericArmor=<i>50</i></b> or <b>ClericArmour=<i>50</i></b></dt>
+<dd>Sets the percentage armor rating of each cleric to <i>50</i>.</dd>
 
 <dt><b>NumCop=<i>3</i></b></dt>
 <dd>Configures the game to have <i>3</i> cops. If you kill the first one, you
@@ -521,13 +521,13 @@ takes at least 5 seconds.</dd>
 <dd>Each player will start the game with a debt to the loan shark of
 <i>$5,000</i>.</dd>
 
-<dt><b>Names.Bitch=<i>"bitch"</i></b></dt>
-<dd>Sets the word used to describe a single "bitch" in the game. Bitch, gun
+<dt><b>Names.Cleric=<i>"cleric"</i></b></dt>
+<dd>Sets the word used to describe a single "cleric" in the game. Cleric, gun
 and drug names are automatically capitalised where necessary by the Church Wars
 code.</dd>
 
-<dt><b>Names.Bitches=<i>"bitches"</i></b></dt>
-<dd>Sets the word used to describe two or more "bitches".</dd>
+<dt><b>Names.Clerics=<i>"clerics"</i></b></dt>
+<dd>Sets the word used to describe two or more "clerics".</dd>
 
 <dt><b>Names.Gun=<i>"gun"</i></b></dt>
 <dd>Sets the word used to describe a single "gun" (for example, it could be
@@ -560,21 +560,21 @@ current game turn.</dd>
 <dd>Sets the year in which the game starts to <i>1984</i>.</dd>
 
 <dt><b>Prices.Spy=<i>20000</i></b></dt>
-<dd>Sets the price to pay a bitch to spy on another player to be
+<dd>Sets the price to pay a cleric to spy on another player to be
 <i>$20,000</i>.</dd>
 
 <dt><b>Prices.Tipoff=<i>20000</i></b></dt>
-<dd>Sets the price to pay a bitch to tip off the cops to another player to be
+<dd>Sets the price to pay a cleric to tip off the cops to another player to be
 <i>$20,000</i>.</dd>
 
-<dt><b>Bitch.MinPrice=<i>20000</i></b></dt>
-<dd>Sets the minimum price for a bitch at the Rough Pub to be <i>$20,000</i>.
-Note that prices for bitches "on the street" (i.e. those that are offered
-by random events) are produced by dividing the normal bitch price
+<dt><b>Cleric.MinPrice=<i>20000</i></b></dt>
+<dd>Sets the minimum price for a cleric at the Rough Pub to be <i>$20,000</i>.
+Note that prices for clerics "on the street" (i.e. those that are offered
+by random events) are produced by dividing the normal cleric price
 distribution by 3, i.e. about one-third of the shop price range (~$6,700–$13,300 by default).</dd>
 
-<dt><b>Bitch.MaxPrice=<i>40000</i></b></dt>
-<dd>Sets the maximum price for a bitch to <i>$40,000</i>.</dd>
+<dt><b>Cleric.MaxPrice=<i>40000</i></b></dt>
+<dd>Sets the maximum price for a cleric to <i>$40,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/doc/example-igneous
+++ b/doc/example-igneous
@@ -602,5 +602,5 @@ Gun[14].Damage = 50
 Gun[15].Damage = 50
 Gun[16].Damage = 100
 Gun[17].Damage = 4000
-Names.Bitch = "Biznatch"
-Names.Bitches = "Biznatches"
+Names.Cleric = "Biznatch"
+Names.Clerics = "Biznatches"

--- a/doc/help/general.html
+++ b/doc/help/general.html
@@ -44,11 +44,11 @@ to denote all prices in the game.<p /></li>
 always printed <b>before</b> prices (e.g. $100). If unchecked, it follows
 the prices (e.g. 100 EUR).<p /></li>
 
-<li><b>Name of one bitch</b>: The word used to refer to a single one of your
-companions. For example, you may prefer "henchman" to "bitch".<p /></li>
+<li><b>Name of one cleric</b>: The word used to refer to a single one of your
+companions. For example, you may prefer "henchman" to "cleric".<p /></li>
 
-<li><b>Name of several bitches</b>: The word used to refer to several of your
-companions. For example, you may prefer "henchmen" to "bitches".<p /></li>
+<li><b>Name of several clerics</b>: The word used to refer to several of your
+companions. For example, you may prefer "henchmen" to "clerics".<p /></li>
 
 <li><b>Web browser</b>: (Unix only) The full pathname of the program that you
 use for displaying webpages. For example, <tt>/usr/bin/mozilla</tt>.<p /></li>

--- a/doc/i18n.html
+++ b/doc/i18n.html
@@ -116,7 +116,7 @@ left unchanged.<p /></li>
 is exactly equivalent to the standard C "<tt>%s</tt>" notation for a string,
 and does essentially the same thing, except that the two-letter code which
 follows the <tt>%t</tt> is used to select an "alternative form" of the word
-- for example, your language may have different words for "bitch" depending
+- for example, your language may have different words for "cleric" depending
 on whether the word is the subject or the object of the sentence. You are
 free to translate <tt>%txx</tt> to use the most appropriate form of the word.
 If you wish to capitalise the first letter of the word (as used in English for
@@ -127,13 +127,13 @@ specify them yourself. Essentially, when setting a string in a Church Wars
 configuration file (or the defaults, which are set in churchwars.c) alternative
 forms can be added by alternating two-letter codes and alternative forms after
 the original word, separating them by _ (underline) symbols. For example,<br />
-<tt>Names.Bitch = "bitch_no_bitcho_ac_bitche"</tt><br />
-specifies two alternative forms for "bitch", identified by the "<tt>no</tt>"
-and "<tt>ac</tt>" codes. You can then use "bitcho" anywhere that "bitch" is
+<tt>Names.Cleric = "cleric_no_clerico_ac_clerice"</tt><br />
+specifies two alternative forms for "cleric", identified by the "<tt>no</tt>"
+and "<tt>ac</tt>" codes. You can then use "clerico" anywhere that "cleric" is
 normally used by translating the relevant string as "<tt>%tno</tt>" (and to
-get "bitche" use "<tt>%tac</tt>"). If you specify a two letter code
+get "clerice" use "<tt>%tac</tt>"). If you specify a two letter code
 in the translation that you haven't given an alternative form for, the
-default word ("bitch") will be used. In the original English, "<tt>%tde</tt>"
+default word ("cleric") will be used. In the original English, "<tt>%tde</tt>"
 is used for this purpose, but there is nothing special about the "<tt>de</tt>"
 code - you can use it yourself if you like, and you can use as many
 different two-letter codes as you want to.</p>

--- a/doc/protocol.html
+++ b/doc/protocol.html
@@ -175,7 +175,7 @@ e.g. "^AI"<br />
 <dt><b>C_UPDATE</b> ('<tt>J</tt>')</dt>
 <dd>Used by the server to update client state. This is also used to tell the
 player about the state of another player (a report from a spy)<br />
-<tt>data</tt> = <tt>&lt;cash&gt;^&lt;debt&gt;^&lt;bank&gt;^&lt;health&gt;^&lt;coatsize&gt;^&lt;locn&gt;^&lt;turn&gt;^&lt;flags&gt;^&lt;GUNS&gt;^&lt;DRUGS&gt;^&lt;DRUGVALUE&gt;^&lt;bitches&gt;</tt><br />
+<tt>data</tt> = <tt>&lt;cash&gt;^&lt;debt&gt;^&lt;bank&gt;^&lt;health&gt;^&lt;coatsize&gt;^&lt;locn&gt;^&lt;turn&gt;^&lt;flags&gt;^&lt;GUNS&gt;^&lt;DRUGS&gt;^&lt;DRUGVALUE&gt;^&lt;clerics&gt;</tt><br />
 <tt>cash</tt>, <tt>debt</tt>, <tt>bank</tt> = money available, owed to the
 loan shark, in the bank<br />
 <tt>coatsize</tt> = amount of space available for drugs/guns<br />
@@ -190,7 +190,7 @@ is set if the player is currently spying on one or more other players<br />
 <tt>DRUGVALUE</tt> = similar, but contains the total cash value of each drug;
 N.B. this field is only sent if the ability
 <a href="#drugvalue">A_DRUGVALUE</a> is present<br />
-<tt>bitches</tt> = number of accompanying bitches<br />
+<tt>clerics</tt> = number of accompanying clerics<br />
 <tt>ID</tt> = blank for a status update, otherwise the ID of the player that
 you're spying on<br />
 <b>Answer required:</b> no<p /></dd>
@@ -277,12 +277,12 @@ e.g. "1^AbFred"<br />
 
 <dt><b>C_INIT</b> ('<tt>k</tt>')</dt>
 <dd>Tells the client about various global game settings<br />
-<tt>data</tt> = <tt>"version"^&lt;numloc&gt;^&lt;numgun&gt;^&lt;numdrug&gt;^"bitch"^"bitches"^"gun"^"guns"^"drug"^"drugs"^"date"^&lt;ID&gt;^"loanshark"^"bank"^"gunshop"^"pub"^(prefix)"currency"</tt><br />
+<tt>data</tt> = <tt>"version"^&lt;numloc&gt;^&lt;numgun&gt;^&lt;numdrug&gt;^"cleric"^"clerics"^"gun"^"guns"^"drug"^"drugs"^"date"^&lt;ID&gt;^"loanshark"^"bank"^"gunshop"^"pub"^(prefix)"currency"</tt><br />
 <tt>version</tt> = Church Wars version of the server - e.g. "1.5.2"<br />
 <tt>numloc</tt> = the number of locations in the game<br />
 <tt>numgun</tt> = the number of guns in the game<br />
 <tt>numdrug</tt> = the number of drugs in the game<br />
-<tt>bitch</tt>, <tt>bitches</tt>, <tt>gun</tt>, <tt>guns</tt>, <tt>drug</tt>,
+<tt>cleric</tt>, <tt>clerics</tt>, <tt>gun</tt>, <tt>guns</tt>, <tt>drug</tt>,
 <tt>drugs</tt>, <tt>date</tt>, <tt>loanshark</tt>,
 <tt>bank</tt>, <tt>gunshop</tt>, <tt>pub</tt> = various names used in the
 game<br />
@@ -290,7 +290,7 @@ game<br />
 <tt>prefix</tt> = '1' if the currency symbol (e.g. $) should be printed before
 prices in the game, '0' otherwise<br />
 <tt>currency</tt> = the currency symbol to use<br />
-e.g. "^Ak1.5.2^8^4^12^bitch^bitches^gun^guns^drug^drugs^12-^-1984^0^the Loan Shark^the Bank^Dan's House of Guns^the pub"^1$<br />
+e.g. "^Ak1.5.2^8^4^12^cleric^clerics^gun^guns^drug^drugs^12-^-1984^0^the Loan Shark^the Bank^Dan's House of Guns^the pub"^1$<br />
 <b>Answer required:</b> no<p /></dd>
 
 <dt><b>C_DATA</b> ('<tt>l</tt>')</dt>
@@ -330,16 +330,16 @@ e.g. "^Al0^D20000^10000"</dd>
 <b>Answer required:</b> no<p /></dd>
 
 <dt><b>C_FIGHTPRINT</b> ('<tt>m</tt>')</dt>
-<dd><tt>data</tt> = <tt>"attack"^"defend"^&lt;health&gt;^&lt;bitches&gt;^"bitchname"^&lt;killed&gt;^&lt;armpct&gt;^(fightpoint)(runhere)(loot)(canfire)^"text"</tt><br />
+<dd><tt>data</tt> = <tt>"attack"^"defend"^&lt;health&gt;^&lt;clerics&gt;^"clericname"^&lt;killed&gt;^&lt;armpct&gt;^(fightpoint)(runhere)(loot)(canfire)^"text"</tt><br />
 <tt>attack</tt> = name of the attacker player/cop if applicable (if blank,
 it's you)<br />
 <tt>defend</tt> = name of the defending player/cop if applicable (if blank,
 it's you)<br />
 <tt>health</tt> = defender's health, if applicable<br />
-<tt>bitches</tt> = number of bitches/deputies accompanying the defending
+<tt>clerics</tt> = number of clerics/deputies accompanying the defending
 player<br />
-<tt>bitchname</tt> = usually "bitch", "bitches", "deputy" or "deputies"<br />
-<tt>killed</tt> = number of bitches killed in this attack<br />
+<tt>clericname</tt> = usually "cleric", "clerics", "deputy" or "deputies"<br />
+<tt>killed</tt> = number of clerics killed in this attack<br />
 <tt>armpct</tt> = a number between 0 and 100 showing how heavily armed the
 attacker is<br />
 <tt>fightpoint</tt> =<br />
@@ -451,11 +451,11 @@ from the server to the client.</p>
 <dt><b>C_BUYOBJECT</b> ('<tt>T</tt>')</dt>
 <dd>Requests the server to buy or sell an object<br />
 <tt>data</tt> = <tt>"type"^&lt;index&gt;^&lt;amount&gt;</tt><br />
-<tt>type</tt> = "bitch", "gun" or "drug"<br />
+<tt>type</tt> = "cleric", "gun" or "drug"<br />
 <tt>index</tt> = the zero-based index of the gun/drug that you want to
-buy/sell, or zero if type="bitch"<br />
+buy/sell, or zero if type="cleric"<br />
 <tt>amount</tt> = the number of objects to buy (or, if negative, to sell)<br />
-e.g. "^ATbitch^0^1"<p /></dd>
+e.g. "^ATcleric^0^1"<p /></dd>
 
 <dt><b>C_DONE</b> ('<tt>U</tt>')</dt>
 <dd>Sent by the client when it's finished with the loan shark, bank, or gun
@@ -489,8 +489,8 @@ e.g. "^AY10000"<p /></dd>
 N.B. this is always sent at the start of the game, in which case the old
 format should be used, e.g. "^^AcFred"<p /></dd>
 
-<dt><b>C_SACKBITCH</b> ('<tt>d</tt>')</dt>
-<dd>Requests that a bitch should be sacked<br />
+<dt><b>C_SACKCLERIC</b> ('<tt>d</tt>')</dt>
+<dd>Requests that a cleric should be sacked<br />
 e.g. "^Ad"<p /></dd>
 
 <dt><b>C_TIPOFF</b> ('<tt>e</tt>')</dt>


### PR DESCRIPTION
## Summary
- Replace remaining references to "bitch/bitches" with "cleric/clerics" across documentation
- Update configuration, protocol, help, example, and gameplay docs to use cleric terminology

## Testing
- `pytest tests/test_gun_balance.py -q` *(fails: SystemExit 0)*

------
https://chatgpt.com/codex/tasks/task_e_689bb38b7a0c8326bf81dda47e0f5d1b