### PR TITLE
Avoid redundant strlen in base64 encoding

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1592,11 +1592,13 @@ static void AddB64char(GString *str, int c)
 void AddB64Enc(GString *str, gchar *unenc)
 {
   guint i;
+  size_t len;
   long value = 0;
 
   if (!unenc || !str)
     return;
-  for (i = 0; i < strlen(unenc); i++) {
+  len = strlen(unenc);
+  for (i = 0; i < len; i++) {
     value <<= 8;
     value |= (unsigned char)unenc[i];
     if (i % 3 == 2) {


### PR DESCRIPTION
## Summary
- Precompute the length of unencoded data in AddB64Enc to avoid repeated strlen calls and ensure unsigned comparison

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca6ce62c483268a572b11a855c616