### PR TITLE
Specify UTF-8 encoding for gettext extraction

### DIFF
--- a/po/Makevars
+++ b/po/Makevars
@@ -12,7 +12,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --add-comments
+XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --add-comments --from-code=UTF-8
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding


### PR DESCRIPTION
## Summary
- ensure xgettext reads source files as UTF-8 during POT/PO generation

## Testing
- `make -C po churchwars.pot-update` *(fails: No rule to make target 'churchwars.pot-update')*


------
https://chatgpt.com/codex/tasks/task_e_689c386815e4832682743f8a345f8191