### PR TITLE
Use g_string_free return values

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -1064,7 +1064,6 @@ price_t strtoprice(char *buf)
 gchar *pricetostr(price_t price)
 {
   GString *PriceStr;
-  gchar *NewBuffer;
   price_t absprice;
 
   if (price < 0)
@@ -1080,10 +1079,8 @@ gchar *pricetostr(price_t price)
         g_string_prepend_c(PriceStr, '-');
     }
   }
-  NewBuffer = PriceStr->str;
   /* Free the string structure, but not the actual char array */
-  g_string_free(PriceStr, FALSE);
-  return NewBuffer;
+  return g_string_free(PriceStr, FALSE);
 }
 
 /* 
@@ -1095,7 +1092,6 @@ gchar *pricetostr(price_t price)
 gchar *FormatPrice(price_t price)
 {
   GString *PriceStr;
-  gchar *NewBuffer;
   char thou[10];
   gboolean First = TRUE;
   price_t absprice;
@@ -1132,10 +1128,8 @@ gchar *FormatPrice(price_t price)
   if (negative)
     g_string_prepend_c(PriceStr, '-');
 
-  NewBuffer = PriceStr->str;
   /* Free the string structure only, not the char data */
-  g_string_free(PriceStr, FALSE);
-  return NewBuffer;
+  return g_string_free(PriceStr, FALSE);
 }
 
 /* 
@@ -1198,10 +1192,8 @@ int read_string(FILE *fp, char **buf)
       g_string_append_c(text, (char)c);
   } while (c != EOF && c != 0);
 
-  *buf = text->str;
-
   /* Free the GString, but not the actual data text->str */
-  g_string_free(text, FALSE);
+  *buf = g_string_free(text, FALSE);
   if (c == EOF)
     return EOF;
   else


### PR DESCRIPTION
## Summary
- Simplify `pricetostr` and `FormatPrice` by returning the result of `g_string_free`
- Use `g_string_free` to assign buffers in `read_string`

## Testing
- `gcc -Wall -Wextra -c src/dopewars.c -o /tmp/dopewars.o` *(fails: glib.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd553d7083268e90f315d04af85e