### PR TITLE
Rebalance cleric and spy costs

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -559,22 +559,22 @@ current game turn.</dd>
 <dt><b>StartDate.Year=<i>"1984"</i></b></dt>
 <dd>Sets the year in which the game starts to <i>1984</i>.</dd>
 
-<dt><b>Prices.Spy=<i>20000</i></b></dt>
+<dt><b>Prices.Spy=<i>1500</i></b></dt>
 <dd>Sets the price to pay a cleric to spy on another player to be
-<i>$20,000</i>.</dd>
+<i>$1,500</i>.</dd>
 
-<dt><b>Prices.Tipoff=<i>20000</i></b></dt>
+<dt><b>Prices.Tipoff=<i>1500</i></b></dt>
 <dd>Sets the price to pay a cleric to tip off the cops to another player to be
-<i>$20,000</i>.</dd>
+<i>$1,500</i>.</dd>
 
-<dt><b>Cleric.MinPrice=<i>20000</i></b></dt>
-<dd>Sets the minimum price for a cleric at the Rough Pub to be <i>$20,000</i>.
+<dt><b>Cleric.MinPrice=<i>2500</i></b></dt>
+<dd>Sets the minimum price for a cleric at the Rough Pub to be <i>$2,500</i>.
 Note that prices for clerics "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal cleric price
-distribution by 3, i.e. about one-third of the shop price range (~$6,700–$13,300 by default).</dd>
+distribution by 3, i.e. about one-third of the shop price range (~$800–$1,700 by default).</dd>
 
-<dt><b>Cleric.MaxPrice=<i>40000</i></b></dt>
-<dd>Sets the maximum price for a cleric to <i>$40,000</i>.</dd>
+<dt><b>Cleric.MaxPrice=<i>5000</i></b></dt>
+<dd>Sets the maximum price for a cleric to <i>$5,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -203,11 +203,11 @@ struct CURRENCY Currency = {
 };
 
 struct PRICES Prices = {
-  20000, 20000
+  1500, 1500
 };
 
 struct BITCH Bitch = {
-  20000, 40000
+  2500, 5000
 };
 
 #ifdef NETWORKING


### PR DESCRIPTION
## Summary
- Lower default cleric hire prices for more affordable protection
- Drop spy and tipoff service costs to match player wealth
- Document new pricing defaults in config file guide

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc -Isrc tests/test_socks5.c src/network.c src/util.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0) -lm` *(fails: Package glib-2.0 was not found)*
- `gcc -Isrc tests/test_sound.c src/sound.c src/util.c -o tests/test_sound $(pkg-config --cflags --libs glib-2.0) -lm` *(fails: Package glib-2.0 was not found)*
- `make check` *(fails: No rule to make target 'check')*
- `python3 - <<'PY' ...` (script verifying new prices vs starting cash)


------
https://chatgpt.com/codex/tasks/task_e_689bb8b5354c83268cf6ecbcc9ee185a