### PR TITLE
Replace 'bitch' with 'cleric' in translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -265,12 +265,12 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Sound-Datei für das Nachladen einer Waffe"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
-msgstr "Sound-Datei für das Ableben einer/s feindlichen Hure/Hilfssheriffs"
+msgid "Sound file played when an enemy cleric/deputy is killed"
+msgstr "Sound-Datei für das Ableben eines feindlichen Klerikers oder Hilfssheriffs"
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
-msgstr "Sound-Datei für das Ableben einer eigenen Hure"
+msgid "Sound file played when one of your clerics is killed"
+msgstr "Sound-Datei für das Ableben eines eigenen Klerikers"
 
 #: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
@@ -369,8 +369,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% Trefferresistenz jedes Spielers"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% Trefferresistenz jeder Huren"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% Trefferresistenz jedes Klerikers"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -477,12 +477,12 @@ msgid "Damage done by each weapon"
 msgstr "Schaden jeder Waffe"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Wie soll eine einzelne Hure bezeichnet werden?"
+msgid "Word used to denote a single \"cleric\""
+msgstr "Wie soll ein einzelner Kleriker bezeichnet werden?"
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Wie sollen zwei oder mehrere Huren bezeichnet werden?"
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Wie sollen zwei oder mehrere Kleriker bezeichnet werden?"
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -505,20 +505,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() Format-String für das Anzeigen der Spielrunden"
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Kosten, damit ein Kleriker den Feind ausspioniert"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Kosten, damit ein Kleriker die Polizei über einen Feind informiert"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Minimaler Geldbetrag für das Anheuern einer Hure"
+msgid "Minimum price to hire a cleric"
+msgstr "Minimaler Geldbetrag für das Anheuern eines Klerikers"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Minimaler Geldbetrag fuer das Anheuern einer Hure"
+msgid "Maximum price to hire a cleric"
+msgstr "Maximaler Geldbetrag fuer das Anheuern eines Klerikers"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -1950,7 +1950,7 @@ msgstr "_Rennen"
 
 #: src/gui_client/gtk_client.c:971
 msgid "%/Combat: Bitches/%d %tde"
-msgstr "%/Kampf: Huren/%d %tde"
+msgstr "%/Kampf: Kleriker/%d %tde"
 
 #: src/gui_client/gtk_client.c:976
 msgid "(Left)"
@@ -1971,7 +1971,7 @@ msgstr "Du"
 
 #: src/gui_client/gtk_client.c:1189
 msgid "%/GTK Stats: Bitches/%Tde"
-msgstr "%/GTK Stats: Huren/%Tde"
+msgstr "%/GTK Stats: Kleriker/%Tde"
 
 #: src/gui_client/gtk_client.c:1301
 msgid "%/Inventory drug name/%tde"
@@ -2367,7 +2367,7 @@ msgstr "Name des Kredithais"
 
 #: src/gui_client/optdialog.c:834
 msgid "Name of several Janissaries"
-msgstr "Name für mehrere Huren"
+msgstr "Name für mehrere Janitscharen"
 
 #: src/gui_client/optdialog.c:835
 msgid "Minimum no. of Janissaries"
@@ -2418,12 +2418,12 @@ msgid "Symbol prefixes prices"
 msgstr "Währungssymbol dem Preis voranstellen"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
-msgstr "Name für eine Hure"
+msgid "Name of one cleric"
+msgstr "Name für einen Kleriker"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
-msgstr "Name für mehrere Huren"
+msgid "Name of several clerics"
+msgstr "Name für mehrere Kleriker"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -3687,11 +3687,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "SOCKS Authentifizierung benötigt"
 
-#~ msgid "bitch"
-#~ msgstr "Hure"
-
-#~ msgid "bitches"
-#~ msgstr "Huren"
 
 #~ msgid "gun"
 #~ msgstr "Waffe"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -260,11 +260,11 @@ msgid "Sound file played when guns are reloaded"
 msgstr ""
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
+msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
 #: src/dopewars.c:403
@@ -364,7 +364,7 @@ msgid "% resistance to gunshots of each player"
 msgstr ""
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
+msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
 #: src/dopewars.c:488
@@ -469,11 +469,11 @@ msgid "Damage done by each weapon"
 msgstr ""
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
+msgid "Word used to denote a single \"cleric\""
 msgstr ""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
+msgid "Word used to denote two or more \"clerics\""
 msgstr ""
 
 #: src/dopewars.c:604
@@ -497,19 +497,19 @@ msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
+msgid "Cost for a cleric to spy on the enemy"
 msgstr ""
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
+msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr ""
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
+msgid "Minimum price to hire a cleric"
 msgstr ""
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
+msgid "Maximum price to hire a cleric"
 msgstr ""
 
 #: src/dopewars.c:631
@@ -2390,11 +2390,11 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
+msgid "Name of one cleric"
 msgstr ""
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
+msgid "Name of several clerics"
 msgstr ""
 
 #: src/gui_client/optdialog.c:903

--- a/po/es.po
+++ b/po/es.po
@@ -270,13 +270,13 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
-"Fichero de sonido que suena cuando se mata a un ayudante o a una puta enemiga"
+"Fichero de sonido que suena cuando se mata a un ayudante o a un clérigo enemigo"
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
-msgstr "Fichero de sonido reproducido cuando muere una de sus putas"
+msgid "Sound file played when one of your clerics is killed"
+msgstr "Fichero de sonido reproducido cuando muere uno de sus clérigos"
 
 #: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
@@ -380,8 +380,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% de resistencia a disparos de cada puta"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% de resistencia a disparos de cada clérigo"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -486,12 +486,12 @@ msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Palabra usada para designar una sola \"puta\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Palabra usada para designar un solo \"clérigo\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Palabra usada para designar dos o más \"putas\""
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Palabra usada para designar dos o más \"clérigos\""
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -514,20 +514,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar la ronda del juego"
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Coste para que un clérigo espíe al enemigo"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Coste para que un clérigo delate a la policía a un enemigo"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Precio mínimo de contratar una puta"
+msgid "Minimum price to hire a cleric"
+msgstr "Precio mínimo de contratar un clérigo"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Precio máximo de contratar una puta"
+msgid "Maximum price to hire a cleric"
+msgstr "Precio máximo de contratar un clérigo"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2413,7 +2413,7 @@ msgstr "Nombre del usurero"
 
 #: src/gui_client/optdialog.c:834
 msgid "Name of several Janissaries"
-msgstr "Nombre de varias putas"
+msgstr "Nombre de varios jenízaros"
 
 #: src/gui_client/optdialog.c:835
 msgid "Minimum no. of Janissaries"
@@ -2464,12 +2464,12 @@ msgid "Symbol prefixes prices"
 msgstr "Símbolo antes del precio"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
-msgstr "Nombre de una puta"
+msgid "Name of one cleric"
+msgstr "Nombre de un clérigo"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
-msgstr "Nombre de varias putas"
+msgid "Name of several clerics"
+msgstr "Nombre de varios clérigos"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -3773,11 +3773,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Se precisa autenticación SOCKS"
 
-#~ msgid "bitch"
-#~ msgstr "puta"
-
-#~ msgid "bitches"
-#~ msgstr "putas"
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -4074,7 +4069,7 @@ msgstr ""
 #~ "que le esté guardando."
 
 #~ msgid "%/Sack Bitch dialog title/Sack %Tde"
-#~ msgstr "%/Título del diálogo Echar a una puta/Echar a una %Tde"
+#~ msgstr "%/Título del diálogo Echar a un clérigo/Echar a un %Tde"
 
 #, c-format
 #~ msgid ""
@@ -4082,7 +4077,7 @@ msgstr ""
 #~ "by this %tde may be lost!)"
 #~ msgstr ""
 #~ "¿Está seguro? (Perderá todas las %tde y %tde\n"
-#~ "que le esté guardando esta %tde!)"
+#~ "que le esté guardando este %tde!)"
 
 #~ msgid "Name of one deputy"
 #~ msgstr "Nombre de un ayudante"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -269,14 +269,13 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
-"Fichero de sonido a reproducir cuando se mata a un ayudante o a una puta "
-"enemiga"
+"Fichero de sonido a reproducir cuando se mata a un ayudante o a un clérigo enemigo"
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
-msgstr "Fichero de sonido reproducido cuando muere una de tus putas"
+msgid "Sound file played when one of your clerics is killed"
+msgstr "Fichero de sonido reproducido cuando muere uno de tus clérigos"
 
 #: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
@@ -379,8 +378,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% de resistencia a disparos de cada puta"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% de resistencia a disparos de cada clérigo"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -484,12 +483,12 @@ msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Palabra usada para designar una sola \"puta\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Palabra usada para designar un solo \"clérigo\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Palabra usada para designar dos o más \"putas\""
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Palabra usada para designar dos o más \"clérigos\""
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -512,20 +511,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar el turno del juego"
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Coste para que un clérigo espíe al enemigo"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Coste para que un clérigo delate a la policía a un enemigo"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Precio mínimo de contratar una puta"
+msgid "Minimum price to hire a cleric"
+msgstr "Precio mínimo de contratar un clérigo"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Precio máximo de contratar una puta"
+msgid "Maximum price to hire a cleric"
+msgstr "Precio máximo de contratar un clérigo"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2410,7 +2409,7 @@ msgstr "Nombre del usurero"
 
 #: src/gui_client/optdialog.c:834
 msgid "Name of several Janissaries"
-msgstr "Nombre de varias putas"
+msgstr "Nombre de varios jenízaros"
 
 #: src/gui_client/optdialog.c:835
 msgid "Minimum no. of Janissaries"
@@ -2461,12 +2460,12 @@ msgid "Symbol prefixes prices"
 msgstr "Símbolo antes del precio"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
-msgstr "Nombre de una puta"
+msgid "Name of one cleric"
+msgstr "Nombre de un clérigo"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
-msgstr "Nombre de varias putas"
+msgid "Name of several clerics"
+msgstr "Nombre de varios clérigos"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -3769,11 +3768,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Se precisa autenticación SOCKS"
 
-#~ msgid "bitch"
-#~ msgstr "puta"
-
-#~ msgid "bitches"
-#~ msgstr "putas"
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -4072,7 +4066,7 @@ msgstr ""
 #~ "que te esté guardando."
 
 #~ msgid "%/Sack Bitch dialog title/Sack %Tde"
-#~ msgstr "%/Título del diálogo Echar a una puta/Echar a una %Tde"
+#~ msgstr "%/Título del diálogo Echar a un clérigo/Echar a un %Tde"
 
 #, c-format
 #~ msgid ""
@@ -4080,7 +4074,7 @@ msgstr ""
 #~ "by this %tde may be lost!)"
 #~ msgstr ""
 #~ "¿Estás seguro? (Perderás todas las %tde y %tde\n"
-#~ "que te esté guardando esta %tde!)"
+#~ "que te esté guardando este %tde!)"
 
 #~ msgid "Name of one deputy"
 #~ msgstr "Nombre de un ayudante"

--- a/po/fr.po
+++ b/po/fr.po
@@ -261,11 +261,11 @@ msgid "Sound file played when guns are reloaded"
 msgstr ""
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
+msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
 #: src/dopewars.c:403
@@ -365,8 +365,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% de resistance aux coups de fusil de chaque joueur"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% de resistance aux coups de fusil de chaque chienne"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% de resistance aux coups de fusil de chaque clerc"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -470,12 +470,12 @@ msgid "Damage done by each weapon"
 msgstr "Dommage inflige par chaque flingue"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Mot utilise pour decrire 1 \"chienne\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Mot utilise pour decrire 1 \"clerc\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Mot utilise pour decrire 2 \"chiennes\" ou plus"
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Mot utilise pour decrire 2 \"clercs\" ou plus"
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -498,20 +498,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Coût pour qu'un clerc espionne l'ennemi"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Coût pour qu'un clerc dénonce un ennemi aux flics"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Prix minimum pour employer une salope"
+msgid "Minimum price to hire a cleric"
+msgstr "Prix minimum pour engager un clerc"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Prix MAX pour employer une chienne"
+msgid "Maximum price to hire a cleric"
+msgstr "Prix MAX pour engager un clerc"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2402,11 +2402,11 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
+msgid "Name of one cleric"
 msgstr ""
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
+msgid "Name of several clerics"
 msgstr ""
 
 #: src/gui_client/optdialog.c:903
@@ -3649,11 +3649,6 @@ msgstr ""
 #~ msgid "Metaserver"
 #~ msgstr "Metaserver"
 
-#~ msgid "bitch"
-#~ msgstr "chienne"
-
-#~ msgid "bitches"
-#~ msgstr "chiennes"
 
 #~ msgid "gun"
 #~ msgstr "flingue"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -259,12 +259,12 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Son d'un gun qui est rechargé"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
-msgstr "Son accompagnant la mort d'une pute ou d'un adjoint ennemi"
+msgid "Sound file played when an enemy cleric/deputy is killed"
+msgstr "Son accompagnant la mort d'un clerc ou d'un adjoint ennemi"
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
-msgstr "Son accompagnant la more d'une de vos putes"
+msgid "Sound file played when one of your clerics is killed"
+msgstr "Son accompagnant la mort d'un de vos clercs"
 
 #: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
@@ -364,8 +364,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% de résistance aux coups de gun de chaque joueur"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% de résistance aux coups de gun de chaque pute"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% de résistance aux coups de gun de chaque clerc"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -474,12 +474,12 @@ msgid "Damage done by each weapon"
 msgstr "Dommage infligé par chaque gun"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Mot utilisé pour décrire une \"pute\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Mot utilisé pour décrire un \"clerc\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Mot utilisé pour décrire deux \"putes\" ou plus"
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Mot utilisé pour décrire deux \"clercs\" ou plus"
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -502,20 +502,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr "Chaîne de formattage strftime() pour l'affichage du tour"
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Coût pour qu'un clerc espionne l'ennemi"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Coût pour qu'un clerc dénonce un ennemi aux flics"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Prix minimum pour employer une pute"
+msgid "Minimum price to hire a cleric"
+msgstr "Prix minimum pour employer un clerc"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Prix maximum pour employer une pute"
+msgid "Maximum price to hire a cleric"
+msgstr "Prix maximum pour employer un clerc"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2391,7 +2391,7 @@ msgstr "Nom du prêteur à gages"
 
 #: src/gui_client/optdialog.c:834
 msgid "Name of several Janissaries"
-msgstr "Nom de plusieurs putes"
+msgstr "Nom de plusieurs clercs"
 
 #: src/gui_client/optdialog.c:835
 msgid "Minimum no. of Janissaries"
@@ -2442,12 +2442,12 @@ msgid "Symbol prefixes prices"
 msgstr "Le symbole monétaire précède les prix"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
-msgstr "Nom d'une pute"
+msgid "Name of one cleric"
+msgstr "Nom d'un clerc"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
-msgstr "Nom de plusieurs putes"
+msgid "Name of several clerics"
+msgstr "Nom de plusieurs clercs"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -3736,11 +3736,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Authentification SOCKS nécessaire"
 
-#~ msgid "bitch"
-#~ msgstr "pute"
-
-#~ msgid "bitches"
-#~ msgstr "putes"
 
 #~ msgid "gun"
 #~ msgstr "gun"
@@ -4039,7 +4034,7 @@ msgstr ""
 #~ "donc tout ce qu'elle porte (%tde ou %tde) pourra être perdu!"
 
 #~ msgid "%/Sack Bitch dialog title/Sack %Tde"
-#~ msgstr "%/Renvoyer une pute dialog title/Renvoyer %Tde"
+#~ msgstr "%/Renvoyer un clerc dialog title/Renvoyer %Tde"
 
 #, c-format
 #~ msgid ""

--- a/po/nn.po
+++ b/po/nn.po
@@ -274,12 +274,12 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Lyd som blir spelt når våpna blir lada"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
-msgstr "Lyd som blir spelt når ei fientleg hore eller betjent blir drepen"
+msgid "Sound file played when an enemy cleric/deputy is killed"
+msgstr "Lyd som blir spelt når ein fiendtleg klerikar eller betjent blir drepen"
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
-msgstr "Lyd som blir spelt når ei av horene dine blir drepen"
+msgid "Sound file played when one of your clerics is killed"
+msgstr "Lyd som blir spelt når ein av klerikarane dine blir drepen"
 
 #: src/dopewars.c:403
 msgid "Sound file played when another player or cop is killed"
@@ -379,8 +379,8 @@ msgid "% resistance to gunshots of each player"
 msgstr "% motstand mot skot for kvar spelar"
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
-msgstr "% motstand mot skot for kvar hore"
+msgid "% resistance to gunshots of each cleric"
+msgstr "% motstand mot skot for kvar klerikar"
 
 #: src/dopewars.c:488
 msgid "Name of each cop"
@@ -484,12 +484,12 @@ msgid "Damage done by each weapon"
 msgstr "Skaden kvart våpen gjer"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Ord for ei einskild «hore»"
+msgid "Word used to denote a single \"cleric\""
+msgstr "Ord for ein einskild «klerikar»"
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Ord for to eller fleire «horer»"
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Ord for to eller fleire «klerikarar»"
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -512,20 +512,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() formatstreng for å visa tida i spelet"
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Kostnad for at ein klerikar spionerer på fienden"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Kostnad for at ein klerikar tystar til politiet på ein fiende"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Minstepris for å tilsetja ei hore"
+msgid "Minimum price to hire a cleric"
+msgstr "Minstepris for å tilsetja ein klerikar"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Høgaste pris for å tilsetja ei hore"
+msgid "Maximum price to hire a cleric"
+msgstr "Høgaste pris for å tilsetja ein klerikar"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2386,7 +2386,7 @@ msgstr "Namnet på lånehaien"
 
 #: src/gui_client/optdialog.c:834
 msgid "Name of several Janissaries"
-msgstr "Namn på fleire horer"
+msgstr "Namn på fleire janitsjarar"
 
 #: src/gui_client/optdialog.c:835
 msgid "Minimum no. of Janissaries"
@@ -2437,12 +2437,12 @@ msgid "Symbol prefixes prices"
 msgstr "Symbol står før prisen"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
-msgstr "Namn på ei hore"
+msgid "Name of one cleric"
+msgstr "Namn på ein klerikar"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
-msgstr "Namn på fleire horer"
+msgid "Name of several clerics"
+msgstr "Namn på fleire klerikarar"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -3727,11 +3727,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Må ha SOCKS-autentisering"
 
-#~ msgid "bitch"
-#~ msgstr "hore_ue_hore_be_hora"
-
-#~ msgid "bitches"
-#~ msgstr "horer_uf_horer_bf_horene"
 
 #~ msgid "gun"
 #~ msgstr "våpen_ue_våpen_be_våpenet"
@@ -4022,7 +4017,7 @@ msgstr ""
 #~ "ho har på seg kan gå tapt!"
 
 #~ msgid "%/Sack Bitch dialog title/Sack %Tde"
-#~ msgstr "%/Spark hore dialog-tittel/Spark %tde"
+#~ msgstr "%/Spark klerikar dialog-tittel/Spark %tde"
 
 #, c-format
 #~ msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -260,11 +260,11 @@ msgid "Sound file played when guns are reloaded"
 msgstr ""
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
+msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
 #: src/dopewars.c:403
@@ -364,7 +364,7 @@ msgid "% resistance to gunshots of each player"
 msgstr ""
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
+msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
 #: src/dopewars.c:488
@@ -469,12 +469,12 @@ msgid "Damage done by each weapon"
 msgstr "Obrażenia zadawane prze poszczególne bronie"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Słowo określające jedną \"dziwkę\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Słowo określające jednego \"kleryka\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Słowo określające dwie lub więcej \"dziwek\""
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Słowo określające dwóch lub więcej \"kleryków\""
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -497,20 +497,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Koszt szpiegowania wroga przez kleryka"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Koszt donosu kleryka na wroga do glin"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Minimalna cena wynajęcia dziwki"
+msgid "Minimum price to hire a cleric"
+msgstr "Minimalna cena wynajęcia kleryka"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Maksymalna wynajęcia dziwki"
+msgid "Maximum price to hire a cleric"
+msgstr "Maksymalna cena wynajęcia kleryka"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2391,11 +2391,11 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
+msgid "Name of one cleric"
 msgstr ""
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
+msgid "Name of several clerics"
 msgstr ""
 
 #: src/gui_client/optdialog.c:903
@@ -3629,11 +3629,6 @@ msgstr ""
 #~ msgid "Metaserver"
 #~ msgstr "Metaserwer"
 
-#~ msgid "bitch"
-#~ msgstr "dziwka"
-
-#~ msgid "bitches"
-#~ msgstr "dziwki"
 
 #~ msgid "gun"
 #~ msgstr "broń"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -261,11 +261,11 @@ msgid "Sound file played when guns are reloaded"
 msgstr "Arquivo de som tocado quando armas são recarregadas"
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
+msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
 #: src/dopewars.c:403
@@ -365,7 +365,7 @@ msgid "% resistance to gunshots of each player"
 msgstr ""
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
+msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
 #: src/dopewars.c:488
@@ -470,12 +470,12 @@ msgid "Damage done by each weapon"
 msgstr "Dano de cada arma"
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
-msgstr "Palavra usada para denominar uma simples \"puta\""
+msgid "Word used to denote a single \"cleric\""
+msgstr "Palavra usada para denominar um simples \"clérigo\""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
-msgstr "Palavra usada para denominar duas ou mais \"putas\""
+msgid "Word used to denote two or more \"clerics\""
+msgstr "Palavra usada para denominar dois ou mais \"clérigos\""
 
 #: src/dopewars.c:604
 msgid "Word used to denote a single gun or equivalent"
@@ -498,20 +498,20 @@ msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
-msgstr ""
+msgid "Cost for a cleric to spy on the enemy"
+msgstr "Custo para que um clérigo espione o inimigo"
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
-msgstr ""
+msgid "Cost for a cleric to tipoff the cops to an enemy"
+msgstr "Custo para que um clérigo denuncie um inimigo à polícia"
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
-msgstr "Preço mínimo para contratar uma puta"
+msgid "Minimum price to hire a cleric"
+msgstr "Preço mínimo para contratar um clérigo"
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
-msgstr "Preço máximo para contratar uma puta"
+msgid "Maximum price to hire a cleric"
+msgstr "Preço máximo para contratar um clérigo"
 
 #: src/dopewars.c:631
 msgid "List of things which you overhear on the subway"
@@ -2419,11 +2419,11 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one bitch"
+msgid "Name of one cleric"
 msgstr ""
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several bitches"
+msgid "Name of several clerics"
 msgstr ""
 
 #: src/gui_client/optdialog.c:903
@@ -3683,11 +3683,6 @@ msgstr ""
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Autenticação SOCKS Necessária"
 
-#~ msgid "bitch"
-#~ msgstr "puta"
-
-#~ msgid "bitches"
-#~ msgstr "putas"
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -3981,7 +3976,7 @@ msgstr ""
 #~ "todo %tde ou %tde que ela está carregando será perdido!"
 
 #~ msgid "%/Sack Bitch dialog title/Sack %Tde"
-#~ msgstr "%/Despedir puta dialog title/Despedir %Tde"
+#~ msgstr "%/Despedir clérigo dialog title/Despedir %Tde"
 
 #, c-format
 #~ msgid ""


### PR DESCRIPTION
## Summary
- Replace offensive term "bitch/bitches" with "cleric/clerics" across all PO files
- Update locale translations to match new terminology

## Testing
- `for p in po/*.po; do msgfmt "$p" -o /tmp/$(basename ${p%.po}).mo; done`

------
https://chatgpt.com/codex/tasks/task_e_689bb38df9a48326ada226e6790921df