### PR TITLE
Remove obsolete OurWebBrowser argument

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2394,7 +2394,7 @@ void display_intro(GtkWidget *widget, gpointer data)
   gtk_box_pack_start(GTK_BOX(vbox), grid, FALSE, FALSE, 0);
 
   PackCentredURL(vbox, _("Original Church Wars information here:"),
-                 "https://churchwars.sourceforge.io/", OurWebBrowser);
+                 "https://churchwars.sourceforge.io/");
 
   hsep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
   gtk_box_pack_start(GTK_BOX(vbox), hsep, FALSE, FALSE, 0);


### PR DESCRIPTION
## Summary
- fix PackCentredURL call in `display_intro` to match current three-parameter signature

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc tests/test_socks5.c src/network.c src/util.c -Isrc $(pkg-config --cflags --libs glib-2.0) -o tests/test_socks5` *(fails: Package glib-2.0 was not found)*
- `gcc tests/test_sound.c src/sound.c src/util.c -Isrc $(pkg-config --cflags --libs glib-2.0) -o tests/test_sound` *(fails: Package glib-2.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb810226883269eeb409c20d21e2c