### PR TITLE
Guard _GNU_SOURCE definition in dopewars.c

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -20,7 +20,9 @@
  *                   MA  02111-1307, USA.                               *
  ************************************************************************/
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>


### PR DESCRIPTION
## Summary
- guard the `_GNU_SOURCE` macro definition in `dopewars.c` to avoid redefinition warnings

## Testing
- `./autogen.sh` *(fails: automake not installed)*
- `gcc -E src/dopewars.c -DHAVE_UNISTD_H=1 -DHAVE_GETOPT_LONG=1 -I/tmp -o /tmp/dopewars.i`

------
https://chatgpt.com/codex/tasks/task_e_689bbd6129308326b4167e32d2fec2ff