### PR TITLE
Remove unused variables in server-side logic

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -320,7 +320,7 @@ void RemoteVersionCheck(Player *Play)
  */
 void HandleServerMessage(gchar *buf, Player *Play)
 {
-  Player *To, *tmp, *pt;
+  Player *To, *pt;
   GSList *list;
   char *Data;
   AICode AI;
@@ -2191,7 +2191,7 @@ int SendSingleHighScore(Player *Play, struct HISCORE *Score,
 void SendEvent(Player *To)
 {
   price_t Money;
-  int i, j;
+  int i;
   gchar *text;
   Player *Play;
   GSList *list;


### PR DESCRIPTION
## Summary
- Drop unused variables `tmp` and `j` from `serverside.c` to clean up build warnings.

## Testing
- `./autogen.sh` *(fails: automake missing)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689c386d0514832691ede7d4bccdb4b1