### PR TITLE
Rename local config file paths for Church Wars

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2285,7 +2285,7 @@ gchar *GetGlobalConfigFile(void)
 gchar *GetLocalConfigFile(void)
 {
 #ifdef CYGWIN
-  return g_strdup_printf("%s/dopewars-config.txt",
+  return g_strdup_printf("%s/churchwars-config.txt",
                          appdata_path ? appdata_path : ".");
 #else
   gchar *home, *conf = NULL;
@@ -2293,7 +2293,7 @@ gchar *GetLocalConfigFile(void)
   /* Local config is in the user's home directory */
   home = getenv("HOME");
   if (home) {
-    conf = g_strdup_printf("%s/.dopewars", home);
+    conf = g_strdup_printf("%s/.churchwars", home);
   }
   return conf;
 #endif


### PR DESCRIPTION
## Summary
- use `churchwars-config.txt` for local config file under Cygwin
- store per-user config as `~/.churchwars` on Unix
- confirm callers rely on `GetLocalConfigFile()` return value

## Testing
- `python tests/test_gun_balance.py`
- `gcc -Wall tests/test_socks5.c -o /tmp/test_socks5 && /tmp/test_socks5` *(fails: network.h: No such file or directory)*
- `gcc -Wall tests/test_sound.c -o /tmp/test_sound && /tmp/test_sound` *(fails: sound.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cab0927388326afdb741a102dc41d