### PR TITLE
Check local socket path length in admin client

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -58,8 +58,12 @@ static int OpenSocket(void)
   }
 
   addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, sockname, sizeof(addr.sun_path));
-  addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
+  if (g_strlcpy(addr.sun_path, sockname, sizeof(addr.sun_path)) >
+      sizeof(addr.sun_path) - 1) {
+    g_warning("Unix domain socket path '%s' is too long", sockname);
+    g_free(sockname);
+    exit(EXIT_FAILURE);
+  }
 
   if (connect(sock, (struct sockaddr *)&addr,
               sizeof(struct sockaddr_un)) == -1) {


### PR DESCRIPTION
## Summary
- avoid truncated Unix domain socket paths in admin client
- log and abort when socket path exceeds `sun_path` capacity

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `sudo apt-get update` *(fails: repositories not signed/403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ca6b77dec8326abe27b553b4c6985