### PR TITLE
Balance weapon costs and weight tiers

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -698,9 +698,9 @@ struct COP DefaultCop[] = {
 struct GUN DefaultGun[] = {
   /* The names of the default guns */
   {N_("Mace"), 3000, 4, 5},
-  {N_("Crossbow"), 6000, 4, 9},
-  {N_("Spear"), 2500, 4, 4},
-  {N_("Battle Axe"), 4500, 4, 7}
+  {N_("Crossbow"), 5400, 6, 9},
+  {N_("Spear"), 2400, 3, 4},
+  {N_("Battle Axe"), 4200, 5, 7}
 };
 
 struct DRUG DefaultDrug[] = {


### PR DESCRIPTION
## Summary
- Rebalance default weapon table with consistent price-to-damage ratios
- Differentiate weapon heft using space requirements

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*

------
https://chatgpt.com/codex/tasks/task_e_689bb8909770832695102aa0ee937a75