### PR TITLE
Include sound header in serverside

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -54,6 +54,7 @@
 #include "network.h"
 #include "nls.h"
 #include "serverside.h"
+#include "sound.h"
 #include "tstring.h"
 #include "util.h"
 


### PR DESCRIPTION
## Summary
- include sound.h in serverside module to provide SoundPlay declarations

## Testing
- `gcc -Isrc -c src/serverside.c` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c386aa4ac8326b6f33f1546bac437