### PR TITLE
Update scorefile paths to churchwars.sco

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2001-04-08 15:48+0100\n"
 "Last-Translator: Benjamin Karaca <mister-freeze@web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -18,131 +18,146 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "den Kredithai"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "die Bank"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Netzwerk-Port zu dem verbunden werden soll"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Name der Highscore-Datei"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Server zu dem verbunden werden soll"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Begrüßungsnachricht (MOTD) des Servers"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Netzwerkadresse für den Server"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE, wenn ein SOCKS-Server für das Netzwerkspiel genutzt werden soll"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE, wenn numerische Benutzer-IDs für SOCKS4 benutzt werden sollen"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Der Benutzername für SOCKS4, wenn nicht leer"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "Der Hostname eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "Die Port-Adresse eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Die Version des zu verwendenden SOCKS-Protokolls (4 oder 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Benutzername für die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Passwort für  die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE wenn der Server bei einem MetaServer Meldung erstatten soll"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 "Name des Metaservers, zu/von dem Server-Details gesendet/erhalten werden "
 "sollen"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Bevorzugter Hostname deines Servers"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Bestätigung für LocalName mit dem Metaserver"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Server-Beschreibung, die an den Metaserver gemeldet wird"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Wenn TRUE wird der Server zur Taskleiste minimiert"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Wenn TRUE läuft der Server im Hintergrund"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "Das Kommando, welches zum Starten deines Web-Browsers benutzt wird"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -266,7 +281,8 @@ msgstr "Sound-Datei für das Nachladen einer Waffe"
 
 #: src/dopewars.c:397
 msgid "Sound file played when an enemy cleric/deputy is killed"
-msgstr "Sound-Datei für das Ableben eines feindlichen Klerikers oder Hilfssheriffs"
+msgstr ""
+"Sound-Datei für das Ableben eines feindlichen Klerikers oder Hilfssheriffs"
 
 #: src/dopewars.c:400
 msgid "Sound file played when one of your clerics is killed"
@@ -544,6 +560,9 @@ msgstr "Liste der Dinge die du machen kannst"
 msgid "Number of things which you can stop to do"
 msgstr "Anzahl der Dinge die du machen kannst"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -616,6 +635,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -636,18 +659,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -664,6 +691,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -680,6 +708,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -749,6 +779,7 @@ msgstr ""
 "Ein kolumbianischer Frachter hat die Küstenwache umschippert. Der Preis für "
 "Weed ist ins bodenlose gefallen!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -781,6 +812,7 @@ msgstr "Nachricht"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -793,6 +825,10 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Junkies kaufen %tde für horrende Summen!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Wäre es nicht cool, wenn alle plötzlich mal zittern würden?"
@@ -920,17 +956,17 @@ msgstr "Magst du ein Gummibärchen?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Ausführen der Konfigurationsdatei %s in Zeile %d abgebrochen"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Fehler beim Öffnen der Datei %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -941,115 +977,132 @@ msgstr ""
 "oder entferne sie mit dem push oder kill Kommando und versuche es dann noch "
 "mal"
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Index in Array %s sollte zwischen 1 und %d sein"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s ist %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s ist %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s ist %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s ist \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] ist %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s ist { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kann nicht kleiner sein als %d  ignorieren!"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kann nicht größer sein als %d  ignorieren!"
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Optimierte Struktur-Liste von %d Elementen\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Erwarteter Boolean-Wert (0, FALSE, 1, TRUE"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1097,7 +1150,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1107,27 +1160,30 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1167,7 +1223,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1177,7 +1233,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1187,7 +1243,7 @@ msgstr ""
 "Option \"--enable-curses-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den GTK+-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1197,7 +1253,7 @@ msgstr ""
 "Option \"--enable-gui-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den curses-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1208,7 +1264,7 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben\n"
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1220,6 +1276,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Deutsche Übersetzung         Benjamin Karaca"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1295,7 +1352,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Unkonstruktive Kritk         James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr "Für Informationen über die Startparameter tipp Church Wars -h in"
 
 #: src/curses_client/curses_client.c:375
@@ -1304,8 +1363,11 @@ msgid ""
 msgstr ""
 "deiner Unix Prompt ein. Dies listet dir alle verfügbaren Parameter auf."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Bitte gib den Hostnamen und Port des Church Wars servers an:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1320,6 +1382,7 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Bitte warten... Erstelle Verbindung zu Metaserver..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1359,6 +1422,10 @@ msgstr "Kommentar: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>ächster ; V>orheriger ; W>ähle diesen Server... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NVW"
@@ -1391,15 +1458,21 @@ msgid "Password: "
 msgstr "Passwort: "
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Bitten warten... versuche Church Wars-Server zu kontaktieren..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Bekomme keine Details des Metaserver"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Kann den Multiplayer-Modus nicht starten"
 
 #: src/curses_client/curses_client.c:720
@@ -1407,7 +1480,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Öffne V>erbindug zu einem Server, "
 
 #: src/curses_client/curses_client.c:729
@@ -1415,24 +1489,30 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "L>iste Server des Metaserver auf und wähle einen aus"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "möchtest Du das Spiel B>eenden"
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr " oder möchtest Du als E>inzelspieler spielen "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "VLBE"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Wohin soll's gehen, Kumpel? "
 
@@ -1440,6 +1520,8 @@ msgstr "Wohin soll's gehen, Kumpel? "
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1453,6 +1535,7 @@ msgstr "Was willst du wegwerfen? "
 msgid "How many do you drop? "
 msgstr "Wie viel schmeißt du weg? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Was willst du kaufen? "
@@ -1461,6 +1544,8 @@ msgstr "Was willst du kaufen? "
 msgid "What do you wish to sell? "
 msgstr "Was möchtest du verscherbeln? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1484,10 +1569,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Willst du wirklich aufhören? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "JN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Neuer Name: "
@@ -1501,17 +1587,18 @@ msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre zum Einzelspieler-Modus zurück"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s betritt das Spiel!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s hat das Spiel verlassen."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1522,7 +1609,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Derzeitiger Aufenthaltsort/%tde"
 
@@ -1536,34 +1623,50 @@ msgstr "Leider benutzt schon jemand anders \"deinen\" Namen. Bitte ändere Ihn"
 msgid "H I G H   S C O R E S"
 msgstr "B E S T E N L I S T E"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du brauchst mehr %tde Platz um noch mehr %tde tragen zu können!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du hast nicht genug Platz um eine %tde zu tragen!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du hast nicht genug Kohle für eine %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "EVG"
@@ -1572,27 +1675,40 @@ msgstr "EVG"
 msgid "How much money do you pay back? "
 msgstr "Wieviel Geld möchtest Du zurückzahlen?"
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Soviel Kohle hast Du nicht!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Möchtest Du E>inzahlen, A>bheben, oder die Bank V>erlassen? "
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "EAV"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Wie viel Kohle?"
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "So viel Knete hast du gar nicht..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
@@ -1621,32 +1737,46 @@ msgstr "V:Verschwinden"
 msgid "Press any key..."
 msgstr "Drück irgend'ne Taste..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Nachrichten (-/+ zum Scrollen)"
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Statistik"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Bargeld"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Gesundheit"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Konto"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Schulden"
 
@@ -1655,6 +1785,8 @@ msgstr "Schulden"
 msgid "Space %6d"
 msgstr "Platz %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Platz %6d"
@@ -1663,6 +1795,10 @@ msgstr "%Tde %3d  Platz %6d"
 msgid "Trenchcoat"
 msgstr "Mantel"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogen/%Tde"
@@ -1671,11 +1807,13 @@ msgstr "%/Stats: Drogen/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1686,10 +1824,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogen/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1702,202 +1843,217 @@ msgstr "Tja, Du bist alleine auf der Welt!"
 msgid "Players currently logged on:-"
 msgstr "Eingeloggte Mitspieler:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hey Kleiner, die %tde Preise von hier:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kann den SIGWINCH Interrupt Handler nicht installieren"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Hey Kleiner, wie lautet dein Name? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "Willst Du E>inkaufen"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", V>erkaufen"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", W>egwerfen"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", S>prechen, F>lüstern"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", L>iste"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", K>ämpfen"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", R>eisen"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", oder B>eenden? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Willst Du "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "K>ämpfen, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "S>tehen bleiben, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "R>ennen, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "mit %tde H>andeln, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "oder B>eenden? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre in den Einzelspieler-Modus zurück"
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "EVWSFLAKRB"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "HRKSE"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Zeige S>pieler oder P>unkte? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Wem möchtest du etwas zuflüstern ? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Sprich: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Möchtest du noch mal spielen? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Spiel"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Spiel/_Neu..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Spiel/_Abbrechen..."
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Spiel/Sound"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Spiel/_Ende..."
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Anzeigen"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Anzeigen/der _Spieler..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Anzeigen/der _Punkte..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Anzeigen/des _Inventars..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Hilfe"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Hilfe/_Über..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Warnung"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Fehler"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Willst du das aktuelle Spiel abbrechen?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Spiel verlassen"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Neues Spiel starten"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Spiel Abbrechen"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventar"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Schließen"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Verbindung zum Server verloren - wechsle in Einzelspieler-Modus"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -1905,7 +2061,8 @@ msgstr ""
 "Du wurdest vom Server geworfen.\n"
 "Kehre in Einzelspieler-Modus zurück."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -1913,236 +2070,271 @@ msgstr ""
 "Verbindung zu Server unterbrochen!\n"
 "Kehre zurück in den Einzelspieler-Modus"
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Reise zu %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "B E S T E N  L I S T E"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "Fehlerhafte Bestenliste!"
 
 # src/gtk_client.c:737
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Kämpfen"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_%Tde dealen"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Kämpfen"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Stehen bleiben"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Rennen"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Kampf: Kleriker/%d %tde"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Links)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Tot)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Gesundheit: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Du"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Kleriker/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr "Inventar"
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Reise zu Ort"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr "%/Reiseziel/%tde"
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "für %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Zur Zeit trägst Du %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Verfügbarer Platz: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Du kannst %d kaufen"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Einkaufen"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Verkaufen"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Wegwerfen"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "Wieviel Einkaufen?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "Wieviel Verkaufen?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "Wieviel Wegwerfen?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Kaufen %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Verkaufen %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Wegwerfen %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Ja"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Nein"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Angriff"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Verschwinden"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Frage"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Platz"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Deutsche Übersetzung"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Symbole und Grafiken"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sounds"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Drogen Handel und Nachforschung"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testspieler"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Exzessives Testspielen"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Konstruktive Kritik"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Unkonstruktive Kritik"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2169,7 +2361,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2178,120 +2371,146 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars wurde unter der GNU General Public License veröffentlicht.\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Kredithai Fenstertitel/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/BankName Fenstertitel/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Sie müßen einen positiven Geldbetrag eingeben!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Ein B?nker spricht: \"Soviel Geld haben Sie nicht.\""
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Bargeld: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Schulden: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Konto: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Zurückzahlen:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Einzahlen"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Abheben"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Bezahle alles"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Spieler Liste"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Rede mit Spieler(n)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Rede mit allen Spielern"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Nachricht:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Senden"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Name"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preis"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Anzahl"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Einkaufen ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Verkaufen"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Wegwerfen <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde hier"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde dabei"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Ändere Name"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Leider benutzt schon jemand anders \"deinen\" Namen, ändere Ihn bitte."
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Waffenladen Fenstertitel/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2418,11 +2637,13 @@ msgid "Symbol prefixes prices"
 msgstr "Währungssymbol dem Preis voranstellen"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+#, fuzzy
+msgid "Name of one bitch"
 msgstr "Name für einen Kleriker"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+#, fuzzy
+msgid "Name of several bitches"
 msgstr "Name für mehrere Kleriker"
 
 #: src/gui_client/optdialog.c:903
@@ -2501,6 +2722,7 @@ msgstr "_Hilfe"
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kannst kein Spiel starten, ohne vorher einen Namen anzugeben!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Neues Spiel"
@@ -2513,20 +2735,28 @@ msgstr "Status: Warte auf Benutzereingabe"
 msgid "Connection closed by remote host"
 msgstr "Verbindung wurde durch remote Host geschlossen"
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Konnte keine Verbindung zu %s herstellen"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Verbinde mit SOCKS server %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Authentifizieren mit SOCKS server"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2536,49 +2766,60 @@ msgstr "Status: Frage SOCKS um zu %s zu verbinden..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Hey Kleiner, wie heißt Du? "
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Starte Einzelspieler Spiel"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
 msgstr ""
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "Church Wars Server"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "Der Server wurde beendet."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "Church Wars AI"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr ""
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2619,52 +2860,57 @@ msgstr ""
 "Verfügbare Variablen werden hier aufgelistet :-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Konnte nicht zu Metaserver verbinden %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServer : %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Warte auf Verbindung zu Metaserver %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxKlients (%d) erreicht - verwerfe Verbindung"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr "Sorry, aber hier dürfen max. 1 spielen.^Bitte versuchs später nochmal."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2672,169 +2918,181 @@ msgid ""
 msgstr ""
 "Sorry, aber hier dürfen max. %d spielen.^Bitte versuchs später nochmal."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s ist nun bekannt als %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: VERWEIGERT Reise zu %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Deine Zeit als Dealer ist vorbei..."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: VERWEIGERT Reise zu %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Unbekannte Nachricht: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Pflege PID Datei %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Kann PID Datei nicht erstellen %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr "Kann nicht auf Port %u (%s) starten. Breche ab."
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr "Kann nicht am Netzwerksockeln horchen. Breche ab."
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 "Church Wars server version %s klar und wartet auf verbindungen auf port %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kann SIGUSR1 nicht installieren, breche ab"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Kann SIGHUP nicht installieren, breche ab"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Kann SIGINT nicht installieren, breche ab"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Kann SIGTERM nicht installieren, breche ab"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Kann pipe handler nicht installieren"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Eingelogte Spieler:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Du bist ganz allein auf der Welt!\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Drücke %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Kein solcher Benutzer!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s getötet\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Unbekanntes Kommando - versuch mal \"help\" für Hilfe...\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "bekommt Verbindung von %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "Der Server wurde beendet."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s verlässt den Server!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
+"Church Wars server version %s klar und wartet auf verbindungen auf port %d."
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Neue Admin verbindung"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Admin Befehl: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Admin Verbindung geschlossen"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr "Kann NT Dienst Status nicht setzen"
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr "Konnte Service Benachrichtigung nicht senden"
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr "Kann Dienst handler nicht registrieren"
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr "Kann NT Dienst nicht starten"
 
@@ -2842,12 +3100,26 @@ msgstr "Kann NT Dienst nicht starten"
 msgid "Command:"
 msgstr "Befehl:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"Kann kein Backup (%s) der\n"
+"Bestenliste-Datei %s erstellen."
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Fehler beim Lesen der Punkte aus %s."
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -2856,7 +3128,7 @@ msgstr ""
 "Die Bestenliste-Datei %s wurde in das neue Format konvertiert.\n"
 "Ein Backup der alten Datei wurde als %s erstellt.\n"
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2865,12 +3137,12 @@ msgstr ""
 "Kann kein Backup (%s) der\n"
 "Bestenliste-Datei %s erstellen."
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2883,13 +3155,13 @@ msgstr ""
 "auf die Datei/das Verzeichnis hast oder gib eine andere Bestenliste-Datei\n"
 "mit derm -f Kommandozeilen-Parameter an."
 
-#: src/serverside.c:1992
-#, c-format
+#: src/serverside.c:2005
+#, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 "%s scheint keine gültige Bestenliste-Datei zu sein -\n"
@@ -2898,17 +3170,18 @@ msgstr ""
 "mit Hilfe des Parameters \"Church Wars -C %s\"\n"
 "in der Kommandozeile."
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
+#, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 "Beim Lesen der Konfigurationsdatei traten Fehler auf. Als Folge\n"
 "werden einige Einstellungen vielleicht nicht wie erwartet funktionieren.\n"
 "Ziehe die Datei \"Church Wars-log.txt\" für weitere Details zu Rate."
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -2918,109 +3191,116 @@ msgstr ""
 "werden einige Einstellungen vielleicht nicht wie erwartet funktionieren.\n"
 "Schau dir die Nachrichten unter Standard Output für weitere Details an."
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Kann die Bestenliste-Datei %s nicht lesen."
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Glückwunsch! Du hast Dir einen Platz in der Bestenliste erkämpft!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Tja, besser spielen, dann gibt's auch 'nen Highscore..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Kann Bestenliste-Datei %s nicht schreiben."
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Die Lady neben dir in der U-Bahn sagte,^ \"%s\"%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (Zumindest -glaubst- du, sie hätte das gesagt)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Du hörst jemanden %s spielen"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Möchtest du %tde besuchen?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Willst Du eine %tde für %P anwerben?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s ist schon hier!^Willst du angreifen, oder dich verdrücken?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "Keine Bullen oder Waffen!"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "Polizisten können sich nicht gegenseitig angreifen."
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "Spieler kämpfen bereits!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "Spieler kämpfen bereits in verschieden Kämpfen!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kann nicht kämpfen - keine Waffen vorhanden!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 "YN^Willst du einem Doktor %P blechen, damit er dich wieder zusammenflickt?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du wurdest in der U-Bahn bestohlen!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du triffst einen Freund! Er gibt dir %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du triffst einen Freund! Du gibst ihm %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3028,17 +3308,17 @@ msgstr ""
 "Polizeihunde jagend dich %d Blocks entlang! Du hast ein wenig %tde "
 "weggeworfen! So'n Scheiß."
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du findest %d %tde bei einem toten Penner in der U-Bahn!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Deine Mama hat aus deinem %tde Brownies gemacht! Die waren super!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3046,24 +3326,24 @@ msgstr ""
 "YN^Du findest etwas Weed, das wie wie übelstes Rattengift stinkt!^Sieht aber "
 "sonst ganz gut aus! Willst Du es rauchen?"
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du machst eine kleine Pause um %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Möchtest Du einen größeren Mantel für %P kaufen?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hey Kumpel! Ich trage dir %tde für %P. Wie wär's? Ja oder Nein?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Willst Du eine %tde für %P kaufen?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3072,29 +3352,29 @@ msgstr ""
 "alles, was du bisher erlebt hast. Dann bist du abgekratzt, weil dein Gehirn "
 "in tausend Teile zersprungen ist."
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Zu spät - %s hat sich verpisst!"
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Die Cops haben dich gesehen als du %tde wegwerfen wolltest!"
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sende Update an Metaserver..."
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sende Erinnerungsnachricht an Metaserver..."
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Spieler entfernt aufgrund von Idle Timeout"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Spieler entfernt aufgrund von Timeout bei Verbindungsaufbau"
 
@@ -3111,6 +3391,8 @@ msgstr "Verbindung abgebrochen aufgrund eines vollen Buffers"
 msgid "Internal error code %d"
 msgstr "Interner Fehler %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock wurde nicht richtig initialisiert"
@@ -3175,6 +3457,7 @@ msgstr "Protokoll nicht unterstützt"
 msgid "Socket type not supported"
 msgstr "Sockeltyp nicht unterstützt"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Host nicht gefunden"
@@ -3215,150 +3498,150 @@ msgstr "Falsche Antwort des Metaservers \"%s\""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Willst Du abhauen?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Willst Du Rennen, oder Kämpfen?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "ärmlich bewaffnet"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "leicht bewaffnet"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "recht gut bewaffnet"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "schwer bewaffnet"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "bis an die Zähne bewaffnet"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - verfolgt dich Mann!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s und %d %tde - %s - verfolgen dich, Mann!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s trifft mit %d %tde ein, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s steht rum und kriegt's voll ab."
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Du bleibst stehen und fängst die Kugeln"
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s versucht erfolglos zu fliehen."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "Verdammt! Du wirst sie nicht los!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s ist geflohen nach %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s ist abgehauen!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "Du entkommst!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Waffen nachgeladen..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s schiesst auf %s... und verfehlt!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s schießt auf dich... und verfehlt!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "Du triffst %s nicht!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s erledigt %s."
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s schießt auf %s und tötet eine %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s ist %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s schießt auf dich und tötet eine %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "%s trifft dich, Mann!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "Du triffst und tötest %s"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Du triffst %s und tötest eine %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "Du schießt, und triffst %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr "Du findest %P in der Leiche!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr "Du plünderst die verdammte Leiche!"
 
@@ -3367,115 +3650,129 @@ msgstr "Du plünderst die verdammte Leiche!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kann WinSock nicht initialisieren (%s)"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr "SOCKS-Server allgemeiner Fehler"
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Verbindung von SOCKS ruleset abgelehnt"
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Netzwerk unerreichbar"
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Host unerreichbar"
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Verbindung abgelehnt"
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL abgelaufen"
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Befehl nicht unterstützt"
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Addressen-Typ nicht unterstützt"
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS: Server hat alle angebotenen Methoden abgelehnt"
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr "Unbekannter SOCKS Addressentyp zurückgekehrt"
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-Bestätigung fehlgeschlagen"
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-Bestätigung vom Benutzer abgebrochen"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Nachfrage abgelehnt oder fehlgeschlagen"
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Abgelehnt  unmöglich identd zu kontaktieren"
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Abgelehnt  identd meldet andere Benutzer-ID"
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr "Unbekannter SOCKS Antwort-Code"
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr "Unbekannter SOCKS Antwort-Version-Code"
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr "Unbekannte SOCKS Server-Version"
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS Fehler Code %d"
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 "Versuche, lokalen Church Wars Server via Unix Domänen Socket\n"
 "%s zu kontaktieren...\n"
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
 msgstr "Verbindung hergestellt. Beende deine Session mit Strg+D.\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Kann Datei nicht öffnen %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Kann Datei nicht öffnen %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr "Konnte lokale Konfigurationsdatei nicht bestimmen"
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Kann Datei nicht öffnen %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3528,93 +3825,94 @@ msgstr "Benutze Name %s\n"
 msgid "Players in this game:-\n"
 msgstr "Spieler im Spiel:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s betritt das Spiel.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s verlassst das Spiel.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Reise von %tde mit %P Bargeld und %P Schulden\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "KI Spieler wurde getötet. Beende normal.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Spielzeit ist um. Verlasse Spiel.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "KI Spieler wurde vom Server geworfen.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "Der Server wurde beendet.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Verkaufe %d %tde in %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Kaufe %d %tde für %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kaufe eine %tde für %P im Waffenladen\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "%P Schulden an den Kredithai zurückgezahlt.\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Kredithai ist in %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Waffenladen ist in%s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Pub ist in %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Bank ist in %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Ihr nennt euch Drogendealer?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Selbst ein trainierter Affe könnte das besser"
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Denkste Du bist hart genug um mit Leuten wie mir zu handeln?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... handelst du mit Schokoriegeln oder was?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Kleiner, ich muss dich töten - zu deinem eigenen Besten!"
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3624,12 +3922,12 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben"
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Fehler beim Öffnen der Datei %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3637,6 +3935,24 @@ msgid ""
 msgstr ""
 "Ungültiges Plugin \"%s\" ausgewählt.\n"
 "(%s verfügbar; verwende nun \"%s\".)"
+
+#~ msgid "The command used to start your web browser"
+#~ msgstr "Das Kommando, welches zum Starten deines Web-Browsers benutzt wird"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "Wem möchtest du etwas zuflüstern ? "
+
+#~ msgid "Talk: "
+#~ msgstr "Sprich: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "Church Wars Server"
+
+#~ msgid "dopewars AI"
+#~ msgstr "Church Wars AI"
 
 #~ msgid ""
 #~ "\n"
@@ -3686,7 +4002,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "SOCKS Authentifizierung benötigt"
-
 
 #~ msgid "gun"
 #~ msgstr "Waffe"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,128 +17,143 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:301
-msgid "If TRUE, the server runs in the background"
-msgstr ""
-
 #: src/dopewars.c:304
-msgid "The command used to start your web browser"
+msgid "If TRUE, the server runs in the background"
 msgstr ""
 
 #: src/dopewars.c:308
@@ -262,11 +277,11 @@ msgid "Sound file played when guns are reloaded"
 msgstr ""
 
 #: src/dopewars.c:397
-msgid "Sound file played when an enemy bitch/deputy is killed"
+msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
 #: src/dopewars.c:400
-msgid "Sound file played when one of your bitches is killed"
+msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
 #: src/dopewars.c:403
@@ -366,7 +381,7 @@ msgid "% resistance to gunshots of each player"
 msgstr ""
 
 #: src/dopewars.c:482 src/dopewars.c:485
-msgid "% resistance to gunshots of each bitch"
+msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
 #: src/dopewars.c:488
@@ -471,11 +486,11 @@ msgid "Damage done by each weapon"
 msgstr ""
 
 #: src/dopewars.c:598
-msgid "Word used to denote a single \"bitch\""
+msgid "Word used to denote a single \"cleric\""
 msgstr ""
 
 #: src/dopewars.c:601
-msgid "Word used to denote two or more \"bitches\""
+msgid "Word used to denote two or more \"clerics\""
 msgstr ""
 
 #: src/dopewars.c:604
@@ -499,19 +514,19 @@ msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
 #: src/dopewars.c:619
-msgid "Cost for a bitch to spy on the enemy"
+msgid "Cost for a cleric to spy on the enemy"
 msgstr ""
 
 #: src/dopewars.c:622
-msgid "Cost for a bitch to tipoff the cops to an enemy"
+msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr ""
 
 #: src/dopewars.c:625
-msgid "Minimum price to hire a bitch"
+msgid "Minimum price to hire a cleric"
 msgstr ""
 
 #: src/dopewars.c:628
-msgid "Maximum price to hire a bitch"
+msgid "Maximum price to hire a cleric"
 msgstr ""
 
 #: src/dopewars.c:631
@@ -538,6 +553,9 @@ msgstr ""
 msgid "Number of things which you can stop to do"
 msgstr ""
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -610,6 +628,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -630,18 +652,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -658,6 +684,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -674,6 +701,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -740,6 +769,7 @@ msgid ""
 "out!"
 msgstr ""
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -772,6 +802,7 @@ msgstr ""
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -782,6 +813,10 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -907,132 +942,149 @@ msgstr ""
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr ""
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2462
+#: src/dopewars.c:2460
 #, c-format
-msgid "dopewars version %s\n"
+msgid "Church Wars version %s\n"
 msgstr ""
 
-#: src/dopewars.c:2471
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
 #, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1052,7 +1104,7 @@ msgid ""
 "format\n"
 msgstr ""
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1062,27 +1114,30 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2508
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
 #, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1095,7 +1150,7 @@ msgid ""
 "  -A       connect to a locally-running server for administration\n"
 msgstr ""
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1105,21 +1160,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1127,7 +1182,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1139,6 +1194,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr ""
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr ""
@@ -1209,7 +1265,8 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr ""
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr ""
 
 #: src/curses_client/curses_client.c:375
@@ -1217,8 +1274,10 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr ""
 
 #: src/curses_client/curses_client.c:402
@@ -1233,6 +1292,7 @@ msgstr ""
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1272,6 +1332,10 @@ msgstr ""
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr ""
@@ -1303,15 +1367,19 @@ msgid "Password: "
 msgstr ""
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+msgid "Could not start multiplayer Church Wars"
 msgstr ""
 
 #: src/curses_client/curses_client.c:720
@@ -1319,7 +1387,7 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr ""
 
 #: src/curses_client/curses_client.c:729
@@ -1328,23 +1396,28 @@ msgstr ""
 
 #: src/curses_client/curses_client.c:732
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr ""
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr ""
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr ""
 
@@ -1352,6 +1425,8 @@ msgstr ""
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1365,6 +1440,7 @@ msgstr ""
 msgid "How many do you drop? "
 msgstr ""
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
@@ -1373,6 +1449,8 @@ msgstr ""
 msgid "What do you wish to sell? "
 msgstr ""
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1396,10 +1474,11 @@ msgid "Are you sure you want to quit? "
 msgstr ""
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr ""
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr ""
@@ -1412,17 +1491,18 @@ msgstr ""
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1433,7 +1513,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
@@ -1447,34 +1527,50 @@ msgstr ""
 msgid "H I G H   S C O R E S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
@@ -1483,27 +1579,40 @@ msgstr ""
 msgid "How much money do you pay back? "
 msgstr ""
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr ""
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
@@ -1532,32 +1641,46 @@ msgstr ""
 msgid "Press any key..."
 msgstr ""
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr ""
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr ""
 
@@ -1566,6 +1689,8 @@ msgstr ""
 msgid "Space %6d"
 msgstr ""
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
@@ -1574,6 +1699,10 @@ msgstr ""
 msgid "Trenchcoat"
 msgstr ""
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1582,11 +1711,13 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1597,10 +1728,13 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1613,441 +1747,492 @@ msgstr ""
 msgid "Players currently logged on:-"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr ""
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr ""
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr ""
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2074,127 +2259,154 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
 "Church Wars is released under the GNU General Public License\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2404,6 +2616,7 @@ msgstr ""
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
@@ -2416,20 +2629,28 @@ msgstr ""
 msgid "Connection closed by remote host"
 msgstr ""
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2439,49 +2660,59 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr ""
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
 msgstr ""
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+msgid "Church Wars server"
 msgstr ""
 
-#: src/winmain.c:369
-msgid "dopewars AI"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr ""
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2504,220 +2735,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr ""
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr ""
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr ""
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr ""
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr ""
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr ""
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr ""
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr ""
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr ""
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr ""
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr ""
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr ""
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr ""
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr ""
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr ""
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr ""
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr ""
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
+#: src/serverside.c:1233
 #, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr ""
 
@@ -2725,31 +2972,43 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr ""
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr ""
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2758,199 +3017,206 @@ msgid ""
 "-f command line option."
 msgstr ""
 
-#: src/serverside.c:1992
+#: src/serverside.c:2005
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr ""
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr ""
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr ""
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr ""
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr ""
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr ""
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr ""
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr ""
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -2967,6 +3233,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3031,6 +3299,7 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3071,150 +3340,150 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr ""
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr ""
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr ""
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr ""
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr ""
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr ""
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr ""
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr ""
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr ""
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr ""
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr ""
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr ""
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr ""
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr ""
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr ""
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr ""
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr ""
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr ""
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr ""
 
@@ -3223,105 +3492,119 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
 #, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
 msgstr ""
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, c-format
+msgid "Could not write to config file: %s"
+msgstr ""
+
+#: src/configfile.c:225
+#, c-format
+msgid "Could not truncate config file: %s"
+msgstr ""
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3329,7 +3612,7 @@ msgstr ""
 #: src/AIPlayer.c:76
 #, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3379,105 +3662,106 @@ msgstr ""
 msgid "Players in this game:-\n"
 msgstr ""
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr ""
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr ""
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr ""
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr ""
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr ""
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr ""
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr ""
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr ""
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr ""
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr ""
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
 "Recompile passing --enable-networking to the configure script."
 msgstr ""
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars SVN\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2020-12-09 12:02-0800\n"
 "Last-Translator: Ben Webb <benwebb@users.sf.net>\n"
 "Language-Team: British English <en@li.org>\n"
@@ -15,128 +15,143 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:301
-msgid "If TRUE, the server runs in the background"
-msgstr ""
-
 #: src/dopewars.c:304
-msgid "The command used to start your web browser"
+msgid "If TRUE, the server runs in the background"
 msgstr ""
 
 #: src/dopewars.c:308
@@ -536,6 +551,9 @@ msgstr ""
 msgid "Number of things which you can stop to do"
 msgstr ""
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -608,6 +626,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -628,18 +650,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -656,6 +682,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -672,6 +699,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -738,6 +767,7 @@ msgid ""
 "out!"
 msgstr ""
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -770,6 +800,7 @@ msgstr ""
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -780,6 +811,10 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -905,132 +940,149 @@ msgstr ""
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr ""
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2462
+#: src/dopewars.c:2460
 #, c-format
-msgid "dopewars version %s\n"
+msgid "Church Wars version %s\n"
 msgstr ""
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1070,8 +1122,8 @@ msgstr ""
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a Church Wars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1090,7 +1142,7 @@ msgstr ""
 "  -C, --convert=FILE      convert an \"old format\" score file to the new "
 "format\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1100,27 +1152,30 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1150,7 +1205,8 @@ msgstr ""
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a Church Wars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1162,7 +1218,7 @@ msgstr ""
 "  -C file  convert an \"old format\" score file to the new format\n"
 "  -A       connect to a locally-running server for administration\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1172,21 +1228,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1194,7 +1250,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1206,6 +1262,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr ""
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr ""
@@ -1276,7 +1333,8 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr ""
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr ""
 
 #: src/curses_client/curses_client.c:375
@@ -1284,8 +1342,10 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr ""
 
 #: src/curses_client/curses_client.c:402
@@ -1300,6 +1360,7 @@ msgstr ""
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1339,6 +1400,10 @@ msgstr ""
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr ""
@@ -1370,15 +1435,19 @@ msgid "Password: "
 msgstr ""
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+msgid "Could not start multiplayer Church Wars"
 msgstr ""
 
 #: src/curses_client/curses_client.c:720
@@ -1386,7 +1455,7 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr ""
 
 #: src/curses_client/curses_client.c:729
@@ -1395,23 +1464,28 @@ msgstr ""
 
 #: src/curses_client/curses_client.c:732
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr ""
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr ""
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr ""
 
@@ -1419,6 +1493,8 @@ msgstr ""
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1432,6 +1508,7 @@ msgstr ""
 msgid "How many do you drop? "
 msgstr ""
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr ""
@@ -1440,6 +1517,8 @@ msgstr ""
 msgid "What do you wish to sell? "
 msgstr ""
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1463,10 +1542,11 @@ msgid "Are you sure you want to quit? "
 msgstr ""
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr ""
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr ""
@@ -1479,17 +1559,18 @@ msgstr ""
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1500,7 +1581,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
@@ -1514,34 +1595,50 @@ msgstr ""
 msgid "H I G H   S C O R E S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr ""
@@ -1550,27 +1647,40 @@ msgstr ""
 msgid "How much money do you pay back? "
 msgstr ""
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr ""
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr ""
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr ""
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr ""
@@ -1599,32 +1709,46 @@ msgstr ""
 msgid "Press any key..."
 msgstr ""
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr ""
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr ""
 
@@ -1633,6 +1757,8 @@ msgstr ""
 msgid "Space %6d"
 msgstr ""
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr ""
@@ -1641,6 +1767,10 @@ msgstr ""
 msgid "Trenchcoat"
 msgstr ""
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1649,11 +1779,13 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1664,10 +1796,13 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1680,441 +1815,492 @@ msgstr ""
 msgid "Players currently logged on:-"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr ""
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr ""
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr ""
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2141,7 +2327,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2150,120 +2337,146 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars is released under the GNU General Public Licence\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2390,11 +2603,11 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+msgid "Name of one bitch"
 msgstr ""
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+msgid "Name of several bitches"
 msgstr ""
 
 #: src/gui_client/optdialog.c:903
@@ -2473,6 +2686,7 @@ msgstr ""
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr ""
@@ -2485,20 +2699,28 @@ msgstr ""
 msgid "Connection closed by remote host"
 msgstr ""
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr ""
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2508,49 +2730,59 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr ""
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr ""
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
 msgstr ""
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+msgid "Church Wars server"
 msgstr ""
 
-#: src/winmain.c:369
-msgid "dopewars AI"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr ""
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2573,220 +2805,236 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr ""
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
 "^Please try connecting again later."
 msgstr ""
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr ""
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr ""
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr ""
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr ""
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr ""
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr ""
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr ""
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr ""
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr ""
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr ""
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr ""
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr ""
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr ""
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr ""
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr ""
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr ""
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
+#: src/serverside.c:1233
 #, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr ""
 
@@ -2794,31 +3042,43 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr ""
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr ""
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2827,199 +3087,206 @@ msgid ""
 "-f command line option."
 msgstr ""
 
-#: src/serverside.c:1992
+#: src/serverside.c:2005
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr ""
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr ""
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr ""
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr ""
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr ""
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr ""
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr ""
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr ""
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3036,6 +3303,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock has not been properly initialised"
@@ -3100,6 +3369,7 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3140,150 +3410,150 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr ""
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr ""
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr ""
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr ""
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr ""
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr ""
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr ""
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr ""
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr ""
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr ""
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr ""
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr ""
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr ""
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr ""
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr ""
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr ""
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr ""
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr ""
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr ""
 
@@ -3292,105 +3562,119 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Cannot initialise WinSock (%s)!"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS authentication cancelled by user"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
 #, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
 msgstr ""
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, c-format
+msgid "Could not write to config file: %s"
+msgstr ""
+
+#: src/configfile.c:225
+#, c-format
+msgid "Could not truncate config file: %s"
+msgstr ""
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3398,7 +3682,7 @@ msgstr ""
 #: src/AIPlayer.c:76
 #, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3448,105 +3732,106 @@ msgstr ""
 msgid "Players in this game:-\n"
 msgstr ""
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr ""
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr ""
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr ""
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr ""
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr ""
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr ""
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr ""
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr ""
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr ""
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr ""
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
 "Recompile passing --enable-networking to the configure script."
 msgstr ""
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2003-12-10 09:29+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -24,129 +24,144 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de su servidor"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "La orden usada para iniciar su navegador web"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -272,7 +287,8 @@ msgstr "Fichero de sonido que suena cuando se recarga un arma"
 #: src/dopewars.c:397
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
-"Fichero de sonido que suena cuando se mata a un ayudante o a un clérigo enemigo"
+"Fichero de sonido que suena cuando se mata a un ayudante o a un clérigo "
+"enemigo"
 
 #: src/dopewars.c:400
 msgid "Sound file played when one of your clerics is killed"
@@ -553,6 +569,9 @@ msgstr "Lista de cosas que puede dejar de hacer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puede dejar de hacer"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -625,6 +644,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -645,18 +668,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -673,6 +700,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -689,6 +717,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -755,6 +785,7 @@ msgid ""
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -787,6 +818,7 @@ msgstr "Mensaje"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -798,6 +830,10 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los adictos están comprando %tde a precios absurdos!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite!"
@@ -928,17 +964,17 @@ msgstr "La telepatía existe. ¿No siente la energía del universo?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -949,68 +985,83 @@ msgstr ""
 "jugador conectado. Espere a que se desconecten todos los jugadores, o\n"
 "elimínelos con las órdenes echar o matar, e inténtelo otra vez."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1018,7 +1069,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1026,42 +1077,44 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars versión %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1087,7 +1140,8 @@ msgstr ""
 "  -n, --single-player     ser aburrido y no conectarse a ninguno de los\n"
 "                            servidores Church Wars disponibles (modo 1 "
 "jugador)\n"
-"  -a, --antique           Church Wars \"antiguo\" Church Wars - parecerse a la\n"
+"  -a, --antique           Church Wars \"antiguo\" Church Wars - parecerse a "
+"la\n"
 "                            versión original cuanto sea posible (sin red)\n"
 "  -f, --scorefile=FICHERO indicar que fichero usar como tabla de "
 "puntuaciones\n"
@@ -1127,7 +1181,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1139,31 +1193,34 @@ msgstr ""
 "  -h, --help              mostrar esta información de ayuda\n"
 "  -v, --version           mostrar información sobre la versión y salir\n"
 "\n"
-"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la GNU "
-"GPL\n"
+"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la "
+"GNU GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1206,7 +1263,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1218,11 +1275,11 @@ msgstr ""
 "  -h       mostrar esta información de ayuda\n"
 "  -v       mostrar información sobre la versión y salir\n"
 "\n"
-"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la GNU "
-"GPL\n"
+"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la "
+"GNU GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1232,7 +1289,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o use una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1242,7 +1299,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o use el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1250,7 +1307,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1265,6 +1322,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1342,8 +1400,11 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
-msgstr "Para conocer las opciones en la línea de órdenes, escriba Church Wars -h"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
+msgstr ""
+"Para conocer las opciones en la línea de órdenes, escriba Church Wars -h"
 
 #: src/curses_client/curses_client.c:375
 msgid ""
@@ -1352,8 +1413,11 @@ msgstr ""
 "en su terminal. Se mostrará una pantalla de ayuda con las opciones "
 "disponibles."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Introduzca el nombre y puerto de un servidor Church Wars:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1368,6 +1432,7 @@ msgstr "Puerto: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espere... intentando contactar con el metaservidor..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1407,6 +1472,10 @@ msgstr "Comentario: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SAE"
@@ -1439,15 +1508,22 @@ msgid "Password: "
 msgstr "Contraseña: "
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
-msgstr "Por favor, espere... intentando contactar con el servidor Church Wars..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
+msgstr ""
+"Por favor, espere... intentando contactar con el servidor Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "No se pueden obtener los detalles del metaservidor"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "No se puede iniciar Church Wars en modo multijugador"
 
 #: src/curses_client/curses_client.c:720
@@ -1455,7 +1531,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "¿Quiere... C>onectarte a un servidor Church Wars determinado"
 
 #: src/curses_client/curses_client.c:729
@@ -1464,24 +1541,31 @@ msgstr ""
 "            L>istar los servidores que hay en el metaservidor, y elegir uno"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
-msgstr "            S>alir (puede iniciar un servidor tecleando «Church Wars -s»)"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
+msgstr ""
+"            S>alir (puede iniciar un servidor tecleando «Church Wars -s»)"
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "¿Dónde quiere ir, caballero? "
 
@@ -1489,6 +1573,8 @@ msgstr "¿Dónde quiere ir, caballero? "
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1502,6 +1588,7 @@ msgstr "¿Qué quiere tirar? "
 msgid "How many do you drop? "
 msgstr "¿Cuántas quiere tirar? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quiere comprar? "
@@ -1510,6 +1597,8 @@ msgstr "¿Qué quiere comprar? "
 msgid "What do you wish to sell? "
 msgstr "¿Qué quiere vender? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1533,10 +1622,11 @@ msgid "Are you sure you want to quit? "
 msgstr "¿Está seguro de que quiere salir? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "SN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nuevo nombre: "
@@ -1549,17 +1639,18 @@ msgstr "Ha sido expulsado del servidor. Pasando al modo 1 jugador."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1570,7 +1661,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
@@ -1584,34 +1675,50 @@ msgstr "Desgraciadamente ya hay alguien usando «su» nombre. Elija otro."
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tiene ningún %tde que vender!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "¡No tiene ninguna que vender!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesita más %tde para que le guarden más %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tiene suficiente espacio para llevar ese %tde!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tiene suficiente dinero para comprar ese %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVI"
@@ -1620,27 +1727,40 @@ msgstr "CVI"
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quiere devolver? "
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "¡No tiene tanto dinero!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quiere I>ngresar dinero, O>btener dinero o S>alir?"
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "IOS"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tiene tanto dinero en el banco..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
@@ -1669,32 +1789,46 @@ msgstr "H:Huir"
 msgid "Press any key..."
 msgstr "Pulse cualquier tecla..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Situación"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Dinero"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Salud"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Deuda"
 
@@ -1703,6 +1837,8 @@ msgstr "Deuda"
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
@@ -1711,6 +1847,10 @@ msgstr "%Tde %5d  Espacio %4d"
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
@@ -1719,11 +1859,13 @@ msgstr "%/Situación: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1734,10 +1876,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1750,201 +1895,216 @@ msgstr "¡No hay ningún otro jugador conectado en este momento!"
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, oiga. Los precios de las %tde aquí son:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Eh oiga, ¿cómo se llama? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "¿Quiere C>omprar"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", E>nfrentarse"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", I>r a otro sitio"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "¿Quiere "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>ender %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "CVTHJLMEIS"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "VCLES"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quiere? ¿J>ugadores o P>untuaciones? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "¿Con quién quiere hablar en privado?"
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Decir: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Juego"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Juego/_Nueva partida..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Juego/_Abandonar partida..."
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Juego/Activar_sonido"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Juego/_Salir..."
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Listar"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Listar/_Jugadores..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Listar/_Puntuaciones..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventario..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Ayuda"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Ayuda/_Acerca de..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Advertencia"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Error"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Mensaje"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "¿Abandonar esta partida?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Salir del juego"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Empezar nueva partida"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventario"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -1952,7 +2112,8 @@ msgstr ""
 "Ha sido expulsado del servidor.\n"
 "Pasando al modo 1 jugador."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -1960,235 +2121,270 @@ msgstr ""
 "El servidor se ha apagado.\n"
 "Pasando al modo 1 jugador."
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Yendo a %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Puntuaciones"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "El fichero de puntuaciones está corrupto :-("
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Enfrentarse"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "¡A _traficar!"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Luchar"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Esperar"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Correr"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Enfrentamiento: Putas/%d %tde"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Quedan)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Muertas)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Salud: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Usted"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putas/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Ir al barrio:"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr "%/Lugar al que irse/%tde"
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "a %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Ahora lleva %d dosis de %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Espacio disponible: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Tiene dinero para comprar %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Comprar"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Vender"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Tirar"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "¿Cuánto quiere comprar?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "¿Cuánto quiere vender?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "¿Cuánto quiere tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Comprar %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Vender %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Tirar %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Sí"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_No"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Atacar"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Huir"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Pregunta"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Espacio"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2215,7 +2411,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2224,120 +2421,146 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está publicado bajo la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tiene que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "No tiene tanto dinero en el banco..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Dinero en efectivo: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Deuda: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Saldar:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Ingresar"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Sacar"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar todo"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jugadores"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Mensaje:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Enviar"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Número"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde que tiene"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Desgraciadamente ya hay otro jugador usando «su» nombre. Elija otro"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2464,11 +2687,13 @@ msgid "Symbol prefixes prices"
 msgstr "Símbolo antes del precio"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+#, fuzzy
+msgid "Name of one bitch"
 msgstr "Nombre de un clérigo"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+#, fuzzy
+msgid "Name of several bitches"
 msgstr "Nombre de varios clérigos"
 
 #: src/gui_client/optdialog.c:903
@@ -2547,6 +2772,7 @@ msgstr "_Ayuda"
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puede empezar la partida sin dar un nombre antes!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
@@ -2559,20 +2785,28 @@ msgstr "Situación: Esperando datos del usuario"
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2582,17 +2816,22 @@ msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh oiga, ¿cuál es su _nombre?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
+#, fuzzy
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
@@ -2602,33 +2841,40 @@ msgstr ""
 "de procesar el fichero de configuración, etc.\n"
 "\n"
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "servidor Church Wars"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "cerrando el servidor Church Wars."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "Jugador automático de Church Wars"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr "AH"
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2673,43 +2919,46 @@ msgstr ""
 "Las variables válidas son:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "No se ha podido conectar al metaservidor en %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaservidor: %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Intentos para conectarse al metaservidor demasiado frecuentes - esperando al "
 "siguiente turno"
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Esperando para conectarse al metaservidor en %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
+#, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 "Parece que está usando un cliente tremendamente viejo (versión 1.4.x)^ "
 "Aunque posiblemente funcione, muchas de las nuevas funcionalidades^ no "
 "estarán soportadas. Obtenga la última versión del sitio web de Church Wars,^ "
 "https://dopewars.sourceforge.io/."
 
-#: src/serverside.c:307
+#: src/serverside.c:308
+#, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 "Advertencia: su cliente es demasiado viejo para soportar todas las^ "
@@ -2717,13 +2966,15 @@ msgstr ""
 "consiga la última versión de Church Wars del servidor web,^ http://dopewars."
 "sourceforge.net/."
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 "Alcanzado el número máximo de clientes (MaxClients %d) - cerrando la conexión"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2731,7 +2982,9 @@ msgstr ""
 "Disculpe, pero este servidor tiene un límite de 1 jugador, que ya ha sido "
 "alcanzado. ^Pruebe más tarde a conectarte de nuevo."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2740,133 +2993,144 @@ msgstr ""
 "Disculpe, pero este servidor tiene un límite de %d jugadores, que ya ha sido "
 "alcanzado. ^Pruebe a conectarte de nuevo más tarde."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s es ahora conocido como %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO irse a %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Se acabó su tiempo para traficar..."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: DENEGADO irse a %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensaje desconocido: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Manteniendo el fichero pid %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "No se puede crear el fichero pid %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 "No se puede crear el socket (%s) (a la escucha) del servidor. Cancelando."
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr "No se puede conectar al puerto %u (%s). Cancelando."
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr "No se puede escuchar el socket de red. Cancelando."
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
-"servidor Church Wars versión %s preparado y esperando conexiones por el puerto "
-"%d."
+"servidor Church Wars versión %s preparado y esperando conexiones por el "
+"puerto %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGHUP!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGINT!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGTERM!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "¡No se puede instalar el gestor de tuberías!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "El fichero de configuración se ha guardado con éxito como %s\n"
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Usuarios conectados:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "No hay ningún usuario conectado.\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Echando a %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s asesinado\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Orden desconocida - use «help» para obtener ayuda\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "recibida una conexión de %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "cerrando el servidor Church Wars."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "¡%s deja el servidor!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -2874,41 +3138,41 @@ msgstr ""
 "No se ha podido establecer el socket de dominio Unix para conexiones de "
 "administración - compruebe los permisos en /tmp."
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 "el servidor de Church Wars versión %s está listo para recibir órdenes de "
 "administración; use «help» para obtener ayuda"
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Nueva conexión de administración"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Orden de administración: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Conexión de administración cerrada"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr "No se ha podido establecer el estado del Servicio NT"
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr "No se ha podido enviar el mensaje de notificación de servicio"
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr "No se ha podido registrar el gestor de servicio"
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr "No se ha podido iniciar el Servicio NT"
 
@@ -2916,12 +3180,26 @@ msgstr "No se ha podido iniciar el Servicio NT"
 msgid "Command:"
 msgstr "Orden:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"No se ha podido crear la copia de respaldo (%s) del\n"
+"fichero de máximas puntuaciones %s."
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "No se ha podido leer la tabla de puntuaciones del fichero %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -2931,7 +3209,7 @@ msgstr ""
 "al nuevo formato. Se ha creado una copia de respaldo del\n"
 "fichero antiguo, que se ha llamado %s.\n"
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2940,12 +3218,12 @@ msgstr ""
 "No se ha podido crear la copia de respaldo (%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2958,13 +3236,13 @@ msgstr ""
 "a este fichero o directorio, o bien indique otro fichero de\n"
 "puntuaciones con la opción -f en la línea de órdenes."
 
-#: src/serverside.c:1992
-#, c-format
+#: src/serverside.c:2005
+#, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 "%s no parece ser un fichero de puntuaciones válido - \n"
@@ -2973,18 +3251,19 @@ msgstr ""
 "formato ejecutando la orden «Church Wars -C %s» en la\n"
 "línea de órdenes."
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
+#, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 "Se han encontrado errores al leer el fichero de configuración.\n"
 "Como resultado, algunas preferencias podrían no funcionar de\n"
 "la manera esperada. Puede consultar el fichero «Church Wars-log.txt»\n"
 "para conocer los detalles."
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -2995,108 +3274,115 @@ msgstr ""
 "de la manera esperada. Puede mirar los mensajes en la\n"
 "salida estándar para conocer más detalles."
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "No se puede leer el fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "¡Enhorabuena! ¡Ha conseguido una de las máximas puntuaciones!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Ni siquiera ha conseguido entrar en la tabla de puntuaciones..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La señorita que está junto a usted en el metro dice:^ «%s»%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (al menos, eso es lo que *piensa* que ha dicho)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Oye a alguien poner %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quiere visitar %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quiere contratar a una %tde por %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quiere Atacar o Huir?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni polis!"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los polis no pueden atacar a otros polis!"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quiere pagar %P a un médico para que le cure?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Le atracan en el metro!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Se encuentra con un amigo! Le da a usted  %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Se encuentra con un amigo! Usted le da %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3104,17 +3390,17 @@ msgstr ""
 "¡Los perros de la policía le persiguen durante %d minutos! ¡Pierde algo de "
 "%tde! Maldita sea..."
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentra %d %tde en un cadáver abandonado en el metro!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Su mamacita ha hecho galletas con algo de su %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3122,24 +3408,24 @@ msgstr ""
 "YN^¡Aquí hay algo de marihuana que huele a herbicida!^¡Tiene buen aspecto! "
 "^¿Quiere fumarla? "
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Se ha parado para %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quiere comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, oiga! Le ayudo a llevar sus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quiere comprar un %tde por %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3147,29 +3433,29 @@ msgstr ""
 "¡Estuvo alucinando durante tres días en el viaje más salvaje que haya "
 "imaginado nunca!^Y entonces se murió debido a que su cerebro se derritió."
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La policía le ve tirando %tde!"
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3188,6 +3474,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código de error interno %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock no ha sido inicializado correctamente."
@@ -3252,6 +3540,7 @@ msgstr "Protocolo no soportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket no soportado"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Servidor no encontrado"
@@ -3292,150 +3581,150 @@ msgstr "Respuesta del metaservidor incorrecta «%s»"
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "¿Echa a correr?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "¿Huye o se enfrenta?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "armados de pena"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "poco armados"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "armados"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "muy armados"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "armados hasta los dientes"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "¡%s - %s - le está dando caza!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "¡%s y %d %tde - %s - le están persiguiendo!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "¡%s llega con %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s se levanta y lo coge"
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Se queda ahí como un tonto."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s intenta huir, pero no lo consigue."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "¡Pánico! ¡No puede escapar!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "¡%s ha conseguido escapar a %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "¡%s ha conseguido escapar!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "¡Ha conseguido escapar!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Armas recargadas..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s dispara a %s... ¡y falla!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s le dispara... ¡y falla!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "¡No le ha dado a %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata a %s."
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s dispara a %s ¡y mata a una %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s es %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s le dispara... ¡y mata a una %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "¡%s le ha dado!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "¡Ha matado a %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Le da a %s, y mata a un %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "¡Le da a %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr " ¡Le encuentra %P en el cuerpo!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr " ¡Le roba al cadaver!"
 
@@ -3444,97 +3733,100 @@ msgstr " ¡Le roba al cadaver!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 "Probando a conectar con el servidor Church Wars local vía sockets de\n"
 "dominio Unix %s...\n"
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
@@ -3542,20 +3834,31 @@ msgstr ""
 "Conexión establecida. Use Ctrl-D para cerrar la sesión.\n"
 "\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 "No se ha podido determinar el fichero de configuración local en que escribir"
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3610,94 +3913,95 @@ msgstr "Usando el nombre %s\n"
 msgid "Players in this game:-\n"
 msgstr "Jugadores en esta partida:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s se une a la partida.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s ha dejado el juego.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Yendo %tal con %P en efectivo y %P de deuda\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jugador automático asesinado. Cerrando de manera normal.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Se ha agotado el tiempo de juego. Saliendo.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "El jugador automático ha sido expulsado del servidor.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "El servidor se ha apagado.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendiendo %d %tde a %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde a %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando un %tde por %P en la armería\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Deuda de %P pagada al usurero\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "El usurero está en %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "La armería está en %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "El bar está en %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y usted se hace llamar traficante?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Un mono amaestrado lo haría mejor..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "¿Cree que es lo suficientemente duro como para manejar a gente como yo?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... ¿está traficando con caramelos o qué?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Voy a tener que dispararle por su propio bien."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3707,12 +4011,12 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompile pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "No es posible abrir el fichero %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3720,6 +4024,24 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#~ msgid "The command used to start your web browser"
+#~ msgstr "La orden usada para iniciar su navegador web"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "¿Con quién quiere hablar en privado?"
+
+#~ msgid "Talk: "
+#~ msgstr "Decir: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "servidor Church Wars"
+
+#~ msgid "dopewars AI"
+#~ msgstr "Jugador automático de Church Wars"
 
 #~ msgid ""
 #~ "\n"
@@ -3772,7 +4094,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Se precisa autenticación SOCKS"
-
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -4043,7 +4364,8 @@ msgstr ""
 #~ "have one month of game time to make your fortune.\n"
 #~ msgstr ""
 #~ "Basado en el juego Drug Wars de John E. Dell, Church Wars es una \n"
-#~ "simulación de un mercado de la droga imaginario. Church Wars es un juego \n"
+#~ "simulación de un mercado de la droga imaginario. Church Wars es un "
+#~ "juego \n"
 #~ "para toda la familia que consiste en la compraventa de droga y en "
 #~ "intentar \n"
 #~ "evitar a la policía.\n"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es_ES\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2003-12-10 09:48+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -24,129 +24,144 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de tu servidor"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "La orden usada para iniciar tu navegador web"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -271,7 +286,8 @@ msgstr "Fichero de sonido que suena cuando se recarga un arma"
 #: src/dopewars.c:397
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
-"Fichero de sonido a reproducir cuando se mata a un ayudante o a un clérigo enemigo"
+"Fichero de sonido a reproducir cuando se mata a un ayudante o a un clérigo "
+"enemigo"
 
 #: src/dopewars.c:400
 msgid "Sound file played when one of your clerics is killed"
@@ -550,6 +566,9 @@ msgstr "Lista de cosas que puedes dejar de hacer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puedes dejar de hacer"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -622,6 +641,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -642,18 +665,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -670,6 +697,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -686,6 +714,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -753,6 +783,7 @@ msgid ""
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -785,6 +816,7 @@ msgstr "Mensaje"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -796,6 +828,10 @@ msgstr ""
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite, co!"
@@ -924,17 +960,17 @@ msgstr "La telepatía existe. ¿No sientes la energía del universo?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -945,68 +981,83 @@ msgstr ""
 "jugador conectado. Espera a que se desconecten todos los jugadores, o\n"
 "elimínalos con las órdenes echar o matar, e inténtalo otra vez."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1014,7 +1065,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1022,42 +1073,44 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars versión %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1083,7 +1136,8 @@ msgstr ""
 "  -n, --single-player     ser aburrido y no conectarse a ninguno de los\n"
 "                            servidores Church Wars disponibles (modo 1 "
 "jugador)\n"
-"  -a, --antique           Church Wars \"antiguo\" Church Wars - parecerse a la\n"
+"  -a, --antique           Church Wars \"antiguo\" Church Wars - parecerse a "
+"la\n"
 "                            versión original cuanto sea posible (sin red)\n"
 "  -f, --scorefile=FICHERO indicar que fichero usar como tabla de "
 "puntuaciones\n"
@@ -1123,7 +1177,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1135,31 +1189,34 @@ msgstr ""
 "  -h, --help              mostrar esta información de ayuda\n"
 "  -v, --version           mostrar información sobre la versión y salir\n"
 "\n"
-"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la GNU "
-"GPL\n"
+"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la "
+"GNU GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1202,7 +1259,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1214,11 +1271,11 @@ msgstr ""
 "  -h       mostrar esta información de ayuda\n"
 "  -v       mostrar información sobre la versión y salir\n"
 "\n"
-"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la GNU "
-"GPL\n"
+"Church Wars es Copyright (C) Ben Webb 1998-2022, y está publicado bajo la "
+"GNU GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1228,7 +1285,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o usa una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1238,7 +1295,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o usa el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1246,7 +1303,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1261,6 +1318,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1337,8 +1395,11 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
-msgstr "Para conocer las opciones en la línea de órdenes, escribe Church Wars -h"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
+msgstr ""
+"Para conocer las opciones en la línea de órdenes, escribe Church Wars -h"
 
 #: src/curses_client/curses_client.c:375
 msgid ""
@@ -1347,8 +1408,11 @@ msgstr ""
 "en tu terminal. Se mostrará una pantalla de ayuda con las opciones "
 "disponibles."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Introduce el nombre y puerto de un servidor doperwars:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1363,6 +1427,7 @@ msgstr "Puerto: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espera... intentando contactar con el metaservidor..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1402,6 +1467,10 @@ msgstr "Comentario: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SAE"
@@ -1434,15 +1503,22 @@ msgid "Password: "
 msgstr "Contraseña: "
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
-msgstr "Por favor, espera... intentando contactar con el servidor Church Wars..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
+msgstr ""
+"Por favor, espera... intentando contactar con el servidor Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "No se pueden obtener los detalles del metaservidor"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "No se puede iniciar Church Wars en modo multijugador"
 
 #: src/curses_client/curses_client.c:720
@@ -1450,7 +1526,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "¿Quieres... C>onectarte a un servidor Church Wars determinado"
 
 #: src/curses_client/curses_client.c:729
@@ -1459,8 +1536,9 @@ msgstr ""
 "            L>istar los servidores que hay en el metaservidor, y elegir uno"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 "            S>alir (puedes iniciar un servidor tecleando «Church Wars -s»)"
 
@@ -1468,16 +1546,21 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "¿Dónde quieres ir, colega? "
 
@@ -1485,6 +1568,8 @@ msgstr "¿Dónde quieres ir, colega? "
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1498,6 +1583,7 @@ msgstr "¿Qué quieres tirar? "
 msgid "How many do you drop? "
 msgstr "¿Cuántas quieres tirar? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "¿Qué quieres pillar? "
@@ -1506,6 +1592,8 @@ msgstr "¿Qué quieres pillar? "
 msgid "What do you wish to sell? "
 msgstr "¿Qué quieres pulir? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1529,10 +1617,11 @@ msgid "Are you sure you want to quit? "
 msgstr "¿Estás seguro de que quieres salir? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "SN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nuevo nombre: "
@@ -1545,17 +1634,18 @@ msgstr "Has sido expulsado del servidor. Pasando al modo 1 jugador."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1566,7 +1656,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
@@ -1580,34 +1670,50 @@ msgstr "Desgraciadamente ya hay alguien usando «tu» nombre. Elige otro."
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tienes ningún %tde que vender!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "¡No tienes ninguna que vender!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesitas más %tde para que te guarden más %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tienes suficiente espacio para llevar ese %tde!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tienes suficientes pelas para comprar ese %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CPD"
@@ -1616,27 +1722,40 @@ msgstr "CPD"
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quieres devolver? "
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "¡No tienes tanta pasta!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quieres I>ngresar dinero, S>acar dinero o L>argarte?"
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ISL"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "No tienes tantos dineros en el banco..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sí"
@@ -1665,32 +1784,46 @@ msgstr "H:Huir"
 msgid "Press any key..."
 msgstr "Pulsa cualquier tecla..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Situación"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Pasta"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Salud"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Pufo"
 
@@ -1699,6 +1832,8 @@ msgstr "Pufo"
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
@@ -1707,6 +1842,10 @@ msgstr "%Tde %5d  Espacio %4d"
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
@@ -1715,11 +1854,13 @@ msgstr "%/Situación: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1730,10 +1871,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1746,201 +1890,216 @@ msgstr "¡No hay ningún otro jugador conectado en este momento!"
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, tío. Los precios de las %tde aquí son:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Eh tío, ¿cómo te llamas? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "¿Quieres C>omprar"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", P>ulir"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", E>nfrentarte"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", D>arte el piro"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "¿Quieres "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "P>ulir %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "CPTHJLMEDS"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "PCLES"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quieres? ¿J>ugadores o P>untuaciones? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "¿Con quién quieres hablar en privado?"
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Decir: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Juego"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Juego/_Nueva partida..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Juego/_Abandonar partida..."
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Juego/Habilitar _sonido"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Juego/_Salir..."
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Listar"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Listar/_Jugadores..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Listar/_Puntuaciones..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventario..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Ayuda"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Ayuda/_Acerca de..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Advertencia"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Error"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Mensaje"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "¿Abandonar esta partida?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Salir del juego"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Empezar nueva partida"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Abandonar esta partida"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventario"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Se ha perdido la conexión con el servidor - pasando al modo 1 jugador"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -1948,7 +2107,8 @@ msgstr ""
 "Has sido expulsado del servidor.\n"
 "Pasando al modo 1 jugador."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -1956,235 +2116,270 @@ msgstr ""
 "El servidor se ha apagado.\n"
 "Pasando al modo 1 jugador."
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Yendo a %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Puntuaciones"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "El fichero de puntuaciones está corrupto :-("
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Enfrentarse"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "¡A _Trapichear!"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Luchar"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Esperar"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Correr"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Enfrentamiento: Putas/%d %tde"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Quedan)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Muertas)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Salud: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Tú"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putas/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Ir al barrio:"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr "%/Lugar al que pirarse/%tde"
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "a %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Ahora llevas %d dosis de %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Espacio disponible: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Tienes dinero para comprar %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Comprar"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Pulir"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Tirar"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "¿Cuánto quieres comprar?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "¿Cuánto quieres pulir?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "¿Cuánto quieres tirar?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Comprar %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Pulir %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Tirar %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Sí"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_No"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Atacar"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Huir"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Pregunta"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Espacio"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2211,7 +2406,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2220,120 +2416,146 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está publicado bajo la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tienes que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "No tienes tantos dineros en el banco..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Pasta en efectivo: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Pufo: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Saldar:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Ingresar"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Sacar"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar todo"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jugadores"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Mensaje:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Enviar"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Número"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Pulir"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde que tienes"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Desgraciadamente ya hay otro jugador usando «tu» nombre. Elije otro"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2460,11 +2682,13 @@ msgid "Symbol prefixes prices"
 msgstr "Símbolo antes del precio"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+#, fuzzy
+msgid "Name of one bitch"
 msgstr "Nombre de un clérigo"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+#, fuzzy
+msgid "Name of several bitches"
 msgstr "Nombre de varios clérigos"
 
 #: src/gui_client/optdialog.c:903
@@ -2543,6 +2767,7 @@ msgstr "_Ayuda"
 msgid "You can't start the game without giving a name first!"
 msgstr "¡No puedes empezar la partida sin dar un nombre antes!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nueva partida"
@@ -2555,20 +2780,28 @@ msgstr "Situación: Esperando input del usuario"
 msgid "Connection closed by remote host"
 msgstr "Conexión cerrada por el servidor remoto."
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Situación: No se ha podido conectar (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Situación: Conectado al servidor SOCKS %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Situación: Autenticando contra servidor SOCKS"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2578,17 +2811,22 @@ msgstr "Situación: Pidiendo SOCKS para conectarse a %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Eh tío, ¿cuál es tu _nombre?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Empezar partida para 1 jugador"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
+#, fuzzy
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
@@ -2598,33 +2836,40 @@ msgstr ""
 "de procesar el fichero de configuración, etc.\n"
 "\n"
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "servidor Church Wars"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "cerrando el servidor Church Wars."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "Jugador automático de Church Wars"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr "AH"
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2669,43 +2914,46 @@ msgstr ""
 "Las variables válidas son:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "No se ha podido conectar al metaservidor en %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaservidor: %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Intentos para conectarse al metaservidor demasiado frecuentes - esperando al "
 "siguiente turno"
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Esperando para conectarse al metaservidor en %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
+#, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 "Parece que estás usando un cliente tremendamente viejo (versión 1.4.x)^ "
 "Aunque posiblemente funcione, muchas de las nuevas funcionalidades^ no "
 "estarán soportadas. Obtén la última versión del sitio web de Church Wars,^ "
 "https://Church Wars.sourceforge.io/."
 
-#: src/serverside.c:307
+#: src/serverside.c:308
+#, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 "Advertencia: tu cliente es demasiado viejo para soportar todas las^ "
@@ -2713,13 +2961,15 @@ msgstr ""
 "obtén la última versión de Church Wars del servidor web,^ http://Church Wars."
 "sourceforge.net/."
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 "Alcanzado el número máximo de clientes (MaxClients %d) - cerrando la conexión"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2727,7 +2977,9 @@ msgstr ""
 "Lo siento, pero este servidor tiene un límite de 1 jugador, que ya ha sido "
 "alcanzado. ^Prueba más tarde a conectarte de nuevo."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2736,132 +2988,144 @@ msgstr ""
 "Lo siento, pero este servidor tiene un límite de %d jugadores, que ya ha "
 "sido alcanzado. ^Prueba a conectarte de nuevo más tarde."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s es ahora conocido como %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO largarse a %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Se acabó tu tiempo para trapichear..."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: DENEGADO largarse a %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensaje desconocido: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Manteniendo el fichero pid %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "No se puede crear el fichero pid %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 "No se puede crear el socket (%s) (a la escucha) del servidor. Cancelando."
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr "No se puede conectar al puerto %u (%s). Cancelando."
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr "No se puede escuchar el socket de red. Cancelando."
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
-"servidor Church Wars versión %s listo y esperando conexiones por el puerto %d."
+"servidor Church Wars versión %s listo y esperando conexiones por el puerto "
+"%d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGHUP!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGINT!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGTERM!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "¡No se puede instalar el gestor de tuberías!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "El fichero de configuración se ha guardado con éxito como %s\n"
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Usuarios conectados:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "No hay ningún usuario conectado.\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Echando a %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s asesinado\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Orden desconocida - usa «help» para obtener ayuda\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "recibida una conexión de %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "cerrando el servidor Church Wars."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "¡%s deja el servidor!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -2869,41 +3133,41 @@ msgstr ""
 "No se ha podido establecer el socket de dominio Unix para conexiones de "
 "administración - comprueba los permisos en /tmp."
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 "el servidor de Church Wars versión %s está listo para recibir órdenes de "
 "administración; usa «help» para obtener ayuda"
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Nueva conexión de administración"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Orden de administración: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Conexión de administración cerrada"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr "No se ha podido establecer el estado del Servicio NT"
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr "No se ha podido enviar el mensaje de notificación de servicio"
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr "No se ha podido registrar el gestor de servicio"
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr "No se ha podido iniciar el Servicio NT"
 
@@ -2911,12 +3175,26 @@ msgstr "No se ha podido iniciar el Servicio NT"
 msgid "Command:"
 msgstr "Orden:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"No se ha podido crear la copia de respaldo(%s) del\n"
+"fichero de máximas puntuaciones %s."
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "No se ha podido leer la tabla de puntuaciones del fichero %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -2926,7 +3204,7 @@ msgstr ""
 "al nuevo formato. Se ha creado una copia de respaldo del\n"
 "fichero antiguo, que se ha llamado %s.\n"
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2935,12 +3213,12 @@ msgstr ""
 "No se ha podido crear la copia de respaldo(%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2953,13 +3231,13 @@ msgstr ""
 "a este fichero o directorio, o bien indica otro fichero de\n"
 "puntuaciones con la opción -f en la línea de órdenes."
 
-#: src/serverside.c:1992
-#, c-format
+#: src/serverside.c:2005
+#, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 "%s no parece ser un fichero de puntuaciones válido - \n"
@@ -2968,18 +3246,19 @@ msgstr ""
 "formato ejecutando la orden «Church Wars -C %s» en la\n"
 "línea de órdenes."
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
+#, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 "Se han encontrado errores al leer el fichero de configuración.\n"
 "Como resultado, algunas preferencias podrían no funcionar de\n"
 "la manera esperada. Puedes consultar el fichero «Church Wars-log.txt»\n"
 "para conocer los detalles."
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -2990,108 +3269,115 @@ msgstr ""
 "de la manera esperada. Puedes mirar los mensajes en la\n"
 "salida estándar para conocer más detalles."
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "No se puede leer el fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "¡Enhorabuena! ¡Has conseguido una de las máximas puntuaciones!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Ni siquiera has conseguido entrar en la tabla de puntuaciones..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La chavala que está junto a ti en el metro dice:^ «%s»%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (al menos, eso es lo que *piensas* que ha dicho)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Oyes a alguien poner %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quieres visitar %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quieres contratar a una %tde por %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quieres Atacar o Huir?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni maderos!"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los maderos no pueden atacar a otros maderos!"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quieres pagar %P a un médico para que te cure?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Te atracan en el metro!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Te encuentras con un amigo! Te da %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Te encuentras con un amigo! Le das %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3099,17 +3385,17 @@ msgstr ""
 "¡Los perros de la bofia te persiguen durante %d manzanas! ¡Pierdes algo de "
 "%tde! Vaya mierda, macho."
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentras %d %tde en el cuerpo de un tío tirado en el metro!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Tu mami ha hecho galletas con algo de tu %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3117,24 +3403,24 @@ msgstr ""
 "YN^¡Aquí hay algo de maría que huele a herbicida!^¡Tiene buena pinta! "
 "^¿Quieres fumarla? "
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Te has parado para %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quieres comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, tío! Te ayudo a llevar tus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quieres comprar un %tde por %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3142,29 +3428,29 @@ msgstr ""
 "¡Estuviste flipando durante tres días en el cuelgue más salvaje que hayas "
 "imaginado nunca!^Y entonces la palmaste debido a que tu cerebro se derritió."
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La bofia te ve tirando %tde!"
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3183,6 +3469,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código de error interno %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock no ha sido inicializado correctamente."
@@ -3247,6 +3535,7 @@ msgstr "Protocolo no soportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket no soportado"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Servidor no encontrado"
@@ -3287,150 +3576,150 @@ msgstr "Respuesta del metaservidor incorrecta «%s»"
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "¿Echas a correr?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "¿Huyes o te enfrentas?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "armados de pena"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "poco armados"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "armados"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "muy armados"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "armados hasta los dientes"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "¡%s - %s - te está dando caza, colega!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "¡%s y %d %tde - %s - te están persiguiendo, colega!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "¡%s llega con %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s se levanta y lo coge"
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Te quedas ahí como un tonto."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s intenta huir, pero no lo consigue."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "¡Pánico! ¡No puedes escapar!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "¡%s ha conseguido escapar a %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "¡%s ha conseguido escapar!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "¡Has conseguido escapar!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Armas recargadas..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s dispara a %s... ¡y falla!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te dispara... ¡y falla!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "¡No le has dado a %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata a %s."
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s dispara a %s ¡y mata a una %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s es %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te dispara... ¡y se carga a una %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "¡%s te ha dado, co!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "¡Has matado a %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Le das a %s, y matas a un %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "¡Le das a %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr " ¡Te encuentras %P en el cuerpo!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr " ¡Le robas al cadaver!"
 
@@ -3439,97 +3728,100 @@ msgstr " ¡Le robas al cadaver!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "¡No se puede inicializar WinSock (%s)!"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 "Probando a conectar con el servidor Church Wars local vía sockets de\n"
 "dominio Unix %s...\n"
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
@@ -3537,20 +3829,31 @@ msgstr ""
 "Conexión establecida. Usa Ctrl-D para cerrar la sesión.\n"
 "\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 "No se ha podido determinar el fichero de configuración local en que escribir"
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3605,94 +3908,95 @@ msgstr "Usando el nombre %s\n"
 msgid "Players in this game:-\n"
 msgstr "Jugadores en esta partida:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s se une a la partida.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s ha dejado el juego.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Yendo %tal con %P en efectivo y %P de deuda\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jugador automático asesinado. Cerrando de manera normal.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Se ha agotado el tiempo de juego. Saliendo.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "El jugador automático ha sido expulsado del servidor.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "El servidor se ha apagado.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendiendo %d %tde a %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde a %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando un %tde por %P en la armería\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Deuda de %P pagada al usurero\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "El usurero está en %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "La armería está en %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "El bar está en %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y tú te haces llamar camello?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Un mono amaestrado lo haría mejor..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "¿Crees que eres lo suficientemente duro como para manejar a tipos como yo?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... ¿estás traficando con caramelos o qué?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Voy a tener que dispararte por tu propio bien."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3702,12 +4006,12 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompila pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "No es posible abrir el fichero %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3715,6 +4019,24 @@ msgid ""
 msgstr ""
 "Seleccionado módulo «%s» no válido.\n"
 "(%s disponible, ahora usando «%s».)"
+
+#~ msgid "The command used to start your web browser"
+#~ msgstr "La orden usada para iniciar tu navegador web"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "¿Con quién quieres hablar en privado?"
+
+#~ msgid "Talk: "
+#~ msgstr "Decir: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "servidor Church Wars"
+
+#~ msgid "dopewars AI"
+#~ msgstr "Jugador automático de Church Wars"
 
 #~ msgid ""
 #~ "\n"
@@ -3767,7 +4089,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Se precisa autenticación SOCKS"
-
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -4040,7 +4361,8 @@ msgstr ""
 #~ "have one month of game time to make your fortune.\n"
 #~ msgstr ""
 #~ "Basado en el juego Drug Wars de John E. Dell, Church Wars es una \n"
-#~ "simulación de un mercado de la droga imaginario. Church Wars es un juego \n"
+#~ "simulación de un mercado de la droga imaginario. Church Wars es un "
+#~ "juego \n"
 #~ "para toda la familia que consiste en la compraventa de droga y en "
 #~ "intentar \n"
 #~ "evitar a la policía.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2001-10-16 20:50+0100\n"
 "Last-Translator: leonard <triton@madchat.org>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -15,128 +15,143 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "Le Preteur a Gages"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "la banque"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Port reseau a se connecter"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur a se connecter"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "Different de zero si le serveur doit reporter a un metaserveur"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur "
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "description du serveur, reporte au metaserveur"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:301
-msgid "If TRUE, the server runs in the background"
-msgstr ""
-
 #: src/dopewars.c:304
-msgid "The command used to start your web browser"
+msgid "If TRUE, the server runs in the background"
 msgstr ""
 
 #: src/dopewars.c:308
@@ -537,6 +552,9 @@ msgstr "liste des trucs que tu peux arreter de faire"
 msgid "Number of things which you can stop to do"
 msgstr "nombre de trucs que tu peux arreter de faire"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -609,6 +627,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -629,18 +651,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -657,6 +683,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -673,6 +700,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -739,6 +768,7 @@ msgid ""
 "out!"
 msgstr "de la bonne herbe d'Amsterdam vient d'arriver en masse"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -771,6 +801,7 @@ msgstr "Message"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -781,6 +812,10 @@ msgstr "Les flics ont mis la main sur un gros stock de %tde !"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les junkies achetent %tde hors de prix !"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "`Vivons dans l'extase de l'illimité`"
@@ -908,17 +943,17 @@ msgstr "La telepathie existe ! Regardez les vibrations."
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -926,115 +961,132 @@ msgid ""
 msgstr ""
 "La config peut seulement etre changee quand aucun joueur n'est connecte."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit etre entre 1 et %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Structure liste redimentionnee a %d elements\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1086,7 +1138,7 @@ msgstr ""
 "Church Wars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1096,27 +1148,30 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1161,7 +1216,7 @@ msgstr ""
 "Church Wars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1171,7 +1226,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1181,7 +1236,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1191,7 +1246,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1199,7 +1254,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1211,6 +1266,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Français Traduction           Leonard"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1220,7 +1276,8 @@ msgstr "D O P E W A R S"
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
-"Base sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation d'un"
+"Base sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation "
+"d'un"
 
 #: src/curses_client/curses_client.c:341
 msgid ""
@@ -1285,7 +1342,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Critiques deconsctructives    James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Pour information sur les options en ligne de commande, taper Church Wars -h"
 
@@ -1295,8 +1354,11 @@ msgid ""
 msgstr ""
 "a votre prompt UNIX. Cela va afficher l'aide sur les options disponibles."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Merci d'entrer le nom du host et le port du server Church Wars:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1311,6 +1373,7 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le metaserver..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1350,6 +1413,10 @@ msgstr "Commentaire: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>uivant server; P>recedent server; C>choisir ce serveur..."
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SPC"
@@ -1381,15 +1448,21 @@ msgid "Password: "
 msgstr ""
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Patientez... tentative de contacter le serveur Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Ne peux pas demarrer Church Wars en multi-joueur"
 
 #: src/curses_client/curses_client.c:720
@@ -1397,7 +1470,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Woulez vous... C>connecter a un hote/port different"
 
 #: src/curses_client/curses_client.c:729
@@ -1405,24 +1479,30 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "               L>ister les serveurs sur le meta, et en selectionner un"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "               Q>uitter (vous pouvez alors demarrer un server"
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr "            ou J>ouer en solo ? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLQJ"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Ou ca, mec ? "
 
@@ -1430,6 +1510,8 @@ msgstr "Ou ca, mec ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1443,6 +1525,7 @@ msgstr "Que veux tu laisser tomber? "
 msgid "How many do you drop? "
 msgstr "Combien d'unites tu laisses tomber? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Que souhaites tu acheter? "
@@ -1451,6 +1534,8 @@ msgstr "Que souhaites tu acheter? "
 msgid "What do you wish to sell? "
 msgstr "Que souhaites tu vendre? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1474,10 +1559,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Etes vous sur de vouloir quitter? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "ON"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nouveau nom: "
@@ -1490,17 +1576,18 @@ msgstr "Vous avez ete vire du serveur. Devient solo."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Devient solo"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitte la partie."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1511,7 +1598,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
@@ -1525,34 +1612,50 @@ msgstr "Malheureusement, qq d'autre utilise deja ton nom. Merci d'en changer"
 msgid "H I G H   S C O R E S"
 msgstr "H I G H   S C O R E S"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Tu n'as aucun %tde a vendre!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "T'en as aucun a vendre!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour porter plus de %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Tu n'as pas assez d'espace pour porter ce %tde"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Tu n'as pas assez de fric pour achter ce %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
@@ -1561,27 +1664,40 @@ msgstr "AVP"
 msgid "How much money do you pay back? "
 msgstr "Combien de fric tu rends ?"
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Tu n'as pas assez d'argent!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Tu veux D>eposer de l'argent, R>etirer des biftons, ou P>artir ?"
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRP"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent?"
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
@@ -1610,32 +1726,46 @@ msgstr "S: S'evader"
 msgid "Press any key..."
 msgstr "Appuyer sur une touche..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Statistiques"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Fric"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Sante"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banque"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Dette"
 
@@ -1644,6 +1774,8 @@ msgstr "Dette"
 msgid "Space %6d"
 msgstr "Espace %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
@@ -1652,6 +1784,10 @@ msgstr "%Tde %3d  Espace %6d"
 msgid "Trenchcoat"
 msgstr "Trenchcoat"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
@@ -1660,11 +1796,13 @@ msgstr "%/Stats: Drogues/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1675,10 +1813,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1691,441 +1832,492 @@ msgstr "Aucun autre joueur est en ligne en ce moment!"
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "He man, les prix du %tde sont la:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer SIGWINCH interrupt handler!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "He mec, c'est quoi ton nom? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", P>arler, R>reveiller"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", L>lister"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", dEplacer"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "C>combat, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "R>este sur place, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "S>e sauver, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>eal %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCEQ"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "DSCRQ"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "A qui tu veux parler en prive ? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Parler: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Rejouer? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Jeu"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Jeu/_Nouveau..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Jeu/_Quitter"
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Liste"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Liste/_Joueurs..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Liste/_Scores..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Liste/_Inventaire..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Aide"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Aide/_A propos..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Avertissement"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Message"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Abandonner cette partie ?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Quitter la partie"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Commencer une nouvelle partie"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fermer"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connection au server perdue - Mode solo"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez ete vire du serveur. Devient solo."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Le serveur est mort. Devient solo"
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Bouger vers %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "High Scores"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "High Score corrompu!"
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Se battre"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_Vendre %Tde"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Combattre"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Rester sur place"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Courrir"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Combat: Salopes/%d %tde"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Sante: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Vous"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Salopes/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Se deplacer a un autre endroit"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "at %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Vous portez en ce moment %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Espace disponible: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Vous pouvez acheter %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Acheter"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Vendre"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Laisser tomber"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "Acheter combien ?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "Vendre combien ?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "Laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Acheter %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Vendre %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Laisser tomber %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Oui"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Non"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Attaquer"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_S'evader"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Question"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Espace"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Français Traduction"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Vente de camme et Recherche"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testeur de jeu"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Testeur extensif du jeu"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2152,7 +2344,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2161,121 +2354,147 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars est diffuse sous la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Preteur window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Fric: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "banque: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Rembourser:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Deposer"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirer"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Tout payer"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Liste des joueurs"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Parler au joueur(s)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Parler a tout les joueurs"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Message:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde ici"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde transporte"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Changer Nom"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 "Malheureusement, quelqu'un d'autre utilise deja ton nom. Merci de le changer"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Armurerie window title/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2402,12 +2621,14 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
-msgstr ""
+#, fuzzy
+msgid "Name of one bitch"
+msgstr "Nom du bar"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
-msgstr ""
+#, fuzzy
+msgid "Name of several bitches"
+msgstr "Nom du Preteur a Gages"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -2485,6 +2706,7 @@ msgstr "_Aide"
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
@@ -2497,20 +2719,28 @@ msgstr "Status: Attente de l'utilisateur"
 msgid "Connection closed by remote host"
 msgstr ""
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2520,17 +2750,22 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr "Salut mec, quel est ton _nom?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Commencer un jeu en solo"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
+#, fuzzy
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
@@ -2540,33 +2775,40 @@ msgstr ""
 "# du fichier de config etc...\n"
 "\n"
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "serveur Church Wars"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "Le serveur has terminated."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "Church Wars AI"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr "AS"
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2605,46 +2847,49 @@ msgstr ""
 "Valid variables are listed below:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServeur: %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) exceeded - dropping connection"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2652,7 +2897,9 @@ msgstr ""
 "Desole, ce serveur a une limite atteinte de 1 joueurMerci de re-essayer "
 "votre connection plus tard."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2661,55 +2908,63 @@ msgstr ""
 "Desole, ce serveur a une limite atteinte de %d joueursMerci de re-essayer "
 "votre connection plus tard."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s est maintenant %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: deplacement vers %s INTERDIT"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Votre temps de deal est termine"
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: deplacement vers %s INTERDIT"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Maintenance du pid file %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Cannot create pid file %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr ""
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -2717,114 +2972,119 @@ msgstr ""
 "Church Wars server version %s pret et attendant les connections\n"
 "sur le port %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Cannot install SIGUSR1 interrupt handler!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Cannot install SIGHUP interrupt handler!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Cannot install SIGINT interrupt handler!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Cannot install SIGTERM interrupt handler!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Ne peut pas installer le truc qui s'occupe des pipes!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Utilisateurs en ligne:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Aucun utilisateur en ligne.\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Pousser %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Cet user n'existe pas.\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s tue\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Commande inconnue - Essaye \"help\" pour l'aide...\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "recu une connection de %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "Le serveur has terminated."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s quittes le serveur!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
+"Church Wars server version %s pret et attendant les connections\n"
+"sur le port %d."
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr ""
 
@@ -2832,31 +3092,43 @@ msgstr ""
 msgid "Command:"
 msgstr "Command:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Cannot create pid file %s: %s"
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2869,175 +3141,182 @@ msgstr ""
 "repertoire\n"
 "ou specifiez un autre fichier et chemin d'acces avec la commande -f."
 
-#: src/serverside.c:1992
+#: src/serverside.c:2005
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Impossible d'ecrire le fichier des high scores %s"
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Felicitations! Vous etes dans les high scores!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "T'as meme pas reussi a etre dans les Scores!"
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Impossible d'ecrire le fichier des high scores %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La dame a cote de vous dans le metro dit,^ \"%s\"%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (au moins, tu -penses- que c'est ce qu'elle a dit)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Tu entends quelqu'un jouer %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Voulez-vous visiter %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Voulez vous engager une %tde pour %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est deja la!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les flics ne peuvent pas attaquer d'autres flics!"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont deja en train de se battre!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont deja dans des bastons separees!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bagarre - pas de flingue a utiliser!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Tu payes le docteur %P pour te recoudre?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu as ete attaque dans le metro!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Tu rencontres un ami! Il te donne %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Tu rencontre un ami! Tu lui donne %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aleatoire."
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens des flics te courent apres sur %d blocs! Tu laisses tomber %tde! "
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Tu trouves %d %tde sur un mec mort dans le metro!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta maman a fait des gateaux avec un peu de ton %tde! Ils sont excellents!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ca a l'air bon! Tu la fume?"
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Tu veux acheter une trenchcoat plus grande pour %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^He! mec! Je t'aiderais a porter tes %tde pour un petit %P. Oui ou non ?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Tu veux acheter un %tde pour %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3045,29 +3324,29 @@ msgstr ""
 "Tu a hallucine pendant trois jours dans le plus trip le plus sauvage "
 "que^t'aurais jamais imagine! Ensuite tu t'est mis a parler avec tes oreilles!"
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard - %s vient juste de partir!"
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Joueur enleve a cause d'inactivite trop longue"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Joueur enleve a cause de temps de connection trop long"
 
@@ -3084,6 +3363,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3148,6 +3429,7 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3188,150 +3470,150 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Tu cours ?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Tu cours ou combat ?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "leur armement fait pitie"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "legerement armes"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "relativement bien armes"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "lourdement armes"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "armes jusqu'aux dents"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - te courent apres, mec!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s and %d %tde - %s - te courent apres, mec!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s est arrive avec %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s reste debout et le prend."
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Tu restes la comme un pantin."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s essaye de se barrer, mais echoue."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "Pannique! Tu peux pas te sauver!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s s'est barre a %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s se sont echappes!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "Tu t'est echappe!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Flingues recharges..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s tire a %s... et manque son coup!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te tire dessus.. et loupe!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "Tu manques %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s tire %s mort"
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s tire a %s et tue une %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s est %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te tire dessus... et tue une %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "%s te troue, mec!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "Tu as bute %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Tu touches %s, et tue une %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "Tu touches %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr "Tu trouves %P sur le corps!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr " Tu cherches le corps!"
 
@@ -3340,113 +3622,127 @@ msgstr " Tu cherches le corps!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
 #, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
 msgstr ""
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Impossible d'ecrire le fichier des high scores %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Cannot create pid file %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3499,94 +3795,95 @@ msgstr "Utiliser nom %s\n"
 msgid "Players in this game:-\n"
 msgstr "Joueurs dans ce jeu:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s joint le jeu.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s a quitte le jeu.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Deplacement de %tde avec %P en cash et %P en dettes\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "joueur IA tue. Teminating normallement.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Temps de jeu termine. Quitte le jeu.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "Joueur IA jette du serveur.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "Le serveur has terminated.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendre %d %tde a %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Acheter %d %tde a %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Acheter un %tde pour %P au magazin de flingues\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dettes de %P payees au preteur a gages\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Le preteur a gages est situe a %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "L'armurerie est situee a %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Le bar est situe a %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "La banque est situee a %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vous osez vous appeller des dealers?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Un singe apprivoise pourrait faire mieux..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "Tu penses que t'est suffisament dur pour dealer avec des mecs comme moi?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzzz... tu vends des bombons ou quoi?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Je crois que je vais devoir te buter pour ton propre bien."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3596,17 +3893,32 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en utilisant --enable-networking avec le script de config."
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "A qui tu veux parler en prive ? "
+
+#~ msgid "Talk: "
+#~ msgstr "Parler: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "serveur Church Wars"
+
+#~ msgid "dopewars AI"
+#~ msgstr "Church Wars AI"
 
 #~ msgid ""
 #~ "\n"
@@ -3648,7 +3960,6 @@ msgstr ""
 
 #~ msgid "Metaserver"
 #~ msgstr "Metaserver"
-
 
 #~ msgid "gun"
 #~ msgstr "flingue"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars 1.5.10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2007-10-25 16:37+1300\n"
 "Last-Translator: François Marier <francois@debian.org>\n"
 "Language-Team: French\n"
@@ -14,129 +14,144 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "le prêteur à gages"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "la Caisse populaire"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Port réseau auquel se connecter"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur auquel se connecter"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Message de bienvenue du serveur pour aujourd'hui"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Adresse réseau du serveur"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "VRAI si un serveur SOCKS est nécessaire pour la connexion réseau"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "VRAI si un numéro d'identification est nécessaire pour SOCKS4"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si non-vide, le nom d'utilisateur à utiliser pour SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "Le nom d'hôte d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "Le numéro de port d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La version du protocole SOCKS à utiliser (4 ou 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Nom d'utilisateur pour l'authentification SOCKS5"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Mot de passe pour l'authentification SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "VRAI si le serveur doit se rapporter à un méta-serveur"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nom du méta-serveur auquel envoyer/recevoir les détails du serveur"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Description du serveur, rapportée au méta-serveur"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si VRAI, le serveur est réduit dans le System Tray"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Si VRAI, le serveur roule en arrière-plan"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "La commande utilisée pour lancer votre fureteur"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -541,6 +556,9 @@ msgstr "Liste des choses que vous pouvez arrêter de faire"
 msgid "Number of things which you can stop to do"
 msgstr "Nombre de choses que vous pouvez arrêter de faire"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -613,6 +631,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -633,18 +655,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -661,6 +687,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -677,6 +704,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -745,6 +774,7 @@ msgstr ""
 "Les récoltes des serres hydroponiques dépassent les attentes, c'est le temps "
 "de fumer!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -777,6 +807,7 @@ msgstr "Message"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -787,6 +818,10 @@ msgstr "Les boeufs ont mis la main sur un gros stock de dope (%tde) !"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
@@ -919,17 +954,17 @@ msgstr "La télépathie existe ! Check les vibrations."
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Impossible de lire le fichier de configuration %s (ligne %d)"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -939,68 +974,83 @@ msgstr ""
 "joueur n'est connecté.  Attendez que tous les joueurs se déconnectent\n"
 "ou éjecter-les avec la commande push ou kill et essayer à nouveau."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit être entre 1 et %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d!"
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Liste de structure redimentionée à %d éléments\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "valeur booléenne attendue (0, FALSE, 1, TRUE)"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1008,7 +1058,7 @@ msgstr ""
 "  -u, --plugin=FICHIER    utiliser le plugin de son \"FICHIER\"\n"
 "                            "
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1016,42 +1066,44 @@ msgstr ""
 "  -u fichier   utiliser le plugin de son \"fichier\"\n"
 "\t          "
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1075,9 +1127,11 @@ msgstr ""
 "  -b, --no-color,        \"noir et blanc\" - n'utilise pas les couleurs\n"
 "      --no-colour          (par défaut, les couleurs sont utilisées\n"
 "                           si le terminal les supporte)\n"
-"  -n, --single-player    ne pas se connecter aux autres serveurs Church Wars\n"
+"  -n, --single-player    ne pas se connecter aux autres serveurs Church "
+"Wars\n"
 "                           (i.e. mode joueur unique)\n"
-"  -a, --antique          \"antique\" Church Wars - rester proche de la version\n"
+"  -a, --antique          \"antique\" Church Wars - rester proche de la "
+"version\n"
 "                           originale (cette option désactive les\n"
 "                           possibilités réseau)\n"
 "  -f, --scorefile=FILE   spécifier un fichier a utiliser pour la table des\n"
@@ -1109,7 +1163,7 @@ msgstr ""
 "  -C, --convert=FILE     convertir un vieux fichier de scores au nouveau \n"
 "                           format\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1121,31 +1175,34 @@ msgstr ""
 "  -h, --help             affiche cet écran d'aide\n"
 "  -v, --version          affiche la version et quitte\n"
 "\n"
-"Church Wars est un Copyright (C) Ben Webb 1998-2022, et est distribué sous la "
-"GNU GPL\n"
+"Church Wars est un Copyright (C) Ben Webb 1998-2022, et est distribué sous "
+"la GNU GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1187,7 +1244,7 @@ msgstr ""
 "scores au nouveau format\n"
 "  -A       se connecte au serveur local pour l'administration\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1199,10 +1256,11 @@ msgstr ""
 "  -h       affiche cet écran d'aide\n"
 "  -v       affiche la version et quitte\n"
 "\n"
-"Church Wars est un Copyright (C) Ben Webb 1998-2022, et distribué sous GNU GPL\n"
+"Church Wars est un Copyright (C) Ben Webb 1998-2022, et distribué sous GNU "
+"GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1212,7 +1270,7 @@ msgstr ""
 "--enable-curses-client comme configuration, ou utiliser un client\n"
 "graphique (si disponible) à la place!\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1222,7 +1280,7 @@ msgstr ""
 "--enable-gui-client comme configuration, ou utiliser un client\n"
 "curses à la place!\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1233,7 +1291,7 @@ msgstr ""
 "fonctionner en mode serveur. Recompilez avec l'option --enable-networking\n"
 "dans le script configure.\n"
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1248,6 +1306,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Traduction québécoise         François Marier"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1257,7 +1316,8 @@ msgstr "D O P E W A R S"
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
-"Basé sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation d'un"
+"Basé sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation "
+"d'un"
 
 #: src/curses_client/curses_client.c:341
 msgid ""
@@ -1323,7 +1383,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Critiques non-consctructives  James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Pour afficher l'aide sur les options disponible sur la ligne de commande,"
 
@@ -1332,8 +1394,11 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "tapez Church Wars -h sur votre prompt UNIX."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Merci d'entrer le nom de l'hôte et le port du serveur:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1348,6 +1413,7 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le méta-serveur..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1387,6 +1453,10 @@ msgstr "Commentaire: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>erveur suivant; P>récedent; C>hoisir ce serveur... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "SPC"
@@ -1418,15 +1488,21 @@ msgid "Password: "
 msgstr "Mot de passe: "
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Patientez... tentative de contacter le serveur Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Impossible d'obtenir les détails du méta-serveur"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Ne peux pas démarrer Church Wars en mode multi-joueurs"
 
 #: src/curses_client/curses_client.c:720
@@ -1434,7 +1510,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Voulez-vous... C>onnecter à un hôte/port différent"
 
 #: src/curses_client/curses_client.c:729
@@ -1442,8 +1519,9 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "            L>iste des serveurs sur le méta, et en sélectionner un"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 "            Q>uitter (vous pouvez alors démarrer un server en             "
 "tapant \"Church Wars -s\")"
@@ -1452,16 +1530,21 @@ msgstr ""
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ouer en solo ? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLQJ"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Où ça, man ? "
 
@@ -1469,6 +1552,8 @@ msgstr "Où ça, man ? "
 msgid "%/Location display/%tde"
 msgstr "%/Affichage de l'endroit/%tde"
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1482,6 +1567,7 @@ msgstr "Qu'est-ce que tu veux crisser à terre? "
 msgid "How many do you drop? "
 msgstr "Combien d'unités veux-tu crisser à terre? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Qu'est-ce que tu veux acheter? "
@@ -1490,6 +1576,8 @@ msgstr "Qu'est-ce que tu veux acheter? "
 msgid "What do you wish to sell? "
 msgstr "Qu'est-ce que tu veux vendre? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1513,10 +1601,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Êtes-vous sur de vouloir quitter? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "ON"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nouveau nom: "
@@ -1529,17 +1618,18 @@ msgstr "La connexion avec le serveur a été terminée. Mode solo."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Mode solo"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitté la partie."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1550,7 +1640,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Endroit présent/%tde"
 
@@ -1564,34 +1654,50 @@ msgstr "Malheureusement, quelqu'un d'autre utilise déjà ton nom. Change-le."
 msgid "H I G H   S C O R E S"
 msgstr "M E I L L E U R S   S C O R E S"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "T'as pas de %tde à vendre!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "T'en n'as pas à vendre!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour transporter plus de %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "T'as pas assez d'espace pour transporter: %tde"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "T'as pas assez de cash pour acheter: %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "AVP"
@@ -1600,28 +1706,41 @@ msgstr "AVP"
 msgid "How much money do you pay back? "
 msgstr "Combien de cash tu rends ? "
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "T'as pas assez de cash!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 "Tu veux D>époser de l'argent, R>etirer de l'argents, ou S>acrer ton camp ? "
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Combien d'argent? "
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Ya pas autant d'argent dans la banque..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "O:Oui"
@@ -1650,32 +1769,46 @@ msgstr "S:Se sauver"
 msgid "Press any key..."
 msgstr "Pèse sur une touche..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Messages (-/+ avancer/reculer)"
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Statistiques"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Cash"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Santé"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banque"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Dette"
 
@@ -1684,6 +1817,8 @@ msgstr "Dette"
 msgid "Space %6d"
 msgstr "Espace %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
@@ -1692,6 +1827,10 @@ msgstr "%Tde %3d  Espace %6d"
 msgid "Trenchcoat"
 msgstr "Manteau"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
@@ -1700,11 +1839,13 @@ msgstr "%/Stats: Drogues/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1715,10 +1856,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1731,441 +1875,492 @@ msgstr "Aucun autre joueur est en ligne en ce moment!"
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Heille man, les prix du %tde sont la:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer le handleur d'interruptions SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Heille man, comment tu t'appelles ? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", P>lacotter, R>éveiller"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", L>ister"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", S>'en aller ailleurs"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "C>ombattre, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "R>ester sur place, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "T>e sauver, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>endre des %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCSQ"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "VTCRQ"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "À qui que tu veux parler en privé ? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Parler: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Jouer à nouveau? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Jeu"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Jeu/_Nouveau..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Jeu/_Abandonner..."
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Jeu/Activer les _sons"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Jeu/_Quitter"
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Liste"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Liste/_Joueurs..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Liste/_Scores..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Liste/_Inventaire..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Aide"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Aide/_À propos..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Attention"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Erreur"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Message"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Abandonner cette partie ?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Quitter la partie"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Commencer une nouvelle partie"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Abandonner la partie"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fermer"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Connexion au serveur perdue - Mode solo"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Vous avez été expulsé(e) du serveur. Mode solo."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Le serveur est mort. Mode solo"
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "S'en aller vers %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Meilleurs scores"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "Le fichier des meilleurs scores est corrompu!"
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Se battre"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_Vendre de la dope"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Combattre"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Rester sur place"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Décrisser"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Combat: Putes/%d %tde"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Restant/es)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Mort/es)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Santé:  %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Toi"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Putes/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr "%/Inventaire nom de la drogue/%tde"
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr "%/Inventaire nom du gun/%tde"
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Se déplacer à un autre endroit"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr "Endroit vers où se déplacer"
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "à %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Tu transportes en ce moment %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Espace disponible: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Tu peux acheter %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Acheter"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Vendre"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Laisser tomber"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr "%/Vendre nom de la drogue/%tde"
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "En acheter combien ?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "En vendre combien ?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "En laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Acheter %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Vendre %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Laisser tomber %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Oui"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Non"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Attaquer"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_S'enfuir"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Question"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Espace"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Traduction québécoise"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Icônes et graphiques"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Effets sonores"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Vente de drogue et recherche"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testeurs de jeu"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Testeurs maniaques du jeu"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2192,7 +2387,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2201,121 +2397,147 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars est distribué sous la licence GNU GPL\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Prêteur window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Vous devez entrer un montant positif!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Argent: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banque: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Rembourser:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Déposer"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirer"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Tout payer"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Liste des joueurs"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Parler au(x) joueur(s)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Parler à tous les joueurs"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Message:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Envoyer"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Quantité"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde en vente/demande ici"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde transporté(e)s"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Changer de nom"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr ""
 "Malheureusement, quelqu'un d'autre utilise déjà ton nom.Merci de le changer:-"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Marchand d'armes window title/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2442,11 +2664,13 @@ msgid "Symbol prefixes prices"
 msgstr "Le symbole monétaire précède les prix"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+#, fuzzy
+msgid "Name of one bitch"
 msgstr "Nom d'un clerc"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+#, fuzzy
+msgid "Name of several bitches"
 msgstr "Nom de plusieurs clercs"
 
 #: src/gui_client/optdialog.c:903
@@ -2525,6 +2749,7 @@ msgstr "A_ide"
 msgid "You can't start the game without giving a name first!"
 msgstr "Impossible de débuter une partie sans se nommer!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nouvelle partie"
@@ -2537,20 +2762,28 @@ msgstr "Status: En attente de l'utilisateur"
 msgid "Connection closed by remote host"
 msgstr "Connexion terminée par l'autre partie"
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Ne peut pas se connecter (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Connecté au serveur SOCKS %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: En cours d'authentification avec le serveur SOCKS"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2560,17 +2793,22 @@ msgstr "Status: En train de demander à SOCKS d'établir la connexion avec %s...
 msgid "Greetings Trader, what's your _name?"
 msgstr "Heille man, c'est quoi ton _nom?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Débuter la partie en mode solo"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
+#, fuzzy
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
@@ -2580,33 +2818,40 @@ msgstr ""
 "# fichier de configuration et autre...\n"
 "\n"
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "Serveur Church Wars"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "Serveur Church Wars en train de terminer."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "IA Church Wars"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr "AS"
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2647,53 +2892,59 @@ msgstr ""
 "Les variables acceptées sont:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Impossible de se connecter au méta-serveur à %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServeur: %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr "Connexion au méta-serveur trop fréquente, attente du prochain timeout"
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "En attente de la connexion au méta-serveur à %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
+#, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 "Vous semblez utiliser une très vieille version (1.4.x) du jeu.  Cette "
 "versionrisque de fonctionner, mais plusieurs des nouvelles fonctionalités ne "
-"serontpas supportées.  Obtenez la dernière version sur le site web de "
-"Church Wars: https://Church Wars.sourceforge.io/"
+"serontpas supportées.  Obtenez la dernière version sur le site web de Church "
+"Wars: https://Church Wars.sourceforge.io/"
 
-#: src/serverside.c:307
+#: src/serverside.c:308
+#, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 "Votre version de Church Wars est trop vieille pour supporter les "
 "fonctionalitésde ce serveur.  Pour une meilleure expérience, obtenez la "
-"dernière versionsur le site web de Church Wars: https://Church Wars.sourceforge.io/"
+"dernière versionsur le site web de Church Wars: https://Church Wars."
+"sourceforge.io/"
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Nombre maximum de clients (%d) dépassé - annulation de la connexion"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2701,7 +2952,9 @@ msgstr ""
 "Désolé, ce serveur a une limite d'un seul joueur et cette limite a été "
 "^atteinte. Merci de réessayer plus tard."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2710,130 +2963,142 @@ msgstr ""
 "Désolé, ce serveur a une limite de %d joueurs et cette limite a été "
 "^atteinte. Merci de réessayer plus tard."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s est maintenant connu sous le nom de %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: déplacement vers %s INTERDIT"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Votre temps de dealage est terminé"
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: déplacement vers %s INTERDIT"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Message inconnu: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Maintenance du pid file %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Impossible de créer le fichier pid %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr "Impossible de créer un socket d'écoute (%s) pour le serveur"
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr "Impossible de s'attacher au port %u (%s)"
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr "Impossible de lire sur le socket réseau"
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
-msgstr "Serveur Church Wars version %s attendant les connexions sur le port %d."
+msgstr ""
+"Serveur Church Wars version %s attendant les connexions sur le port %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGUSR1!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGHUP!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGINT!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGTERM!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Impossible d'installer le handleur de pipeline!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Fichier de configuration enregistré comme %s\n"
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Utilisateurs en ligne:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Aucun utilisateur en ligne!\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Intimidation de %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Cet utilisateur n'existe pas.\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s tué\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Commande inconnue - essayez \"help\" pour l'aide...\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "connexion reçu de %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "Serveur Church Wars en train de terminer."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s quittes le serveur!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -2841,41 +3106,41 @@ msgstr ""
 "Impossible d'installer le socket de domaine UNIX pour les "
 "connexionsadministratives - vérifiez les permissions sur /tmp!"
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
-"Serveur Church Wars version %s en attente de commandes d'administration.Essayez "
-"\"help\" pour l'aide."
+"Serveur Church Wars version %s en attente de commandes d'administration."
+"Essayez \"help\" pour l'aide."
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Nouvelle connexion administrative"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Commande administrative: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Connexion administrative terminée"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr "Impossible d'obtenir le status du service NT"
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr "Impossible d'envoyer un message de notification du service"
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr "Impossible d'installer un handleur de service"
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr "Impossible de démarrer le service NT"
 
@@ -2883,12 +3148,26 @@ msgstr "Impossible de démarrer le service NT"
 msgid "Command:"
 msgstr "Commande:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"Impossible de créer une copie (%s) du\n"
+"fichier des scores: %s"
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Impossible de lire le fichier des meilleurs scores: %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -2897,7 +3176,7 @@ msgstr ""
 "Le fichier des scores (%s) a été converti au nouveau format.\n"
 "Une copie de l'ancien fichier a été créée: %s.\n"
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2906,12 +3185,12 @@ msgstr ""
 "Impossible de créer une copie (%s) du\n"
 "fichier des scores: %s"
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2924,13 +3203,13 @@ msgstr ""
 "répertoire\n"
 "ou specifiez un autre fichier et chemin d'accès avec la commande -f."
 
-#: src/serverside.c:1992
-#, c-format
+#: src/serverside.c:2005
+#, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 "%s n'a pas l'air d'être un fichier de\n"
@@ -2939,17 +3218,18 @@ msgstr ""
 "nouveau format en utilisant la commande:\n"
 "    Church Wars -C %s"
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
+#, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 "Erreurs lors de la lecture du fichier de configuration.  Certaines\n"
 "préférences pourraient ne pas fonctionner correctement.  Voir le\n"
 "fichier \"Church Wars-log.txt\" pour plus de détails."
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -2959,126 +3239,133 @@ msgstr ""
 "préférences pourraient ne pas fonctionner correctement.  Portez attention\n"
 "aux messages figurant sur la sortie standard pour plus de détails."
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Félicitations! Vous êtes dans les meilleurs scores!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "T'as même pas réussi à être dans les scores!"
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Impossible d'écrire le fichier des meilleurs scores %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La madame à côté de toi dans le métro te dit,^ \"%s\"%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (du moins, tu -penses- que c'est ça qu'elle a dit)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Tu entends quelqu'un jouer %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Veux-tu visiter %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Veux-tu engager une %tde pour %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est déjà là!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "Pas de boeufs ou de guns"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les boeufs ne peuvent pas attaquer d'autres boeufs!"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont déjà en train de se battre!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont déjà dans des batailles séparées!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bataille - pas de gun à utiliser!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Vas-tu payer le docteur %P pour te ramancher?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu t'es fait pété la gueule dans le métro!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "T'as rencontré un chum, il t'a donné %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "T'as rencontré ton meilleur chum pis tu lui a donné %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aléatoire."
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens de police te courent après sur %d blocs! T'as échappé: %tde!"
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "T'as trouvé %d %tde sur un gars mort dans le métro!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta mère a fait des gâteaux avec un peu de %tde! Y'étaient vraiment bons!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3086,26 +3373,26 @@ msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ça a l'air bon! Veux-tu la "
 "fumer? "
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Veux-tu acheter un manteau plus gros %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Heille man! J'pourrais t'aider à transporter tes %tde pour un petit %P. "
 "Qu'est-ce que t'en dis ?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Veux-tu acheter un %tde pour %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3114,29 +3401,29 @@ msgstr ""
 "^jamais pu imaginer! Ensuite t'es mort parce que ton cerveau s'est "
 "désintégré!"
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard, %s vient juste de partir!"
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Les boeufs t'ont vu jeter ton stock (%tde)!"
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Envoi des mise à jours au méta-serveur..."
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr "Envoi du rappel au méta-serveur..."
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Joueur éjecté à cause d'une période d'inactivité trop longue"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Joueur éjecté à cause d'un temps de connexion trop long"
 
@@ -3153,6 +3440,8 @@ msgstr "La connexion est brisée à cause d'un tampon plein"
 msgid "Internal error code %d"
 msgstr "Code d'erreur interne: %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock n'a pas été correctement initialisé"
@@ -3217,6 +3506,7 @@ msgstr "Protocole non-supporté"
 msgid "Socket type not supported"
 msgstr "Type de socket non-supporté"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Impossible de trouver l'hôte"
@@ -3257,150 +3547,150 @@ msgstr "Mauvaise réponse du méta-serveur \"%s\""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Tu cours ?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Courir ou combattre ?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "leurs guns font pitié"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "légèrement armés"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "relativement bien armés"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "lourdement armés"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "armés jusqu'aux dents"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - te courent après, man!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s et %d %tde - %s - te courent après, man!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s est arrivé avec %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s reste debout et le prend."
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Tu restes là comme une momie."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s essaye de décrisser, mais échoue."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "Fuck! Tu peux pas te sauver!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s s'est enfuit %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s se sont échappés!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "Tu t'es échappé!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Guns rechargés..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s tire sur %s... et manque son coup!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te tire dessus.. et rate!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "Tu as manqué %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s tue %s par balle"
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s tire sur %s et tue une %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s est %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te tire dessus... et tue une %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "%s t'a pogné, man!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "T'as achevé %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Tu pognes %s, et tue une %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "Tu pognes %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr " Tu trouves %P sur le corps!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr " Tu fouilles le corps!"
 
@@ -3409,97 +3699,100 @@ msgstr " Tu fouilles le corps!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Impossible d'initialiser WinSock (%s)!"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr "Échec général du serveur SOCKS"
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Connexion refusée par les règles SOCKS"
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Connexion réseau impossible"
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Connexion à l'hôte impossible"
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Connexion refusée"
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: Le TTL a expiré"
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Commande non-supportée"
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Type d'adresse non-supporté"
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr "Le serveur SOCKS a réjeté toutes les méthodes offertes"
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr "Le type de l'adresse SOCKS retournée est inconnu"
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr "Échec d'authentification SOCKS"
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "Authentification SOCKS annulée par l'utilisateur"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Requête rejetée ou échouée"
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rejeté - impossible de contacter identd"
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rejeté - identd rapporte un nom d'utilisateur différent"
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr "Code de réponse SOCKS inconnu"
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr "Code de version de réponse SOCKS inconnu"
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr "Version de serveur SOCKS inconnue"
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Code d'error SOCKS: %d"
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 "En train d'essayer d'établir la connexion avec le serveur Church Wars\n"
 "local en utilisant le socket UNIX %s...\n"
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
@@ -3507,19 +3800,30 @@ msgstr ""
 "Connexion établie.  Utilisez Ctrl-D pour terminer votre session.\n"
 "\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Impossible d'ouvrir le fichier %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Impossible d'ouvrir le fichier %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr "Impossible de déterminer le fichier de configuration local."
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Impossible d'ouvrir le fichier %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3574,93 +3878,94 @@ msgstr "Utiliser le nom %s\n"
 msgid "Players in this game:-\n"
 msgstr "Joueurs dans ce jeu:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s joint la partie.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s a quitté la partie.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Déplacement de %tde avec %P en cash et %P en dettes\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Le joueur IA a été tué. Fin normale.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Temps de jeu écoulé. La partie est terminée.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "Joueur IA éjecté du serveur.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "Le serveur a terminé.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendre %d %tde à %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Acheter %d %tde à %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Acheter un %tde pour %P au marchand d'armes\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dettes de %P payées au prêteur à gages\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Le prêteur à gages est situé à %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Le marchand d'armes est situé à %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Le bar est situé à %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "La banque est située à %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Tu oses te prendre pour un pusher?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Un singe apprivoisé pourrait faire mieux..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Tu penses que t'es assez toff pour dealer avec du monde comme moi?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzzz... tu vends des bonbons ou quoi?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Je crois que je vais devoir te tuer pour ton propre bien."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3670,12 +3975,12 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en passant --enable-networking au script de configuration."
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3683,6 +3988,24 @@ msgid ""
 msgstr ""
 "Le plugin sélectionné (\"%s\") est invalide.\n"
 "(%s est disponible, utilisation de \"%s\".)"
+
+#~ msgid "The command used to start your web browser"
+#~ msgstr "La commande utilisée pour lancer votre fureteur"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "À qui que tu veux parler en privé ? "
+
+#~ msgid "Talk: "
+#~ msgstr "Parler: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "Serveur Church Wars"
+
+#~ msgid "dopewars AI"
+#~ msgstr "IA Church Wars"
 
 #~ msgid ""
 #~ "\n"
@@ -3735,7 +4058,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Authentification SOCKS nécessaire"
-
 
 #~ msgid "gun"
 #~ msgstr "gun"

--- a/po/nn.po
+++ b/po/nn.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nn_new\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2003-08-31 22:58+0200\n"
 "Last-Translator: Åsmund Skjæveland <aasmunds@fys.uio.no>\n"
 "Language-Team: Norsk nynorsk <i18n-nn@lister.ping.uio.no>\n"
@@ -29,129 +29,144 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.0.2\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "Lånehaien"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "Banken"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Nettverksport å kopla til"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Namn på poengfila"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Namn på tenaren du vil kopla deg til"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Tenaren si velkomsthelsing for dagen"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Netverkadressa tenaren skal lytta på"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE viss ein SOCKS-tenar skal brukast i nettverket"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE viss numerisk brukar-ID skal brukast for SOCKS4"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Viss ikkje blank, brukarnamnet som skal brukast til SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "Vertsnamnet på SOCKS-tenaren"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "Portnummeret på SOCKS-tenaren"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Versjonen av SOCKS-protokollen du vil bruka (4 eller 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Brukarnamn for SOCKS5-autentisering"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Passord for SOCKS5-autentisering"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE viss tenaren skal rapportera til ein metatenar"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Metatenar å rapportera til/få tenar-detaljar frå"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Føretrukke vertsnamn på tenarmaskinen din"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentisering for LocalName med metatenaren"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Tenarskildring, rapportert til metatenaren"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Viss TRUE, vil tenaren minimera til systemtrauet"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Viss TRUE, så vil tenaren køyra i bakgrunnen"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "Kommandoen som startar nettlesaren din"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -275,7 +290,8 @@ msgstr "Lyd som blir spelt når våpna blir lada"
 
 #: src/dopewars.c:397
 msgid "Sound file played when an enemy cleric/deputy is killed"
-msgstr "Lyd som blir spelt når ein fiendtleg klerikar eller betjent blir drepen"
+msgstr ""
+"Lyd som blir spelt når ein fiendtleg klerikar eller betjent blir drepen"
 
 #: src/dopewars.c:400
 msgid "Sound file played when one of your clerics is killed"
@@ -551,6 +567,9 @@ msgstr "Liste over ting du kan stoppa for å gjera"
 msgid "Number of things which you can stop to do"
 msgstr "Tal på ting du kan stoppa for å gjera"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -623,6 +642,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -643,18 +666,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -671,6 +698,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -687,6 +715,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -753,6 +783,7 @@ msgid ""
 "out!"
 msgstr "Colombiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -785,6 +816,7 @@ msgstr "Melding"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -795,6 +827,10 @@ msgstr "Politiet gjorde eit kjempebeslag av %tde! Prisane er skyhøge!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Narkomane kjøper %tde til avsindige prisar!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Ville det ikkje vore festleg viss alle plutseleg kvekkte samtidig?"
@@ -921,17 +957,17 @@ msgstr "Vil du ha ein seigmann?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Kan ikkje tolka oppsettfila %s, linje %d"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Klarte ikkje å opna fila %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -941,68 +977,83 @@ msgstr ""
 " er logga på. Vent til alle spelarane har logga av, eller\n"
 "fjern dei med dytt- eller-drep-kommandoane, og prøv igjen."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks til %s array burde vore mellom 1 og %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s er %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s er %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s er %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s er «%s»\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] er %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s er { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kan ikkje vera mindre enn %d - ignorerer!"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kan ikkje vera større enn %d - ignorerer!"
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Forandra storleiken på strukturlista til %d element\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Venta ein boolsk verdi (ein av 0, FALSE, 1, TRUE)"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=TRUE"
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1010,7 +1061,7 @@ msgstr ""
 "  -u, --plugin=FIL        bruk lydmodul «FIL»\n"
 "                            "
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1018,42 +1069,44 @@ msgstr ""
 "  -u fil   bruk lydmodul «fil»\n"
 "\t          "
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s tilgjengeleg)\n"
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars versjon %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1108,7 +1161,7 @@ msgstr ""
 "  -C, --convert=FIL       konverter ei poengfil i gamalt format til det\n"
 "                            nye formatet\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1120,31 +1173,34 @@ msgstr ""
 "  -h, --help              vis denne hjelpeteksten\n"
 "  -v, --version           vis versjonsinformasjon og avslutt\n"
 "\n"
-"Church Wars er Copyright (C) Ben Webb 1998-2022, og er tilgjengeleg under GNU "
-"GPL\n"
+"Church Wars er Copyright (C) Ben Webb 1998-2022, og er tilgjengeleg under "
+"GNU GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1184,7 +1240,7 @@ msgstr ""
 "  -C fil   konverter ei poengfil i gamalt format til det nye formatet\n"
 "  -A       kopla til ein lokalt køyrande tenar for administrasjon\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1196,11 +1252,11 @@ msgstr ""
 "  -h,      vis denne hjelpeteksten\n"
 "  -v,      vis versjonsinformasjon og avslutt\n"
 "\n"
-"Church Wars er Copyright (C) Ben Webb 1998-2022, og er tilgjengeleg under GNU "
-"GPL\n"
+"Church Wars er Copyright (C) Ben Webb 1998-2022, og er tilgjengeleg under "
+"GNU GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1210,7 +1266,7 @@ msgstr ""
 "på nytt, med valet --enable-curses-client til configure,\n"
 "eller bruk ein grafisk klient (viss tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1221,7 +1277,7 @@ msgstr ""
 "configure, eller bruk tekstmodus-klienten (viss\n"
 "tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1229,7 +1285,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1244,6 +1300,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Norsk omsetjing               Åsmund Skjæveland"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1318,7 +1375,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Ukonstruktiv kritikk          James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr "For informasjon om kommandolinevala, skriv Church Wars -h på"
 
 #: src/curses_client/curses_client.c:375
@@ -1327,8 +1386,11 @@ msgid ""
 msgstr ""
 "Unix-kommandolina. Det viser ein hjelpetekst med dei tilgjengelege vala."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Skriv vertsnamnet og porten på ein Church Wars-tenar:"
 
 #: src/curses_client/curses_client.c:402
@@ -1343,6 +1405,7 @@ msgstr "Port:"
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Vent litt... prøver å kontakta metatenar..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1382,6 +1445,10 @@ msgstr "Kommentar: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>este tenar: F>ørre tenar: V>el denne tenaren"
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NFV"
@@ -1413,15 +1480,21 @@ msgid "Password: "
 msgstr "Passord:"
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Vent litt... prøver å kopla til Church Wars-tenar..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Kan ikkje henta metatenar-detaljar"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Kunne ikkje starta fleirspelar Church Wars"
 
 #: src/curses_client/curses_client.c:720
@@ -1429,7 +1502,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Vil du K>opla til ein bestemt Church Wars-tenar"
 
 #: src/curses_client/curses_client.c:729
@@ -1437,24 +1511,30 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "       L>ista tenarane på metatenaren, og velga ein"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "       A>vslutta (du kan starta ein tenar med «Church Wars -s»)"
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr "       eller S>pela åleine? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "KLAS"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Kor til, kompis? "
 
@@ -1462,6 +1542,8 @@ msgstr "Kor til, kompis? "
 msgid "%/Location display/%tde"
 msgstr "%/Liste over stader/%tde"
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1475,6 +1557,7 @@ msgstr "Kva vil du kasta? "
 msgid "How many do you drop? "
 msgstr "Kor mange vil du kasta? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Kva vil du kjøpa? "
@@ -1483,6 +1566,8 @@ msgstr "Kva vil du kjøpa? "
 msgid "What do you wish to sell? "
 msgstr "Kva vil du selja? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1506,10 +1591,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Er du viss på at du vil avslutta? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "JN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nytt namn:"
@@ -1522,17 +1608,18 @@ msgstr "Du har blitt dytta av tenaren. Byter til einspelar-modus."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Tenaren har stengt. Byter til einspelar-modus."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s blir med i spelet!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s har forlatt spelet."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1543,7 +1630,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Staden du er no/%tde"
 
@@ -1557,34 +1644,50 @@ msgstr "Diverre er det alt nokon som brukar «ditt» namn. Vér snill og byt det
 msgid "H I G H   S C O R E S"
 msgstr "P O E N G L I S T E"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du har ikkje noko %tde å selja!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Du har ikkje noko å selja!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du treng fleire %tde for å bera meir %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du har ikkje nok plass til å bera det %tde!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du har ikkje nok pengar til å kjøpa det %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Vil du K>jøpa, S>elja eller G>å?"
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSG"
@@ -1593,27 +1696,40 @@ msgstr "KSG"
 msgid "How much money do you pay back? "
 msgstr "Kor mykje pengar vil du betala tilbake?"
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Du har ikkje så mykje pengar!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Vil du S>etja inn pengar, T>a ut pengar, eller G>å?"
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "STG"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Kor mykje pengar?"
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Du har ikkje så mykje i banken."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "J:Ja"
@@ -1642,32 +1758,46 @@ msgstr "U:Unngå"
 msgid "Press any key..."
 msgstr "Trykk ein tast..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Meldingar (-/+ rullar opp/ned)"
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Status"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Kontantar"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tuf"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Helse"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Bank"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Gjeld"
 
@@ -1676,6 +1806,8 @@ msgstr "Gjeld"
 msgid "Space %6d"
 msgstr "Plass %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d plass %6d"
@@ -1684,6 +1816,10 @@ msgstr "%Tde %3d plass %6d"
 msgid "Trenchcoat"
 msgstr "Frakk"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%Tde"
@@ -1692,11 +1828,13 @@ msgstr "%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1707,10 +1845,13 @@ msgstr "%-22tde %3d"
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tuf"
@@ -1723,201 +1864,216 @@ msgstr "Ingen andre spelarar er logga på no."
 msgid "Players currently logged on:-"
 msgstr "Spelarar som er logga på:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hei du. Her kostar %tde:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kan ikkje installera SIGWINCH-avbrotshandsamar!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Namnet ditt:"
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "Vil du K>jøpa"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", S>elja"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", H>iva"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", sN>akka med alle, snakka med E>in"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", sjå L>ister"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", kJ>empa"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", R>eisa"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", eller A>vslutta? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Vil du "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "K>jempa, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "V>enta, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "R>ømma, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "S>elja %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "eller A>vslutta?"
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Mista sambandet til tenaren! Går tilbake til einspelar-modus."
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "KSHNELGJRA"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "SRKVA"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Lista opp kva? S>pelarar eller P>oeng? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Kven vil du snakka privat med? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Snakk: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Spela igjen? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Spel"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Spel/_Nytt ..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Spel/_Gje opp"
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Spel/Slå på _lyd"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Spel/_Avslutt"
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Lister"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Lister/_Spelarar..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Lister/_Poeng..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Lister/_Eignelutar..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Hjelp"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Hjelp/_Om ..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Åtvaring"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Feil"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Melding"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Gje opp denne runden?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Avslutt spelet"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Start nytt spel"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Gje opp dette spelet"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Eignelutar"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Steng"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Mista sambandet til tenaren - byter til einspelar-modus"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
@@ -1925,7 +2081,8 @@ msgstr ""
 "Du har blitt dytta av tenaren.\n"
 "Byter til einspelar-modus."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
@@ -1933,235 +2090,270 @@ msgstr ""
 "Tenaren har avslutta.\n"
 "Byter til einspelar-modus."
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Reiser til %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Poengtavle"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "Poengtavlefila er øydelagt!"
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Kjemp"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_Sel %tuf"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Kjemp"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Vent"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Røm"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr "%/Kamp: Horer/%d %tuf"
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Ute av spelet)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Daud)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Helse: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "Du"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/GTK Stats: Horer/%Tuf"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr "Narkotika"
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr "Våpen"
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Reis til plass:"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr "%/Plass å reisa til/%tde"
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr "_%c. %tde"
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "for %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "No har du på deg %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Ledig plass: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Du har råd til %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Kjøp"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Sel"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Hiv"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr "%tuf"
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "Kjøpa kor mange?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "Selja kor mange?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "Hiva kor mange?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Avbryt"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Kjøpa %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Selja %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Hiva %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Ja"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Nei"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Angrip"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Dukk unna"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Spørsmål"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Plass"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Norsk omsetjing"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Ikon og grafikk"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Lydar"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Dopsal og research"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Speltesting"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Grundig speltesting"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Konstruktiv kritikk"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Ukonstruktiv kritikk"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2188,7 +2380,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2197,120 +2390,146 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars er tilgjengeleg under GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Lånehai vindagustittel/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banknamn vindaugstittel/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Du må skriva inn ei positiv mengde pengar!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Du har ikkje så mykje pengar i banken."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Kontantar: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Gjeld: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Bank: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Betal tilbake:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Sett inn"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Ta ut"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Betal alt"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Spelarliste"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Snakk med spelar(ar)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Snakk med alle spelarane"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Melding:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Send"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Namn"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Pris"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Mengde"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Kjøp ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Sel"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Hiv <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tuf her"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tuf du har"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Byt namn"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Diverre, nokon andre bruker «ditt» namn. Ver snill og byt det:-"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Våpenforretning-tittel/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2437,11 +2656,13 @@ msgid "Symbol prefixes prices"
 msgstr "Symbol står før prisen"
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
+#, fuzzy
+msgid "Name of one bitch"
 msgstr "Namn på ein klerikar"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
+#, fuzzy
+msgid "Name of several bitches"
 msgstr "Namn på fleire klerikarar"
 
 #: src/gui_client/optdialog.c:903
@@ -2520,6 +2741,7 @@ msgstr "_Hjelp"
 msgid "You can't start the game without giving a name first!"
 msgstr "Du kan ikkje starta spelet utan å velja eit namn!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nytt spel"
@@ -2532,20 +2754,28 @@ msgstr "Status: Ventar på brukaren"
 msgid "Connection closed by remote host"
 msgstr "Sambandet vart stengd av nettverksverten."
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Kunne ikkje kopla til (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Kopla til SOCKS-tenar %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Status: Autentiserer mot SOCKS-tenar"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2555,17 +2785,22 @@ msgstr "Ber SOCKS om samband til %s..."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Namnet ditt:"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Start spel for ein spelar"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
+#, fuzzy
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
@@ -2575,33 +2810,40 @@ msgstr ""
 "# oppsettfilene og slikt.\n"
 "\n"
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "Church Wars-tenar"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "Church Wars-tenaren avsluttar."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "Datastyrt Church Wars-spelar"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr "AD"
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2643,53 +2885,58 @@ msgstr ""
 "Lovlege variablar er lista under:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Kunne ikkje kopla til metatenaren på %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metatenar  : %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr "Prøver for ofte å kopla til metatenaren - venter på neste tidsavbrot"
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Ventar på tilkopling til metatenaren på %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
+#, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 "Det ser ut til at du bruker ein svært gamal (versjon 1.4.x)-klient.^Dette "
-"vil truleg fungera, men mange av dei nye eigenskapane til^Church Wars vil ikkje "
-"vera støtta. Hent den nyaste versjonen frå^Church Wars-vevsida, http://Church Wars."
-"sourceforge.net/."
+"vil truleg fungera, men mange av dei nye eigenskapane til^Church Wars vil "
+"ikkje vera støtta. Hent den nyaste versjonen frå^Church Wars-vevsida, http://"
+"Church Wars.sourceforge.net/."
 
-#: src/serverside.c:307
+#: src/serverside.c:308
+#, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 "Åtvaring: Klienten din er for gamal til å støtta alle^ eigenskapane ved "
 "denne tenaren. For den fulle^ «opplevinga» bør du henta den siste versjonen "
 "av ^ Church Wars frå vevsida: https://Church Wars.sourceforge.io/"
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Gjekk over MaxClients (%d) - bryt sambandet"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2697,7 +2944,9 @@ msgstr ""
 "Denne tenaren har ei grense på 1 spelar, og denne grensa har blitt nådd. "
 "^Prøv att seinare."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2706,130 +2955,141 @@ msgstr ""
 "Denne tenaren har ei grense på %d spelarar, og denne grensa har blitt^nådd. "
 "Prøv att seinare."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s kallar seg no for %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: NEKTA reise til %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Pushetida di er ute."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: NEKTA reise til %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Ukjend melding: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Bruker pid-fil %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Kan ikkje laga pid-fil %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr "Kan ikkje laga (lytte-)sokkel (%s) til tenaren. Avbryt."
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr "Kan ikkje kopla til port %u (%s). Bryt av."
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr "Kan ikkje lytta til nettverkssokkel. Avbryt."
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "Church Wars-tenar versjon %s er klar og ventar på samband på port %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kan ikkje installera SIGUSR1-avbrotshandsamar!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Kan ikkje installera SIGHUP-avbrotshandsamar!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Kan ikkje installera SIGINT-avbrotshandsamar!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Kan ikkje installera SIGTERM-avbrotshandsamar!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Kan ikkje installera røyr-handsamar!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Oppsettfil lagra OK som %s\n"
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Brukarar logga på:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Ingen brukarar er logga på no.\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Dyttar %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Ingen slik brukar!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s drepen\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Ukjend kommando - prøv «help» for hjelp\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "Vart kopla til frå %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "Church Wars-tenaren avsluttar."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s forlét tenaren!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -2837,41 +3097,41 @@ msgstr ""
 "Kunne ikkje laga unix domenesokkel til admin-samband - sjekk skriveløyva på /"
 "tmp!"
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 "Church Wars-tenar versjon %s er klar til å ta imot admin-kommandoar, prøv "
 "«help» for å få hjelp"
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Nytt admin-samband"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Admin-kommando: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Admin-samband stengt"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr "Klarte ikkje å setja NT teneste-status"
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr "Kunne ikkje posta tenestevarselsmelding"
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr "Kunne ikkje registrera tenestehandsamar"
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr "Klarte ikkje å starta NT-teneste"
 
@@ -2879,12 +3139,26 @@ msgstr "Klarte ikkje å starta NT-teneste"
 msgid "Command:"
 msgstr "Kommando:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"Kan ikkje laga kopi (%s) av\n"
+"poengtavlefila %s."
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Feil ved lesing av poeng frå %s."
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Kan ikkje opna poengtavlefila %s: %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -2893,7 +3167,7 @@ msgstr ""
 "Den gamle poengfila %s har blitt konvertert til det nye\n"
 "formatet. Ein kopi av den gamle fila har fått namnet %s.\n"
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2902,12 +3176,12 @@ msgstr ""
 "Kan ikkje laga kopi (%s) av\n"
 "poengtavlefila %s."
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Kan ikkje opna poengtavlefila %s: %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2920,13 +3194,13 @@ msgstr ""
 "til å bruka denne fila, eller spesifisera ei\n"
 "anna poengtavlefil med kommandolineopsjonen -f."
 
-#: src/serverside.c:1992
-#, c-format
+#: src/serverside.c:2005
+#, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 "%s ser ikkje ut til å vera ei gyldig\n"
@@ -2935,17 +3209,18 @@ msgstr ""
 "fyrst konvertera henne til det nye formatet ved å køyra\n"
 "«Church Wars -C %s» frå kommandolina."
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
+#, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 "Noko vart feil under lesinga av oppsettfila. Det kan gjera at nokon\n"
 "av innstillingane ikkje vil virka som venta. Sjå på loggfila\n"
 "«Church Wars-log.txt» for fleire detaljar."
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -2955,125 +3230,132 @@ msgstr ""
 "av innstillingane ikkje vil virka som venta. Sjå på meldingane på\n"
 "standard-ut for fleire detaljar."
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Kan ikkje opna poengtavlefila %s: %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Kan ikkje lesa poengtavlefila %s"
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Gratulerar! Du kom på poengtavla!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Du kom ikkje ein gong på poengtavla..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Kan ikkje skriva til poengtavlefila %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(Kvil i fred.)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Dama attmed deg på t-banen sa^ «%s»%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (i det minste er det det du -trur- ho sa)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Du høyrer nokon som speler %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Vil du vitja %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Vil du hyra ei %tue for %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s er alt her!^Vil du gå til Angrep, eller Stikka av?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "Ingen politi eller våpen!"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "Politi kan ikkje gå til åtak på andre politi!"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "Spelarane er allereie i ein kamp!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "Spelarane er alt i kvar sine kampar!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kan ikkje starta kamp - har ingen våpen!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^vil du betala %P til ein doktor for å lappa deg saman?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du vart rana på t-banen!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du møter ein venn! Han gjev deg %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du møter ein venn, og gjev han %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Luka vekk eit RandomOffer"
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Politihundar jagar deg %d kvartal! Du mista litt %tde. Det er hardt, mann."
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du finn %d %tde på ein daud kar på t-banen!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mora di laga sjokoladekjeks med litt av %tde. Dei var kjempegode!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3081,24 +3363,24 @@ msgstr ""
 "YN^Det er litt jazztobakk som luktar ugraskverk her.^Det ser bra ut! Vil du "
 "røyka det?"
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du stoppa for å %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Vil du kjøpa ein større frakk for %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hei du! Eg kan hjelpa deg å bera %tde for berre %P. Ja eller nei?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Vil du kjøpa ein %tue for %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3106,29 +3388,29 @@ msgstr ""
 "Du hallusinerte i tre dagar på den villaste trippen du kunne^ forestilla "
 "deg! Så døydde du fordi hjernen din smuldra opp!"
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "For seint. %s har nett gått."
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Politiet ser at du kastar %tde!"
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sender oppdateringar til metatenaren"
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sender påminningsmelding til metatenaren..."
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Spelaren fjerna: Han/ho var ikkje aktiv"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Spelaren fjerna pga. tidsavbrot i sambandet"
 
@@ -3145,6 +3427,8 @@ msgstr "Sambandet vart avbrote pga. fullt buffer"
 msgid "Internal error code %d"
 msgstr "Intern feilkode %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr "WinSock har ikkje starta opp ordentleg"
@@ -3209,6 +3493,7 @@ msgstr "Protokollen er ikkje støtta"
 msgid "Socket type not supported"
 msgstr "Sokkeltypen er ikkje støtta"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Fann ikkje verten"
@@ -3249,150 +3534,150 @@ msgstr "Feil metatenar-svar «%s»"
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Stikk du av?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Stikk du av, eller slåst du?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "Latterleg dårleg væpna"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "lett væpna"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "godt væpna"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "tungt væpna"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "væpna til tennene"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - spring etter deg!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s og %d %tde - %s - spring etter deg!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s kjem hit med %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s står og tek imot"
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Du står der som ein annan tulling."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s prøver å rømma, men får det ikkje til."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "Panikk! Du kjem deg ikkje vekk!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s har rømt til %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s kom seg unna!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "Du kom deg unna!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Våpna lada..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s skyt på %s... og bommar!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s skyt på deg...  og bommar!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "Du bomma på %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s drep %s."
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s skyt på %s og drep ei %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s er %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s skyt på deg... og drep ei %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "%s treff deg, mann!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "Du drap %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Du traff %s, og drap ei %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "Du traff %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr " Du finn %P på liket!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr "Du plyndrar liket!"
 
@@ -3401,97 +3686,100 @@ msgstr "Du plyndrar liket!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr "Kan ikkje starta opp WinSock (%s)!"
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr "SOCKS server generell feil"
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Samband nekta av SOCKS-regelsett"
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Kan ikkje nå nettverket"
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Kan ikkje nå verten"
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr "Samband nekta"
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL gjekk ut"
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Kommandoen er ikkje støtta"
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Adressetypen er ikkje støtta"
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS-tenar avviste alle tilbudte metodar"
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr "Ukjend SOCKS-adressetype returnert"
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-autentiserer feila"
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-autentisering avbroten av brukar"
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Førespurnad vart avvist eller feila"
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Avslått - kan ikkje kontakta identd"
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Avslått - identd rapporterer ein annan brukaridentitet"
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr "Ukjend SOCKS svarkode"
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr "Ukjend SOCKS svar-versjon-kode"
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr "Ukjend SOCKS tenarversjon"
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS feilkode %d"
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 "Prøver å kopla til lokal Church Wars-tenar via\n"
 "Unix-domenesokkel %s\n"
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
@@ -3499,19 +3787,30 @@ msgstr ""
 "Samband oppretta. Bruk Ctrl-D for å stenga tilkoplinga.\n"
 "\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Kunne ikkje opna file %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Kunne ikkje opna file %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr "Kunne ikkje finna ei lokal oppsettfil å skriva til"
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Kunne ikkje opna file %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3565,93 +3864,94 @@ msgstr "Bruker namnet %s\n"
 msgid "Players in this game:-\n"
 msgstr "Spelarar i denne runden:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s blir med i runden.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s har gått ut av spelet.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Reiser til %tde med %P i kontantar og %P i gjeld\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Datastyrt spelar vart drepen. Avsluttar normalt.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Speletida er ute. Avsluttar spelet.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "Datastyrt spelar vart dytta av tenaren.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "Tenaren har avslutta.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Sel %d %tde for %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Kjøper %d %tde for %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kjøper ein %tde for %P på våpenbutikken\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Gjeld på %P vart betalt til lånehaien\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Lånehaien er på %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Våpenforretninga er på %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Puben er på %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Banken er på %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Og de kallar drykk dopseljarar?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Ein trent apekatt kunne gjort det betre."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Trur du du er tøff nok til å takla slike som meg?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Sel du snop, eller kva?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Eg blir vel nøydd til å skyta deg til ditt eige beste."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3661,12 +3961,12 @@ msgstr ""
 "ikkje fungera som ein nettverksspelar.\n"
 "Kompiler på nytt med opsjonen --enable-networking til configure."
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Klarte ikkje å opna fila %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3674,6 +3974,24 @@ msgid ""
 msgstr ""
 "Ugyldig modul «%s» vald.\n"
 "(%s tilgjengeleg, brukar «%s» no.)"
+
+#~ msgid "The command used to start your web browser"
+#~ msgstr "Kommandoen som startar nettlesaren din"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "Kven vil du snakka privat med? "
+
+#~ msgid "Talk: "
+#~ msgstr "Snakk: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "Church Wars-tenar"
+
+#~ msgid "dopewars AI"
+#~ msgstr "Datastyrt Church Wars-spelar"
 
 #~ msgid ""
 #~ "\n"
@@ -3726,7 +4044,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Må ha SOCKS-autentisering"
-
 
 #~ msgid "gun"
 #~ msgstr "våpen_ue_våpen_be_våpenet"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2001-04-08 16:16+01000\n"
 "Last-Translator: Slawomir Molenda <jeszua@panda.bg.univ.gda.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -15,128 +15,143 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "siedziba Złotych Pasów"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "bank"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Port do połączenia"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nazwa pliku z najlepszymi wynikami"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nazwa serwera do połączenia się"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "Niezerowa wartość jeżeli serwer ma się kontaktować z metaserwerem"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nazwa metaserwera do wysyłania szczegółów o serwerze"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Preferowana nazwa hosta twojego serwera"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentyfikacja dla LocalName z metaserwerem"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Opis serwera, zgłaszany do metaserwera"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:301
-msgid "If TRUE, the server runs in the background"
-msgstr ""
-
 #: src/dopewars.c:304
-msgid "The command used to start your web browser"
+msgid "If TRUE, the server runs in the background"
 msgstr ""
 
 #: src/dopewars.c:308
@@ -536,6 +551,9 @@ msgstr "Lista rzeczy, które możesz przestać robić"
 msgid "Number of things which you can stop to do"
 msgstr "Liczba rzeczy, które możesz przestać robić"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -608,6 +626,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -628,18 +650,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -656,6 +682,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -672,6 +699,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -738,6 +767,7 @@ msgid ""
 "out!"
 msgstr "Świeża dostawa marihuany z Holandii! Ceny trawy lecą w dół"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -770,6 +800,7 @@ msgstr "Wiadomość"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -780,6 +811,10 @@ msgstr "Gliny zrobiły obławę na %tde ! Ceny towaru są kosmiczne!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Byłoby fajnie gdyby wszyscy wyszli na ulicę i się pieprzyli"
@@ -905,17 +940,17 @@ msgstr "Chcesz landrynkę kotku?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -925,115 +960,132 @@ msgstr ""
 "żaden z graczy nie jest zalogowany. Zaczekaj, aż wszyscy się wylogują\n"
 "lub usuń ich komendami \"push\" albo \"kill\" i spróbuj jeszcze raz."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks w tablicy %s powinien być pomiędzy 1 i %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s jest %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s jest %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s jest %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s jest \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] jest %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s jest { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Zmieniono strukturę listy do %d elementów\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
-msgstr ""
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
+msgstr "Serwer zakończył pracę."
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1057,7 +1109,8 @@ msgstr ""
 "  -b        bez kolorów (standardowo kolory są używane, gdy terminal je "
 "wspiera\n"
 "  -n        bez łączenia się z żadnym serwerem (gra dla jednego gracza)\n"
-"  -a        \"antyczne\" Church Wars - starają się naśladować antyczną wersję\n"
+"  -a        \"antyczne\" Church Wars - starają się naśladować antyczną "
+"wersję\n"
 "               jak tylko to możliwe (to wyłącza wszelkie połączenia "
 "sieciowe)\n"
 "  -f plik   określa plik, jaki ma być użyty do najlepszych wyników\n"
@@ -1082,7 +1135,7 @@ msgstr ""
 "Church Wars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1092,27 +1145,30 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1129,7 +1185,8 @@ msgstr ""
 "  -b        bez kolorów (standardowo kolory są używane, gdy terminal je "
 "wspiera\n"
 "  -n        bez łączenia się z żadnym serwerem (gra dla jednego gracza)\n"
-"  -a        \"antyczne\" Church Wars - starają się naśladować antyczną wersję\n"
+"  -a        \"antyczne\" Church Wars - starają się naśladować antyczną "
+"wersję\n"
 "               jak tylko to możliwe (to wyłącza wszelkie połączenia "
 "sieciowe)\n"
 "  -f plik   określa plik, jaki ma być użyty do najlepszych wyników\n"
@@ -1154,7 +1211,7 @@ msgstr ""
 "Church Wars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1164,7 +1221,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1174,7 +1231,7 @@ msgstr ""
 "opcję --enable-curses-client to pliku konfigurancyjnego, albo użyj\n"
 "zamiast tego okienkowej wersji klienta (jeżeli jest dostępny).\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1184,7 +1241,7 @@ msgstr ""
 "--enable-gui-client do skryptu konfiguracyjnego, albo użyj\n"
 "zamiast tego (jeżeli jest dostępny) klienta opartego na curses.\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1192,7 +1249,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1204,6 +1261,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Tłumaczenie na polski         Slawomir Molenda"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D R E S S   W A R S"
@@ -1277,7 +1335,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Niekonstruktywna krytyka      James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr "Informacje o komendach linni poleceń uzyskasz pisząc Church Wars -h po"
 
 #: src/curses_client/curses_client.c:375
@@ -1285,8 +1345,11 @@ msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "  twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Wprowadź nazwę hosta i port serwera Church Wars:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1301,6 +1364,7 @@ msgstr "Port: "
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Proszę czekać... próba kontaktu z metaserwerem..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1340,6 +1404,10 @@ msgstr "Komentarz: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>astępny serwer; P>oprzedni serwer; W>ybierz ten serwer... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "NPW"
@@ -1371,15 +1439,21 @@ msgid "Password: "
 msgstr ""
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Proszę czekać... próba kontaktu z serwerem Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr ""
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Nie mogę wystartować trybu multiplayer"
 
 #: src/curses_client/curses_client.c:720
@@ -1387,7 +1461,8 @@ msgid "connection to server failed"
 msgstr ""
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Chcesz... P>ołączyć się z innym hostem i/lub portem"
 
 #: src/curses_client/curses_client.c:729
@@ -1395,24 +1470,30 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "          Z>obaczyć listę serwerów na metaserwerze i wybrać jeden"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "          W>yjść (możesz uruchomić serwer pisząc "
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr "          G>rać w trybie single-player"
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "PZWG"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Dokąd jedziesz ? "
 
@@ -1420,6 +1501,8 @@ msgstr "Dokąd jedziesz ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1433,6 +1516,7 @@ msgstr "Co chcesz zostawić? "
 msgid "How many do you drop? "
 msgstr "Ile chcesz zostawić? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "Co chcesz kupić? "
@@ -1441,6 +1525,8 @@ msgstr "Co chcesz kupić? "
 msgid "What do you wish to sell? "
 msgstr "Co chcesz sprzedać? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1464,10 +1550,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Na pewno chcesz wyjść? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "YN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Nowe imię: "
@@ -1480,17 +1567,18 @@ msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s dołączył do gry!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s opuścił grę."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1501,7 +1589,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
@@ -1515,34 +1603,50 @@ msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 msgid "H I G H   S C O R E S"
 msgstr "N A J L E P S Z E   W Y N I K I"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Nie masz żadnej %tde do sprzedania!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Nie masz nic do opchnięcia!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Będziesz potrzebował więcej %tde aby jeszcze unieść %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Nie masz wystarczająco dużo miejsca, aby unieść tę %tde!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Nie masz tyle kasy na %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "K>upić, S>przedać, czy W>yjść? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "KSW"
@@ -1551,27 +1655,40 @@ msgstr "KSW"
 msgid "How much money do you pay back? "
 msgstr "Ile forsy oddajesz Złotym Pasom? "
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Nie masz tak dużo kasy!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Zamierzasz Z>deponować, W>ycofać gotówkę czy O>puścić bank? "
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "ZWO"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Ile kasy? "
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Nie ma tyle gotówki w banku..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "T:Tak"
@@ -1600,32 +1717,46 @@ msgstr "E:Ewakuuj się"
 msgid "Press any key..."
 msgstr "Naciśnij dowolny klawisz..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Statystyka"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Kasa"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Zdrowie"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Bank"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Debet"
 
@@ -1634,6 +1765,8 @@ msgstr "Debet"
 msgid "Space %6d"
 msgstr "Miejsce %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Miejsce %6d"
@@ -1642,6 +1775,10 @@ msgstr "%Tde %3d  Miejsce %6d"
 msgid "Trenchcoat"
 msgstr "Twój płaszcz"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
@@ -1650,11 +1787,13 @@ msgstr ""
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1665,10 +1804,13 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
@@ -1681,441 +1823,492 @@ msgstr "Nie ma aktualnie innych zalogowanych graczy!"
 msgid "Players currently logged on:-"
 msgstr "Gracze aktualnie zalogowani:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hej cieciu, oto %tde jakie są w obiegu:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Jak się nazywasz cieciu? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "K>up"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr " S>przedaj"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr " U>puść"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr " G>adaj P>owiedz "
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr " Z>obacz"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr " A>takuj"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr " J>edź"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr " W>yjście"
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Czy "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "A>takujesz"
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "S>toisz, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "U>ciekasz, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>ilujesz %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "czy W>yjście "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Połączenie z serwerem zerwane! Włączenie trybu dla jednego gracza"
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "KSUGPZDAJW"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "DUASW"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Co chcesz zobaczyć? G>raczy W>yniki"
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "GW"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Do kogo prywatnie zagadujesz ? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Nawijaj: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Grasz jeszcze raz? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Gra"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Gra/_Nowa..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr ""
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Gra/_Wyjście..."
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/Z_obacz"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Zobacz/_Graczy..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Zobacz/_Wynik..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Zobacz/_Plecak..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Pomoc"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Pomoc/_O programie..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Wiadomość"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Zakończyć aktualną grę?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Wyjście z gry"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Rozpoczniej nową grę"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Plecak"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Zamknij"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Połączenie z serwerem przerwane - włączenie trybu dla jednego gracza"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Podróż do miasta %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Najlepsze wyniki"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Atak"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_Diluj %Tde"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Atakujesz"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Stoisz"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Uciekasz"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "Zdrowie: %d"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Podróż"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "za %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Masz teraz %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Dostępne miejsce: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Stać cię na %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Kup"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Sprzedaj"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Zostaw"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "Z_aniechaj"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Tak"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Nie"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Atakuj"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Ewakuuj się"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Pytanie"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Miejsce"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Tłumaczenie na polski"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Dilowanie dragami i rozwój"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Testowanie gry"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Ekstensywne testowanie gry"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Konstruktywna krytyka"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Niekonstruktywna krytyka"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2142,7 +2335,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2151,120 +2345,146 @@ msgstr ""
 "Wersja %s    Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars są publikowane zgodnie z GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Nie ma tyle gotówki w banku..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Kasa: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Debet: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Bank %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Zwróć:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Depozyt"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Wycofaj się"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Spłać wszystko"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista graczy"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Mów do gracza(y)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Mów do wszystkich graczy"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Wiadomość:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Wyślij"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nazwa"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Cena"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Ilość"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Kup ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Sprzedaj"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Zostaw <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde na rynku"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde w plecaku"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Zmień nicka"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2391,12 +2611,14 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
-msgstr ""
+#, fuzzy
+msgid "Name of one bitch"
+msgstr "Nazwa dyskoteki"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
-msgstr ""
+#, fuzzy
+msgid "Name of several bitches"
+msgstr "Nazwa Złotych Pasów"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -2474,6 +2696,7 @@ msgstr "_Pomoc"
 msgid "You can't start the game without giving a name first!"
 msgstr ""
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Nowa Gra"
@@ -2486,20 +2709,28 @@ msgstr "Status: Czekam na aktywność usera"
 msgid "Connection closed by remote host"
 msgstr ""
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Nie mogę się połączyć (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr ""
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr ""
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2509,49 +2740,60 @@ msgstr ""
 msgid "Greetings Trader, what's your _name?"
 msgstr "Jak się _nazywasz cieciu?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Rozpocznij grę dla jednego gracza"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr ""
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
 msgstr ""
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr ""
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "Serwer zakończył pracę."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr ""
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2591,46 +2833,49 @@ msgstr ""
 "Prawidłowe zmienne są poniżej:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaserwer : %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) przekoroczona wartość - zrywam połączenie"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2638,7 +2883,9 @@ msgstr ""
 "Przykro mi, ale serwer ma limit do 1 gracza, który został osiągnięty. "
 "^Proszę spróbować połączyć się później."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2647,168 +2894,179 @@ msgstr ""
 "Przykro mi, ale serwer ma limit %d graczy, który został osiągnięty.^Proszę "
 "spróbować połączyć się później."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s będzie znany jako %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: ZABRONIONY przejazd do %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Twój czas dilerki dobiegł końca..."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: ZABRONIONY przejazd do %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Używam pliku %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Nie można utworzyć pliku pid %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr ""
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "serwer Church Wars w wersji %s gotowy i oczekuje połączeńna porcie %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGUSR1!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGHUP!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGINT!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGTERM!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Nie można obłużyć potoku!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Użytkownicy aktualnie zalogowani:=\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Nie ma żadnych zalogowanych użytkowników\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Wywalam %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Nie ma takiego użytkownika!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s zabity\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Nieznana komenda - spróbuj \"help\",aby uzyskać pomoc...\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "połączenie z %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "Serwer zakończył pracę."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s opuszcza serwer!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
-msgstr ""
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
+msgstr "serwer Church Wars w wersji %s gotowy i oczekuje połączeńna porcie %d."
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr ""
 
@@ -2816,31 +3074,43 @@ msgstr ""
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Nie można odczytać pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Nie można utworzyć pliku pid %s: %s"
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2852,132 +3122,139 @@ msgstr ""
 "Upewnij się, że masz dostęp do pliku i katalogu, albo podaj nazwę\n"
 "alternatywnego pliku poprzez opcję -f z linni poleceń."
 
-#: src/serverside.c:1992
+#: src/serverside.c:2005
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Nie można odczytać pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Gratulacje! Wpiszesz się na karty historii!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Nawet się nie wpiszesz, cieniasie..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Jakaś kobieta stojąca obok na dworcu powiedziała^\"%s\"%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (tak ci się przynajmniej wydaje, że TO powiedziała)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Słyszysz jak ktoś puszcza %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Chciałbyś odwiedzić %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Chciałbyś wynająć %tde za %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s już tu jest!^A>takujesz czy E>wakuujesz się?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Płacisz doktorowi %P, żeby cię pozszywał?"
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Zostałeś obrzygany w pociągu!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Spotykasz starego dilera! Daje ci %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Spotkałeś przyjaciela! Dajesz mu %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Wyłączono RandomOffer"
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -2985,17 +3262,17 @@ msgstr ""
 "Policyjne psy skoczyły ci do gardła %d! Upuściłeś jakieś %tde! Ale "
 "rozpierdol!dresie!"
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Znalazłeś %d %tde przy zwłokach jakiegoś ćpuna w WC!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mamuśka zrobiła ci kanapki z odrobiną %tde! Były super!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3003,24 +3280,24 @@ msgstr ""
 "YN^Znalazłeś trochę ziela, które pachnie tak świeżo!^Dobrze wygląda! "
 "Zapalisz? "
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Zatrzymujesz się i %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Chciałbyć kupić większy płaszcz za %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hej koleś! Pomogę ci ponieść %tde za jedyne %P. Zgadzasz się?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Chciałbyś kupić %tde za %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3028,29 +3305,29 @@ msgstr ""
 "Miałeś haluny przez trzy dni i najlepszego tripa w swoim życiu!^Potem "
 "umarłeś, bo dla twojego mózga ta wycieczka była za mocna!"
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Za późno - %s właśnie zwiał!"
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Gracz usunięty przez przekroczenie czasu na ruch"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Gracz usunięty przez przekroczenia czasu przy połączeniu"
 
@@ -3067,6 +3344,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr ""
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3131,6 +3410,7 @@ msgstr ""
 msgid "Socket type not supported"
 msgstr ""
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr ""
@@ -3171,150 +3451,150 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Uciekasz?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Uciekasz czy Atakujesz?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "beznadziejnie uzbrojony"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "lekko uzbrojony"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "całkiem nieźle uzbrojony"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "dobrze uzbrojony"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "kurewsko uzbrojony po zęby"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s przybył, z %d %tde, %s"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s stoi i dostaje."
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Stoisz tam jak idiota."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr ""
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s zwiał do %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s zwiał!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr ""
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr ""
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr ""
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr ""
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr ""
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr ""
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s jest %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "Trafisz i zabijasz %s"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr ""
 
@@ -3323,113 +3603,127 @@ msgstr ""
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
 #, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
 msgstr ""
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Nie można utworzyć pliku pid %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3482,93 +3776,94 @@ msgstr "Używa imienia %s\n"
 msgid "Players in this game:-\n"
 msgstr "Gracze w grze:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s dołączył do gry.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s opuścił grę.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Jedziesz do %tde z %P kasą i %P debetem\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Gracz AI zabity. Normalne wyjście.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Czas gry się skończył. Opuszczam grę.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "Gracz AI wyrzucony z serwera.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "Serwer zakończył pracę.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Sprzedaję %d %tde w %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Kupuję %d %tde w %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kupuję %tde za %P na ruskim bazarze z bronią\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dług %P został spłacony Złotym Pasom\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Siedziba Złotych Pasów jest w mieście %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Sklep z bronią jest w mieście %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Dyskoteka jest w mieście %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Bank jest w mieście %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Nazywacie się dilerami?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Wytrenowana małpa zrobiłaby to lepiej..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Myślisz, że jesteś taki twardy, aby ze mną dilować?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... dilujesz cukiereczku czy co?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Uważam, że powiniennem cię zastrzelić dla twojego własnego dobra."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3578,17 +3873,23 @@ msgstr ""
 "jakby był komputerowym graczem.\n"
 "Skonfiguruj z opcją --enable-networking i przekompiluj"
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr ""
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
 "(%s available; now using \"%s\".)"
 msgstr ""
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "Do kogo prywatnie zagadujesz ? "
+
+#~ msgid "Talk: "
+#~ msgstr "Nawijaj: "
 
 #~ msgid ""
 #~ "\n"
@@ -3628,7 +3929,6 @@ msgstr ""
 
 #~ msgid "Metaserver"
 #~ msgstr "Metaserwer"
-
 
 #~ msgid "gun"
 #~ msgstr "broń"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-12 13:54+0000\n"
+"POT-Creation-Date: 2025-08-13 15:14+0000\n"
 "PO-Revision-Date: 2022-06-10 23:06-0300\n"
 "Last-Translator: Bruno Lopes <brunoml@bol.com.br>\n"
 "Language-Team: Portuguese/Brazil <pt_BR@li.org>\n"
@@ -16,129 +16,144 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/dopewars.c:180
+#. Name of a single cleric - if you need to use different words for
+#. "cleric" depending on where in the sentence it occurs (e.g. subject or
+#. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
+#. This notation can be used for most of the translatable strings in
+#. dopewars.
+#: src/dopewars.c:181
 msgid "cleric"
 msgstr ""
 
-#: src/dopewars.c:182
+#. Word used for two or more clerics
+#: src/dopewars.c:183
 msgid "clerics"
 msgstr ""
 
-#: src/dopewars.c:184
+#. Word used for a single gun
+#: src/dopewars.c:185
 msgid "weapon"
 msgstr ""
 
-#: src/dopewars.c:186
+#. Word used for two or more guns
+#: src/dopewars.c:187
 msgid "weapons"
 msgstr ""
 
-#: src/dopewars.c:188 src/dopewars.c:190
+#. Word used for a single drug
+#. Word used for two or more drugs
+#: src/dopewars.c:189 src/dopewars.c:191
 msgid "goods"
 msgstr ""
 
-#: src/dopewars.c:195
+#. String for displaying the game date or turn number. This is passed
+#. to the strftime() function, with the exception that %T is used to
+#. mean the turn number rather than the calendar date.
+#. N_("%m-%d-%Y"),
+#: src/dopewars.c:196
 msgid "Turn %T"
 msgstr ""
 
-#: src/dopewars.c:198
+#. Names of the loan shark, the bank, the gun shop, and the pub,
+#. respectively
+#: src/dopewars.c:199
 msgid "the Loan Collector"
 msgstr "o agiota"
 
-#: src/dopewars.c:198
+#: src/dopewars.c:199
 msgid "the Merchant Bank"
 msgstr "o Banco"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:200
 msgid "Holy Mass"
 msgstr ""
 
-#: src/dopewars.c:238
+#. The following strings are the helptexts for all the options that can
+#. be set in a dopewars configuration file, or in the server. See
+#. doc/configfile.html for more detailed explanations.
+#: src/dopewars.c:241
 msgid "Network port to connect to"
 msgstr "Porta de rede para conectar"
 
-#: src/dopewars.c:241
+#: src/dopewars.c:244
 msgid "Name of the high score file"
 msgstr "Nome do arquivo de pontuação"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:247
 msgid "Name of the server to connect to"
 msgstr "Nome do servidor para conectar"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:250
 msgid "Server's welcome message of the day"
 msgstr "Mensagem de boas vindas do dia no servidor"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:253
 msgid "Network address for the server to listen on"
 msgstr "Endereço de rede para em que o servidor aguardará conexões"
 
-#: src/dopewars.c:254
+#: src/dopewars.c:257
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE se um servidor SOCKS deve ser usado para conectar à rede"
 
-#: src/dopewars.c:258
+#: src/dopewars.c:261
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE se IDs numéricos de usuário devem ser usados para SOCKS4"
 
-#: src/dopewars.c:262
+#: src/dopewars.c:265
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Se não em branco, será o nome de usuário a usar para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:268
 msgid "The hostname of a SOCKS server to use"
 msgstr "O hostname do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:271
 msgid "The port number of a SOCKS server to use"
 msgstr "O número da porta do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:274
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "A versão do protocolo SOCKS a usar (4 ou 5)"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:277
 msgid "Username for SOCKS5 authentication"
 msgstr "Nome de usuário para autenticação SOCKS5"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:280
 msgid "Password for SOCKS5 authentication"
 msgstr "Senha para autenticação SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:283
 msgid "TRUE if server should report to a metaserver"
 msgstr "Não-zero se o servidor deve reportar ao servidor meta"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:286
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nome do meta-servidor para reportar/obter os detalhes do servidor"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:289
 msgid "Preferred hostname of your server machine"
 msgstr "Nome do host preferido para a sua máquina servidor"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:292
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentificação para o NomeLocal com o servidor meta"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:295
 msgid "Server description, reported to the metaserver"
 msgstr "Descrição do servidor, reportado para o servidor meta"
 
-#: src/dopewars.c:297
+#: src/dopewars.c:300
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Se TRUE, o servidor minimiza a Barra do Sistema"
 
-#: src/dopewars.c:301
+#: src/dopewars.c:304
 msgid "If TRUE, the server runs in the background"
 msgstr "Se TRUE, o servidor executa em background"
-
-#: src/dopewars.c:304
-msgid "The command used to start your web browser"
-msgstr "O comando usado para iniciar seu navegador"
 
 #: src/dopewars.c:308
 msgid "No. of game turns (if 0, game never ends)"
@@ -537,6 +552,9 @@ msgstr "Lista de coisas que você pode parar de fazer"
 msgid "Number of things which you can stop to do"
 msgstr "Número de coisas que você pode parar de fazer"
 
+#. Default list of songs that you can hear playing (N.B. this can be
+#. overridden in the configuration file with the "Playing" variable) -
+#. look for "You hear someone playing %s" to see how these are used.
 #: src/dopewars.c:656
 msgid "The Song of Moses"
 msgstr ""
@@ -609,6 +627,10 @@ msgstr ""
 msgid "Kyrie Eleison"
 msgstr ""
 
+#. Default list of things which you can "stop to do" (random events that
+#. cost you a little money). These can be overridden with the "StoppedTo"
+#. variable in the configuration file. See the later string "You stopped
+#. to %s." to see how these strings are used.
 #: src/dopewars.c:682
 msgid "practice your needlework"
 msgstr ""
@@ -629,18 +651,22 @@ msgstr ""
 msgid "celebrate the Eucharist"
 msgstr ""
 
+#. Name of the first police officer to attack you
 #: src/dopewars.c:691
 msgid "Seljuk Malik-shah"
 msgstr ""
 
+#. Name of a single deputy of the first police officer
 #: src/dopewars.c:693 src/dopewars.c:697
 msgid "Janissary"
 msgstr ""
 
+#. Word used for more than one deputy of the first police officer
 #: src/dopewars.c:695 src/dopewars.c:697
 msgid "Janissaries"
 msgstr ""
 
+#. Ditto, for the other police officers
 #: src/dopewars.c:697
 msgid "Ahmad Sanjar"
 msgstr ""
@@ -657,6 +683,7 @@ msgstr ""
 msgid "Amirs"
 msgstr ""
 
+#. The names of the default guns
 #: src/dopewars.c:704
 msgid "Mace"
 msgstr ""
@@ -673,6 +700,8 @@ msgstr ""
 msgid "Battle Axe"
 msgstr ""
 
+#. The names of the default drugs, and the messages displayed when they
+#. are specially cheap or expensive
 #: src/dopewars.c:713
 msgid "Byzantine Icons"
 msgstr ""
@@ -739,6 +768,7 @@ msgid ""
 "out!"
 msgstr "Colombianos enganaram a Guarda Costeira! Preços de maconha abaixaram!"
 
+#. The names of the default locations
 #: src/dopewars.c:736
 msgid "Jerusalem"
 msgstr ""
@@ -771,6 +801,7 @@ msgstr "Mensagem"
 msgid "Nicaea"
 msgstr ""
 
+#. Messages displayed for drug busts, etc.
 #: src/dopewars.c:749
 #, c-format
 msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
@@ -781,6 +812,10 @@ msgstr "Policiais apreenderam %tde! Preços estão super altos!"
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Viciados estão comprando %tde a preços ridículos!"
 
+#. Default list of things which the "lady on the subway" can tell you
+#. (N.B. can be overridden with the "SubwaySaying" config. file
+#. variable). Look for "the lady next to you" to see how these strings
+#. are used.
 #: src/dopewars.c:760
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Não seria engraçado se todos tivessem de uma vez só?"
@@ -908,17 +943,17 @@ msgstr "Você gostaria de um doce, bebê?"
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1758
+#: src/dopewars.c:1757
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Não foi possível processar o arquivo de configuração %s, linha %d"
 
-#: src/dopewars.c:1794
+#: src/dopewars.c:1793
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: src/dopewars.c:1858
+#: src/dopewars.c:1857
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -928,68 +963,83 @@ msgstr ""
 "nenhum jogador está logado. Espere por todos os jogadores saírem,\n"
 "ou remove eles com os comandos push ou kill, e tente de novo."
 
-#: src/dopewars.c:1971
+#: src/dopewars.c:1970
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Índice da array %s deve ser entre 1 e %d"
 
-#: src/dopewars.c:1996
+#. Display of a numeric config. file variable - e.g. "NumDrug is 6"
+#: src/dopewars.c:1995
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s é %d\n"
 
-#: src/dopewars.c:2001
+#. Display of a boolean config. file variable - e.g. "DrugValue is
+#. TRUE"
+#: src/dopewars.c:2000
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s é %s\n"
 
-#: src/dopewars.c:2007
+#. Display of a price config. file variable - e.g. "Cleric.MinPrice is
+#. $200"
+#: src/dopewars.c:2006
 msgid "%s is %P\n"
 msgstr "%s é %P\n"
 
-#: src/dopewars.c:2012
+#. Display of a string config. file variable - e.g. "LoanSharkName is
+#. \"the loan shark\""
+#: src/dopewars.c:2011
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s é \"%s\"\n"
 
-#: src/dopewars.c:2018
+#. Display of an indexed string list config. file variable - e.g.
+#. "StoppedTo[1] is have a beer"
+#: src/dopewars.c:2017
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] é %s\n"
 
-#: src/dopewars.c:2027
+#. Display of the first part of an entire string list config. file
+#. variable - e.g. "StoppedTo is { " (followed by "have a beer",
+#. "smoke a joint" etc.)
+#: src/dopewars.c:2026
 #, c-format
 msgid "%s is { "
 msgstr "%s é { "
 
-#: src/dopewars.c:2082
+#: src/dopewars.c:2081
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s não pode ser menor que %d - ignorando!"
 
-#: src/dopewars.c:2088
+#: src/dopewars.c:2087
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s não pode ser maior que %d - ignorando!"
 
-#: src/dopewars.c:2097
+#: src/dopewars.c:2096
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estrutura de lista redimensionada para %d elementos\n"
 
-#: src/dopewars.c:2135
+#: src/dopewars.c:2134
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Valor booleano esperado (om dentre 0, FALSE, 1, TRUE)"
 
-#: src/dopewars.c:2319
+#. The currency symbol
+#: src/dopewars.c:2318
 msgid "£"
 msgstr ""
 
-#: src/dopewars.c:2323
+#. Translate this to "Currency.Prefix=FALSE" if you want your currency
+#. symbol to follow all prices.
+#: src/dopewars.c:2322
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2449
+#: src/dopewars.c:2447
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -997,7 +1047,7 @@ msgstr ""
 "  -u, --plugin=ARQUIVO    use plugin de som \"ARQUIVO\"\n"
 "                            "
 
-#: src/dopewars.c:2452
+#: src/dopewars.c:2450
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1005,42 +1055,44 @@ msgstr ""
 "  -u arquivo  use plugin de som \"arquivo\"\n"
 "\t          "
 
-#: src/dopewars.c:2456
+#: src/dopewars.c:2454
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s dispnível)\n"
 
-#: src/dopewars.c:2462
-#, c-format
-msgid "dopewars version %s\n"
+#: src/dopewars.c:2460
+#, fuzzy, c-format
+msgid "Church Wars version %s\n"
 msgstr "Church Wars versão %s\n"
 
-#: src/dopewars.c:2471
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (version with support for GNU long options)
+#: src/dopewars.c:2469
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b, --no-color,         \"black and white\" - i.e. do not use pretty "
 "colors\n"
 "      --no-colour           (by default colors are used where available)\n"
 "  -n, --single-player     be boring and don't connect to any available "
-"dopewars\n"
+"Church Wars\n"
 "                            servers (i.e. single player mode)\n"
-"  -a, --antique           \"antique\" dopewars - keep as closely to the "
+"  -a, --antique           \"antique\" Church Wars - keep as closely to the "
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/dopewars.sco is used)\n"
+"                            default %s/churchwars.sco is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
-"                            dopewars can be found\n"
+"                            Church Wars can be found\n"
 "  -s, --public-server     run in server mode (note: see the -A option for\n"
 "                            configuring a server once it's running)\n"
 "  -S, --private-server    run a \"private\" server (do not notify the "
 "metaserver)\n"
 "  -p, --port=PORT         specify the network port to use (default: 7902)\n"
-"  -g, --config-file=FILE  specify the pathname of a dopewars configuration "
-"file;\n"
+"  -g, --config-file=FILE  specify the pathname of a Church Wars "
+"configuration file;\n"
 "                            this file is read immediately when the -g "
 "option\n"
 "                            is encountered\n"
@@ -1065,7 +1117,8 @@ msgstr ""
 "                (por padrão cores são usadas quando o terminal suporta)  -"
 "n         seja chato e não conecta em nenhum servidor Church Wars "
 "disponível                (modo para um jogador)\n"
-"  -a         Church Wars \"antigo\" - se mantém o mais parecido com a versão\n"
+"  -a         Church Wars \"antigo\" - se mantém o mais parecido com a "
+"versão\n"
 "                original (isto também desabilita todo suporte de rede)\n"
 "  -f arquivo especifica um arquivo para usar para a tabela de pontuação\n"
 "                (por padrão, %s/Church Wars.sco é usado)\n"
@@ -1088,7 +1141,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2501
+#: src/dopewars.c:2499
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1103,27 +1156,30 @@ msgstr ""
 "Church Wars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2508
-#, c-format
+#. Usage information, printed when the user runs "dopewars -h"
+#. (short options only version)
+#: src/dopewars.c:2506
+#, fuzzy, c-format
 msgid ""
-"Usage: dopewars [OPTION]...\n"
+"Usage: Church Wars [OPTION]...\n"
 "Drug dealing game based on \"Drug Wars\" by John E. Dell\n"
 "  -b       \"black and white\" - i.e. do not use pretty colors\n"
 "              (by default colors are used where the terminal supports them)\n"
-"  -n       be boring and don't connect to any available dopewars servers\n"
+"  -n       be boring and don't connect to any available Church Wars servers\n"
 "              (i.e. single player mode)\n"
-"  -a       \"antique\" dopewars - keep as closely to the original version "
+"  -a       \"antique\" Church Wars - keep as closely to the original version "
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/dopewars.sco is used)\n"
-"  -o addr  specify a hostname where the server for multiplayer dopewars\n"
+"              (by default %s/churchwars.sco is used)\n"
+"  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
 "              server once it's running)\n"
 "  -S       run a \"private\" server (i.e. do not notify the metaserver)\n"
 "  -p port  specify the network port to use (default: 7902)\n"
-"  -g file  specify the pathname of a dopewars configuration file; this file\n"
+"  -g file  specify the pathname of a Church Wars configuration file; this "
+"file\n"
 "              is read immediately when the -g option is encountered\n"
 "  -r file  maintain pid file \"file\" while running the server\n"
 "  -l file  write log information to \"file\"\n"
@@ -1141,7 +1197,8 @@ msgstr ""
 "                (por padrão cores são usadas quando o terminal suporta)  -"
 "n         seja chato e não conecta em nenhum servidor Church Wars "
 "disponível                (modo para um jogador)\n"
-"  -a         Church Wars \"antigo\" - se mantém o mais parecido com a versão\n"
+"  -a         Church Wars \"antigo\" - se mantém o mais parecido com a "
+"versão\n"
 "                original (isto também desabilita todo suporte de rede)\n"
 "  -f arquivo especifica um arquivo para usar para a tabela de pontuação\n"
 "                (por padrão, %s/Church Wars.sco é usado)\n"
@@ -1164,7 +1221,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2537
+#: src/dopewars.c:2535
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1179,7 +1236,7 @@ msgstr ""
 "Church Wars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2805
+#: src/dopewars.c:2803
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1189,7 +1246,7 @@ msgstr ""
 "--enable-curses-client para configurar, ou use o cliente gráfico\n"
 "(se disponível) no lugar!\n"
 
-#: src/dopewars.c:2825
+#: src/dopewars.c:2823
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1199,7 +1256,7 @@ msgstr ""
 "a opção --enable-gui-client para configurar, ou use o cliente\n"
 "curses (se disponível) no lugar!\n"
 
-#: src/dopewars.c:2873
+#: src/dopewars.c:2871
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1210,7 +1267,7 @@ msgstr ""
 "em modo admin. Recompile passando --enable-networking para o script de "
 "configuração.\n"
 
-#: src/dopewars.c:2894 src/winmain.c:359
+#: src/dopewars.c:2892 src/winmain.c:381
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1225,6 +1282,7 @@ msgstr ""
 msgid "English Translation           Ben Webb"
 msgstr "Tradução de Portugal            Bruno Lopes"
 
+#. Curses client introduction screen
 #: src/curses_client/curses_client.c:334
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
@@ -1234,7 +1292,8 @@ msgstr "D O P E W A R S"
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
-"Baseado no velho jogo Drug Wars de John E. Dell, Church Wars é uma simulação de"
+"Baseado no velho jogo Drug Wars de John E. Dell, Church Wars é uma simulação "
+"de"
 
 #: src/curses_client/curses_client.c:341
 msgid ""
@@ -1301,7 +1360,9 @@ msgid "Unconstructive Criticism      R Batstone"
 msgstr "Crítica não construtiva         James Matthews"
 
 #: src/curses_client/curses_client.c:373
-msgid "For information on the command line options, type dopewars -h at your"
+#, fuzzy
+msgid ""
+"For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Para informações de opções da linha de comando, digite Church Wars -h no seu"
 
@@ -1312,8 +1373,11 @@ msgstr ""
 "prompt Unix. Isto irá mostrar a tela de ajudam listando as opções "
 "disponíveis."
 
+#. Prompts for hostname and port when selecting a server
+#. manually
 #: src/curses_client/curses_client.c:401
-msgid "Please enter the hostname and port of a dopewars server:-"
+#, fuzzy
+msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Por favor entre com o nome do host e porta do servidor Church Wars:-"
 
 #: src/curses_client/curses_client.c:402
@@ -1328,6 +1392,7 @@ msgstr "Porta"
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Aguarde... tentando contactar o servidor meta..."
 
+#. Printout of metaserver information in curses client
 #: src/curses_client/curses_client.c:495
 #, c-format
 msgid "Server : %s"
@@ -1367,6 +1432,10 @@ msgstr "Comentário: %s"
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "P>róximo servidor; A>nterior; S>elecionar este servidor... "
 
+#. The three keys that are valid responses to the previous question -
+#. if you translate them, keep the keys in the same order (N>ext,
+#. P>revious, S>elect) as they are here, otherwise they'll do the
+#. wrong things.
 #: src/curses_client/curses_client.c:521
 msgid "NPS"
 msgstr "PAS"
@@ -1399,15 +1468,21 @@ msgid "Password: "
 msgstr "Senha: "
 
 #: src/curses_client/curses_client.c:698
-msgid "Please wait... attempting to contact dopewars server..."
+#, fuzzy
+msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Aguarde... tentando contactar o servidor Church Wars..."
 
+#. Display of an error while contacting the metaserver
 #: src/curses_client/curses_client.c:709
 msgid "Cannot get metaserver details"
 msgstr "Não foi possível obter detalhes do metaservidor"
 
+#. Display of an error message while trying to contact a dopewars
+#. server (the error message itself is displayed on the next
+#. screen line)
 #: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer dopewars"
+#, fuzzy
+msgid "Could not start multiplayer Church Wars"
 msgstr "Não foi possível iniciar o Church Wars em multiplayer"
 
 #: src/curses_client/curses_client.c:720
@@ -1415,7 +1490,8 @@ msgid "connection to server failed"
 msgstr "a conexão com o servidor falhou"
 
 #: src/curses_client/curses_client.c:727
-msgid "Will you... C>onnect to a named dopewars server"
+#, fuzzy
+msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Você irá... C>onectar em um diferente host e porta"
 
 #: src/curses_client/curses_client.c:729
@@ -1423,24 +1499,30 @@ msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "            L>istar os servidor no servidor meta, e selecionar um"
 
 #: src/curses_client/curses_client.c:732
+#, fuzzy
 msgid ""
-"            Q>uit (where you can start a server by typing \"dopewars -s\")"
+"            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "            S>air (onde você pode iniciar um servidor digitando "
 
 #: src/curses_client/curses_client.c:734
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ogar com apenas um jogador ? "
 
+#. Translate these 4 keys in line with the above options, keeping
+#. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
 #: src/curses_client/curses_client.c:739
 msgid "CLQP"
 msgstr "CLSJ"
 
+#. Display of shortcut keys and locations to jet to
 #: src/curses_client/curses_client.c:832
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1417
+#. Prompt when the player chooses to "jet" to a new location
+#. Prompt in 'Jet' dialog
+#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Para onde, cara ? "
 
@@ -1448,6 +1530,8 @@ msgstr "Para onde, cara ? "
 msgid "%/Location display/%tde"
 msgstr ""
 
+#. List of drugs that you can drop (%tde = "drugs" by
+#. default)
 #: src/curses_client/curses_client.c:881
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
@@ -1461,6 +1545,7 @@ msgstr "O que você quer largar? "
 msgid "How many do you drop? "
 msgstr "Que quantidade você quer largar? "
 
+#. Buy and sell prompts for dealing drugs or guns
 #: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
 msgid "What do you wish to buy? "
 msgstr "O que você quer comprar? "
@@ -1469,6 +1554,8 @@ msgstr "O que você quer comprar? "
 msgid "What do you wish to sell? "
 msgstr "O que você quer vender? "
 
+#. Display of number of drugs you could buy and/or carry, when
+#. buying drugs
 #: src/curses_client/curses_client.c:960
 #, c-format
 msgid "You can afford %d, and can carry %d. "
@@ -1492,10 +1579,11 @@ msgid "Are you sure you want to quit? "
 msgstr "Você tem certeza que quer sair? "
 
 #: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2746
+#: src/curses_client/curses_client.c:2713
 msgid "YN"
 msgstr "SN"
 
+#. Prompt for player to change his/her name
 #: src/curses_client/curses_client.c:1015
 msgid "New name: "
 msgstr "Novo nome: "
@@ -1508,17 +1596,18 @@ msgstr "Você foi tirado do servidor. Revertendo para modo de jogador único."
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "O servidor foi terminado. Revertendo para modo de jogador único."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:499
-#: src/serverside.c:377
+#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
+#: src/serverside.c:371
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s entrou no jogo!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:508
+#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s saiu do jogo."
 
+#. Displayed when a player changes his/her name
 #: src/curses_client/curses_client.c:1125
 #, c-format
 msgid "%s will now be known as %s."
@@ -1529,7 +1618,7 @@ msgid "H O L Y M A S S"
 msgstr ""
 
 #: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1158
+#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Local atual/%tde"
 
@@ -1543,34 +1632,50 @@ msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o.
 msgid "H I G H   S C O R E S"
 msgstr "M E L H O R E S   P O N T U A Ç Õ E S"
 
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1781
+#. Error - player tried to sell guns that he/she doesn't have
+#. (%tde="guns" by default)
+#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Você não tem nenhum %tde para vender!"
 
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1802
+#. Error - player tried to sell some guns that he/she doesn't have
+#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Você não tem nenhum para vender!"
 
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1787
+#. Error - player tried to buy more guns
+#. than his/her bitches can carry (1st
+#. %tde="bitches", 2nd %tde="guns" by
+#. default)
+#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Você irá precisar de mais %tde para carregar ainda mais %tde!"
 
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1793
+#. Error - player tried to buy a gun that he/she doesn't have
+#. space for (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Você não tem espaço suficiente para carregar aquele %tde!"
 
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1798
+#. Error - player tried to buy a gun that he/she can't afford
+#. (%tde="gun" by default)
+#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Você não tem dinheiro suficiente para comprar aquele %tde!"
 
+#. Prompt for actions in the gun shop
 #: src/curses_client/curses_client.c:1405
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Você irá C>omprar, V>ender, ou S>air? "
 
+#. Translate these three keys in line with the above options, keeping
+#. the order (B>uy, S>ell, L>eave) the same - you can change the
+#. wording of the prompt, but if you change the order in this key
+#. list, the keys will do the wrong things!
 #: src/curses_client/curses_client.c:1415
 msgid "BSL"
 msgstr "CVS"
@@ -1579,27 +1684,40 @@ msgstr "CVS"
 msgid "How much money do you pay back? "
 msgstr "Quanto dinheiro você quer pagar de volta? "
 
+#. Error - player doesn't have enough money to pay back the loan
+#. Error - player has tried to put more money into the bank than
+#. he/she has
 #: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2464
+#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
 msgid "You don't have that much money!"
 msgstr "Você não tem todo esse dinheiro!"
 
+#. Prompt for dealing with the bank in the curses client
 #: src/curses_client/curses_client.c:1474
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Você quer D>epositar dinheiro, R>etirar dinheiro, ou S>air ? "
 
+#. Make sure you keep the order the same if you translate these keys!
+#. (D>eposit, W>ithdraw, L>eave)
 #: src/curses_client/curses_client.c:1480
 msgid "DWL"
 msgstr "DRS"
 
+#. Prompt for putting money in or taking money out of the bank
 #: src/curses_client/curses_client.c:1484
 msgid "How much money? "
 msgstr "Quanto dinheiro? "
 
+#. Error - player has tried to withdraw more money from the bank
+#. than there is in the account
 #: src/curses_client/curses_client.c:1500
 msgid "There isn't that much money in the bank..."
 msgstr "Não há todo este dinheiro no banco..."
 
+#. Expansions of the single-letter keypresses for the benefit of the
+#. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
+#. to the user which letter in the word corresponds to the keypress, by
+#. capitalising it or similar.
 #: src/curses_client/curses_client.c:1550
 msgid "Y:Yes"
 msgstr "S:Sim"
@@ -1628,32 +1746,46 @@ msgstr "E:Evacuar"
 msgid "Press any key..."
 msgstr "Pressione qualquer tecla..."
 
+#. Title of the "Messages" window in the curses client
 #: src/curses_client/curses_client.c:1952
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2200
+#. Title of the "Stats" window in the curses client
+#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
 msgid "Stats"
 msgstr "Estatísticas"
 
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2024
+#. Display of the player's cash in the stats window
+#. Player's cash label in GTK+ client status display
+#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Dinheiro"
 
+#. Display of the total number of guns carried (%Tde="Guns" by default)
+#. Title of the "guns" window (the only important bit in this string
+#. is the "%Tde" which is "Guns" by default)
+#. Display of the total number of guns carried (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1181
+#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2055
+#. Display of the player's health
+#. Player's health label in GTK+ client status display
+#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Pontos de vida"
 
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2038
+#. Display of the player's bank balance
+#. Player's bank balance label in GTK+ client status display
+#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2031
+#. Display of the player's debt
+#. Player's debt label in GTK+ client status display
+#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Débito"
 
@@ -1662,6 +1794,8 @@ msgstr "Débito"
 msgid "Space %6d"
 msgstr "Espaço %6d"
 
+#. Display of the player's number of bitches, and available space
+#. (%Tde="Bitches" by default)
 #: src/curses_client/curses_client.c:2008
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espaço %6d"
@@ -1670,6 +1804,10 @@ msgstr "%Tde %3d  Espaço %6d"
 msgid "Trenchcoat"
 msgstr "Casaco"
 
+#. Title of the "drugs" window (the only important bit in this
+#. string is the "%Tde" which is "Drugs" by default; the %/.../ part
+#. is ignored, so you don't need to translate it; see doc/i18n.html)
+#.
 #: src/curses_client/curses_client.c:2027
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Estatísticas: Drogas/%Tde"
@@ -1678,11 +1816,13 @@ msgstr "%/Estatísticas: Drogas/%Tde"
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
+#. Display of carried drugs (%tde="Opium", etc. by default)
 #: src/curses_client/curses_client.c:2042
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
+#. Display of carried guns (%tde="Baretta", etc. by default)
 #: src/curses_client/curses_client.c:2057
 #, c-format
 msgid "%-22tde %3d"
@@ -1693,10 +1833,13 @@ msgstr ""
 msgid "Spy reports for %s"
 msgstr ""
 
+#. Message displayed with a spy's list of drugs (%Tde="Drugs" by
+#. default)
 #: src/curses_client/curses_client.c:2088
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Estatísticas: Drogas/%Tde"
 
+#. Message displayed with a spy's list of guns (%Tde="Guns" by default)
 #: src/curses_client/curses_client.c:2096
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
@@ -1709,441 +1852,492 @@ msgstr "Nenhum outro jogador está atualmente logado!"
 msgid "Players currently logged on:-"
 msgstr "Jogadores atualmente logados:-"
 
-#: src/curses_client/curses_client.c:2305
+#. Display of drug prices (%tde="drugs" by default)
+#: src/curses_client/curses_client.c:2304
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Ei carinha, os preços de %tde aqui estão:"
 
-#: src/curses_client/curses_client.c:2316
+#. List of individual drug names for selection (%tde="Opium" etc.
+#. by default)
+#: src/curses_client/curses_client.c:2315
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2362
+#: src/curses_client/curses_client.c:2360
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2379
+#: src/curses_client/curses_client.c:2377
 msgid "Hey there! What's your name? "
 msgstr "Ei carinha, qual seu nome? "
 
-#: src/curses_client/curses_client.c:2423
+#. Prompts for "normal" actions in curses client
+#: src/curses_client/curses_client.c:2421
 msgid "Will you B>uy"
 msgstr "Você irá C>omprar"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2423
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2425
 msgid ", D>rop"
 msgstr ", L>argar"
 
-#: src/curses_client/curses_client.c:2429
+#: src/curses_client/curses_client.c:2427
 msgid ", T>alk, P>age"
 msgstr ", F>alar, P>agear"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2428
 msgid ", L>ist"
 msgstr ", J>ogadores"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2430
 msgid ", F>ight"
 msgstr ", L>utar"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2432
 msgid ", J>et"
 msgstr ", I>r"
 
-#: src/curses_client/curses_client.c:2436
+#: src/curses_client/curses_client.c:2434
 msgid ", or Q>uit? "
 msgstr ", ou S>air? "
 
-#: src/curses_client/curses_client.c:2445
+#. Prompts for actions during fights in curses client
+#: src/curses_client/curses_client.c:2443
 msgid "Do you "
 msgstr "Você quer "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2446
 msgid "F>ight, "
 msgstr "L>utar, "
 
-#: src/curses_client/curses_client.c:2450
+#: src/curses_client/curses_client.c:2448
 msgid "S>tand, "
 msgstr "F>icar paradão, "
 
-#: src/curses_client/curses_client.c:2454
+#: src/curses_client/curses_client.c:2452
 msgid "R>un, "
 msgstr "C>orrer, "
 
-#: src/curses_client/curses_client.c:2457
+#. (%tde = "drugs" by default here)
+#: src/curses_client/curses_client.c:2455
 #, c-format
 msgid "D>eal %tde, "
 msgstr "T>raficar %tde, "
 
-#: src/curses_client/curses_client.c:2458
+#: src/curses_client/curses_client.c:2456
 msgid "or Q>uit? "
 msgstr "ou S>air? "
 
-#: src/curses_client/curses_client.c:2523
+#: src/curses_client/curses_client.c:2521
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Conexão com o servidor perdida! Revertendo para o modo de um jogador"
 
-#: src/curses_client/curses_client.c:2548
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
+#. L>ist, F>ight, J>et, Q>uit)
+#: src/curses_client/curses_client.c:2546
 msgid "BSDTPLFJQ"
 msgstr "CVLFPJDLIS"
 
-#: src/curses_client/curses_client.c:2554
+#. N.B. You must keep the order of these keys the same as the
+#. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
+#. Q>uit)
+#: src/curses_client/curses_client.c:2552
 msgid "DRFSQ"
 msgstr "TCLFS"
 
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2582
 msgid "List what? P>layers or S>cores? "
 msgstr "Listar o que? J>ogadores ou P>ontuações? "
 
-#: src/curses_client/curses_client.c:2586
+#. P>layers, S>cores
+#: src/curses_client/curses_client.c:2584
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2599
-msgid "Whom do you want to page (talk privately to) ? "
-msgstr "Quem você quer pagear (falar privadamente) ? "
-
-#: src/curses_client/curses_client.c:2605
-#: src/curses_client/curses_client.c:2619
-msgid "Talk: "
-msgstr "Fale: "
-
-#: src/curses_client/curses_client.c:2745
+#: src/curses_client/curses_client.c:2712
 msgid "Play again? "
 msgstr "Jogar novamente? "
 
-#: src/gui_client/gtk_client.c:154
+#. The names of the menus and their items in the GTK+ client
+#: src/gui_client/gtk_client.c:159
 msgid "/_Game"
 msgstr "/_Jogo"
 
-#: src/gui_client/gtk_client.c:155
+#: src/gui_client/gtk_client.c:160
 msgid "/Game/_New..."
 msgstr "/Jogo/_Novo..."
 
-#: src/gui_client/gtk_client.c:156
+#: src/gui_client/gtk_client.c:161
 msgid "/Game/_Abandon..."
 msgstr "/Jogo/_Abandonar"
 
-#: src/gui_client/gtk_client.c:158
+#. {N_("/Game/_Options..."), "<control>O", OptDialog, 0, NULL},
+#: src/gui_client/gtk_client.c:163
 msgid "/Game/Enable _sound"
 msgstr "/Jogo/_Habilitar som"
 
-#: src/gui_client/gtk_client.c:159
+#: src/gui_client/gtk_client.c:164
 msgid "/Game/_Quit..."
 msgstr "/Jogo/_Sair..."
 
-#: src/gui_client/gtk_client.c:160
+#: src/gui_client/gtk_client.c:165
 msgid "/_List"
 msgstr "/_Listar"
 
-#: src/gui_client/gtk_client.c:161
+#: src/gui_client/gtk_client.c:166
 msgid "/List/_Players..."
 msgstr "/Listar/_Jogadores..."
 
-#: src/gui_client/gtk_client.c:162
+#: src/gui_client/gtk_client.c:167
 msgid "/List/_Scores..."
 msgstr "/Listar/_Pontuações..."
 
-#: src/gui_client/gtk_client.c:163
+#: src/gui_client/gtk_client.c:168
 msgid "/List/_Inventory..."
 msgstr "/Listar/_Inventário..."
 
-#: src/gui_client/gtk_client.c:164
+#: src/gui_client/gtk_client.c:169
 msgid "/_Help"
 msgstr "/_Ajuda"
 
-#: src/gui_client/gtk_client.c:165
+#: src/gui_client/gtk_client.c:170
 msgid "/Help/_About..."
 msgstr "/Ajuda/_Sobre..."
 
-#: src/gui_client/gtk_client.c:179
+#. Titles of the message boxes for warnings and errors
+#: src/gui_client/gtk_client.c:184
 msgid "Warning"
 msgstr "Aviso"
 
-#: src/gui_client/gtk_client.c:180
+#: src/gui_client/gtk_client.c:185
 msgid "Error"
 msgstr "Erro"
 
-#: src/gui_client/gtk_client.c:181
+#: src/gui_client/gtk_client.c:186
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/gui_client/gtk_client.c:223 src/gui_client/gtk_client.c:239
-#: src/gui_client/gtk_client.c:248 src/gui_client/gtk_client.c:270
+#. Prompt in 'quit game' dialog
+#: src/gui_client/gtk_client.c:228 src/gui_client/gtk_client.c:244
+#: src/gui_client/gtk_client.c:253 src/gui_client/gtk_client.c:275
 msgid "Abandon current game?"
 msgstr "Abandonar jogo atual?"
 
-#: src/gui_client/gtk_client.c:225 src/gui_client/gtk_client.c:240
+#. Title of 'quit game' dialog
+#: src/gui_client/gtk_client.c:230 src/gui_client/gtk_client.c:245
 msgid "Quit Game"
 msgstr "Sair do Jogo"
 
-#: src/gui_client/gtk_client.c:250
+#. Title of 'stop game to start a new game' dialog
+#: src/gui_client/gtk_client.c:255
 msgid "Start new game"
 msgstr "Iniciar um novo jogo"
 
-#: src/gui_client/gtk_client.c:272
+#. Title of 'abandon game' dialog
+#: src/gui_client/gtk_client.c:277
 msgid "Abandon game"
 msgstr "Abandonar jogo"
 
-#: src/gui_client/gtk_client.c:314
+#. Title of inventory window
+#: src/gui_client/gtk_client.c:319
 msgid "Inventory"
 msgstr "Inventário"
 
-#: src/gui_client/gtk_client.c:337 src/gui_client/gtk_client.c:721
-#: src/gui_client/gtk_client.c:2624 src/gui_client/gtk_client.c:2764
-#: src/gui_client/gtk_client.c:3059 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
+#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
+#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
 msgid "_Close"
 msgstr "_Fechar"
 
-#: src/gui_client/gtk_client.c:393
+#. The network connection to the server was dropped unexpectedly
+#: src/gui_client/gtk_client.c:398
 msgid "Connection to server lost - switching to single player mode"
 msgstr "Conexão com o servidor perdida - mudando para modo de um jogador"
 
-#: src/gui_client/gtk_client.c:461
+#. The server admin has asked us to leave - so warn the user, and do
+#. so
+#: src/gui_client/gtk_client.c:466
 msgid ""
 "You have been pushed from the server.\n"
 "Switching to single player mode."
 msgstr "Você foi tirado do servidor. Revertendo para modo de um jogador."
 
-#: src/gui_client/gtk_client.c:469
+#. The server has sent us notice that it is shutting down
+#: src/gui_client/gtk_client.c:474
 msgid ""
 "The server has terminated.\n"
 "Switching to single player mode."
 msgstr "O servidor foi terminado. Revertendo para modo de um jogador."
 
-#: src/gui_client/gtk_client.c:526
+#. Message displayed when the player "jets" to a new location
+#: src/gui_client/gtk_client.c:531
 #, c-format
 msgid "Travelling to %tde"
 msgstr "Indo para %tde"
 
-#: src/gui_client/gtk_client.c:586
+#. Title of the GTK+ high score dialog
+#: src/gui_client/gtk_client.c:591
 msgid "High Scores"
 msgstr "Melhores Pontuações"
 
-#: src/gui_client/gtk_client.c:638 src/gui_client/gtk_client.c:654
+#. Error - the high score from the server is invalid
+#: src/gui_client/gtk_client.c:643 src/gui_client/gtk_client.c:659
 msgid "Corrupt high score!"
 msgstr "Highscore corrompido!"
 
-#: src/gui_client/gtk_client.c:849
+#: src/gui_client/gtk_client.c:854
 msgid "Fight"
 msgstr "Lutar"
 
-#: src/gui_client/gtk_client.c:890
+#. Button for closing the "Fight" dialog and going back to dealing drugs
+#. (%Tde = "Drugs" by default)
+#: src/gui_client/gtk_client.c:895
 msgid "_Deal %Tde"
 msgstr "_Traficar %Tde"
 
-#: src/gui_client/gtk_client.c:897 src/gui_client/gtk_client.c:1840
-#: src/gui_client/gtk_client.c:2077
+#. Button for shooting at other players in the "Fight" dialog, or for
+#. popping up the "Fight" dialog from the main window
+#: src/gui_client/gtk_client.c:902 src/gui_client/gtk_client.c:1845
+#: src/gui_client/gtk_client.c:2082
 msgid "_Fight"
 msgstr "_Lutar"
 
-#: src/gui_client/gtk_client.c:901
+#. Button to stand and take it in the "Fight" dialog
+#: src/gui_client/gtk_client.c:906
 msgid "_Stand"
 msgstr "_Ficar parado"
 
-#: src/gui_client/gtk_client.c:905 src/gui_client/gtk_client.c:1839
+#. Button to run from combat in the "Fight" dialog
+#: src/gui_client/gtk_client.c:910 src/gui_client/gtk_client.c:1844
 msgid "_Run"
 msgstr "_Correr"
 
-#: src/gui_client/gtk_client.c:971
+#. Display of number of bitches or deputies during combat
+#. (%tde="bitches" or "deputies" (etc.) by default)
+#: src/gui_client/gtk_client.c:976
 msgid "%/Combat: Bitches/%d %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:976
+#: src/gui_client/gtk_client.c:981
 msgid "(Left)"
 msgstr "(Saiu)"
 
-#: src/gui_client/gtk_client.c:978
+#: src/gui_client/gtk_client.c:983
 msgid "(Dead)"
 msgstr "(Morto)"
 
-#: src/gui_client/gtk_client.c:980
+#: src/gui_client/gtk_client.c:985
 #, c-format
 msgid "Health: %d"
 msgstr "(Pontos de vida: %d)"
 
-#: src/gui_client/gtk_client.c:997
+#. Display of the current player's name during combat
+#: src/gui_client/gtk_client.c:1002
 msgid "You"
 msgstr "(Você)"
 
-#: src/gui_client/gtk_client.c:1189
+#. Display of number of bitches in GTK+ client status window
+#. (%Tde="Bitches" by default)
+#: src/gui_client/gtk_client.c:1194
 msgid "%/GTK Stats: Bitches/%Tde"
 msgstr "%/Estatísticas: Putas/%Tde"
 
-#: src/gui_client/gtk_client.c:1301
+#: src/gui_client/gtk_client.c:1306
 msgid "%/Inventory drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1305
+#: src/gui_client/gtk_client.c:1310
 msgid "%/Inventory gun name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1404
+#. Title of 'Jet' dialog
+#: src/gui_client/gtk_client.c:1409
 msgid "Travel to location"
 msgstr "Ir para o local"
 
-#: src/gui_client/gtk_client.c:1447
+#: src/gui_client/gtk_client.c:1452
 msgid "%/Location to jet to/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1456
+#. Display of locations in 'Jet' window (%tde="The Bronx" etc. by
+#. default)
+#: src/gui_client/gtk_client.c:1461
 #, c-format
 msgid "_%c. %tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1491
+#. Display of the current price of the selected drug in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1496
 msgid "at %P"
 msgstr "em %P"
 
-#: src/gui_client/gtk_client.c:1498
+#. Display of current inventory of the selected drug in 'Deal Drugs'
+#. dialog (%tde="Opium" etc. by default)
+#: src/gui_client/gtk_client.c:1503
 #, c-format
 msgid "You are currently carrying %d %tde"
 msgstr "Você está atualmente carregando %d %tde"
 
-#: src/gui_client/gtk_client.c:1505
+#. Available space for drugs in 'Deal Drugs' dialog
+#: src/gui_client/gtk_client.c:1510
 #, c-format
 msgid "Available space: %d"
 msgstr "Espaço disponível: %d"
 
-#: src/gui_client/gtk_client.c:1518
+#. Number of the selected drug that you can afford in 'Deal Drugs'
+#. dialog
+#: src/gui_client/gtk_client.c:1523
 #, c-format
 msgid "You can afford %d"
 msgstr "Você pode comprar %d"
 
-#: src/gui_client/gtk_client.c:1591
+#: src/gui_client/gtk_client.c:1596
 msgid "Buy"
 msgstr "Comprar"
 
-#: src/gui_client/gtk_client.c:1593
+#: src/gui_client/gtk_client.c:1598
 msgid "Sell"
 msgstr "Vender"
 
-#: src/gui_client/gtk_client.c:1595
+#: src/gui_client/gtk_client.c:1600
 msgid "Drop"
 msgstr "Largar"
 
-#: src/gui_client/gtk_client.c:1664
+#: src/gui_client/gtk_client.c:1669
 msgid "%/DealDrugs drug name/%tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1701
+#. Prompts for action in the "deal drugs" dialog
+#: src/gui_client/gtk_client.c:1706
 msgid "Buy how many?"
 msgstr "Comprar que quantidade?"
 
-#: src/gui_client/gtk_client.c:1703
+#: src/gui_client/gtk_client.c:1708
 msgid "Sell how many?"
 msgstr "Vender que quantidade?"
 
-#: src/gui_client/gtk_client.c:1705
+#: src/gui_client/gtk_client.c:1710
 msgid "Drop how many?"
 msgstr "Largar que quantidade?"
 
-#: src/gui_client/gtk_client.c:1721 src/gui_client/gtk_client.c:2396
-#: src/gui_client/gtk_client.c:2565 src/gui_client/gtk_client.c:3005
-#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1728 src/gui_client/gtk_client.c:2577
-#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5381
-#: src/gtkport/gtkport.c:5507
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
+#: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: src/gui_client/gtk_client.c:1771
+#: src/gui_client/gtk_client.c:1776
 #, c-format
 msgid "Buy %tde"
 msgstr "Comprar %tde"
 
-#: src/gui_client/gtk_client.c:1773
+#: src/gui_client/gtk_client.c:1778
 #, c-format
 msgid "Sell %tde"
 msgstr "Vender %tde"
 
-#: src/gui_client/gtk_client.c:1775
+#: src/gui_client/gtk_client.c:1780
 #, c-format
 msgid "Drop %tde"
 msgstr "Largar %tde"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1886
-#: src/gtkport/gtkport.c:5381
+#. Button titles that correspond to the single-keypress options provided
+#. by the curses client (e.g. _Yes corresponds to 'Y' etc.)
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1891
+#: src/gtkport/gtkport.c:5370
 msgid "_Yes"
 msgstr "_Sim"
 
-#: src/gui_client/gtk_client.c:1839 src/gui_client/gtk_client.c:1889
-#: src/gtkport/gtkport.c:5381
+#: src/gui_client/gtk_client.c:1844 src/gui_client/gtk_client.c:1894
+#: src/gtkport/gtkport.c:5370
 msgid "_No"
 msgstr "_Não"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Attack"
 msgstr "_Atacar"
 
-#: src/gui_client/gtk_client.c:1840
+#: src/gui_client/gtk_client.c:1845
 msgid "_Evade"
 msgstr "_Evacuar"
 
-#: src/gui_client/gtk_client.c:1863
+#. Title of the 'ask player a question' dialog
+#: src/gui_client/gtk_client.c:1868
 msgid "Question"
 msgstr "Pergunta"
 
-#: src/gui_client/gtk_client.c:2017
+#. Available space label in GTK+ client status display
+#: src/gui_client/gtk_client.c:2022
 msgid "Space"
 msgstr "Espaço"
 
-#: src/gui_client/gtk_client.c:2080
+#. Caption of 'Jet' button in main window
+#: src/gui_client/gtk_client.c:2085
 msgid "_Travel!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2171 src/winmain.c:381 src/winmain.c:390
-msgid "dopewars"
-msgstr "Church Wars"
+#. Title of main window in GTK+ client
+#: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
+#: src/winmain.c:403 src/winmain.c:412
+msgid "Church Wars"
+msgstr ""
 
-#: src/gui_client/gtk_client.c:2306
+#. Credits labels in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2313
 msgid "English Translation"
 msgstr "Tradução de Portugal"
 
-#: src/gui_client/gtk_client.c:2306
+#: src/gui_client/gtk_client.c:2313
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2307
+#: src/gui_client/gtk_client.c:2314
 msgid "Icons and graphics"
 msgstr "Ícones e gráficos"
 
-#: src/gui_client/gtk_client.c:2308 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sons"
 
-#: src/gui_client/gtk_client.c:2309
+#: src/gui_client/gtk_client.c:2316
 msgid "History and Research"
 msgstr "Tráfico de Drogas e Pesquisas"
 
-#: src/gui_client/gtk_client.c:2310
+#: src/gui_client/gtk_client.c:2317
 msgid "Play Testing"
 msgstr "Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2311
+#: src/gui_client/gtk_client.c:2318
 msgid "Extensive Play Testing"
 msgstr "Extensivo Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2320
 msgid "Constructive Criticism"
 msgstr "Crítica Construtiva"
 
-#: src/gui_client/gtk_client.c:2315
+#: src/gui_client/gtk_client.c:2322
 msgid "Unconstructive Criticism"
 msgstr "Crítica não construtiva"
 
-#: src/gui_client/gtk_client.c:2323
+#. Title of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2330
 msgid "About Church Wars"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2334
+#. Main content of GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2341
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2170,7 +2364,8 @@ msgid ""
 "be afraid!”\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2361
+#. Version and copyright notice in GTK+ 'about' dialog
+#: src/gui_client/gtk_client.c:2368
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2179,120 +2374,146 @@ msgstr ""
 "Versão %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está lançado sob a GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2389
+#: src/gui_client/gtk_client.c:2396
 msgid "Original Church Wars information here:"
 msgstr "Original Church Wars information here:"
 
-#: src/gui_client/gtk_client.c:2442 src/gui_client/gtk_client.c:2494
+#. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
+#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título da janela do agiota/%Tde"
 
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2498
+#. Title of bank dialog - (%Tde="The Bank" by default)
+#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título da janela do NomeDoBanco/%Tde"
 
-#: src/gui_client/gtk_client.c:2458
+#: src/gui_client/gtk_client.c:2465
 msgid "You must enter a positive amount of money!"
 msgstr "Você precisa entrar uma quantidade positiva de dinheiro!"
 
-#: src/gui_client/gtk_client.c:2461
+#: src/gui_client/gtk_client.c:2468
 msgid "There isn't that much money available..."
 msgstr "Não há todo este dinheiro no banco..."
 
-#: src/gui_client/gtk_client.c:2514
+#. Display of player's cash in bank or loan shark dialog
+#: src/gui_client/gtk_client.c:2521
 msgid "Cash: %P"
 msgstr "Dinheiro: %P"
 
-#: src/gui_client/gtk_client.c:2520
+#. Display of player's debt in loan shark dialog
+#: src/gui_client/gtk_client.c:2527
 msgid "Debt: %P"
 msgstr "Débito: %P"
 
-#: src/gui_client/gtk_client.c:2523
+#. Display of player's bank balance in bank dialog
+#: src/gui_client/gtk_client.c:2530
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
-#: src/gui_client/gtk_client.c:2531
+#. Prompt for paying back a loan
+#: src/gui_client/gtk_client.c:2538
 msgid "Pay back:"
 msgstr "Pagar de volta:"
 
-#: src/gui_client/gtk_client.c:2535
+#. Radio button selected if you want to pay money into the bank
+#: src/gui_client/gtk_client.c:2542
 msgid "Deposit"
 msgstr "Depositar"
 
-#: src/gui_client/gtk_client.c:2541
+#. Radio button selected if you want to withdraw money from the bank
+#: src/gui_client/gtk_client.c:2548
 msgid "Withdraw"
 msgstr "Retirar"
 
-#: src/gui_client/gtk_client.c:2572
+#. Button to pay back the entire loan/debt
+#: src/gui_client/gtk_client.c:2579
 msgid "Pay all"
 msgstr "Pagar tudo"
 
-#: src/gui_client/gtk_client.c:2603
+#. Title of player list dialog
+#: src/gui_client/gtk_client.c:2610
 msgid "Player List"
 msgstr "Lista de jogadores"
 
-#: src/gui_client/gtk_client.c:2715
+#. Title of talk dialog
+#: src/gui_client/gtk_client.c:2718
 msgid "Talk to player(s)"
 msgstr "Falar com jogador(es)"
 
-#: src/gui_client/gtk_client.c:2737
+#. Checkbutton set if you want to talk to all players
+#: src/gui_client/gtk_client.c:2740
 msgid "Talk to all players"
 msgstr "Falar com todos os jogadores"
 
-#: src/gui_client/gtk_client.c:2743
+#. Prompt for you to enter the message to be sent to other players
+#: src/gui_client/gtk_client.c:2746
 msgid "Message:-"
 msgstr "Mensagem:-"
 
-#: src/gui_client/gtk_client.c:2758
+#. Button to send a message to other players
+#: src/gui_client/gtk_client.c:2761
 msgid "Send"
 msgstr "Mandar"
 
-#: src/gui_client/gtk_client.c:2839 src/gui_client/optdialog.c:677
+#. Column titles for display of drugs/guns carried or available for
+#. purchase
+#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nome"
 
-#: src/gui_client/gtk_client.c:2840 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preço"
 
-#: src/gui_client/gtk_client.c:2841
+#: src/gui_client/gtk_client.c:2844
 msgid "Number"
 msgstr "Número"
 
-#: src/gui_client/gtk_client.c:2844
+#. Button titles for buying/selling/dropping guns or drugs
+#: src/gui_client/gtk_client.c:2847
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2845
+#: src/gui_client/gtk_client.c:2848
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2846
+#: src/gui_client/gtk_client.c:2849
 msgid "_Drop <-"
 msgstr "_Largar <-"
 
-#: src/gui_client/gtk_client.c:2853
+#. Title of the display of available drugs/guns (%Tde = "Guns" or
+#. "Drugs" by default)
+#: src/gui_client/gtk_client.c:2856
 msgid "%Tde here"
 msgstr "%Tde aqui"
 
-#: src/gui_client/gtk_client.c:2859
+#. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
+#. by default)
+#: src/gui_client/gtk_client.c:2862
 msgid "%Tde carried"
 msgstr "%Tde carregados"
 
-#: src/gui_client/gtk_client.c:2978
+#. Title of dialog for changing a player's name
+#: src/gui_client/gtk_client.c:2981
 msgid "Change Name"
 msgstr "Mudar Nome"
 
-#: src/gui_client/gtk_client.c:2991
+#. Informational text to prompt the player to change his/her name
+#: src/gui_client/gtk_client.c:2994
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
 msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o:-"
 
-#: src/gui_client/gtk_client.c:3036
+#. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
+#. by default)
+#: src/gui_client/gtk_client.c:3039
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/Título da janela da LojaDeArmas/%Tde"
 
+#. Title of window to display reports from spies with other players
 #: src/gui_client/gtk_client.c:3098
 msgid "Spy reports"
 msgstr ""
@@ -2419,12 +2640,14 @@ msgid "Symbol prefixes prices"
 msgstr ""
 
 #: src/gui_client/optdialog.c:892
-msgid "Name of one cleric"
-msgstr ""
+#, fuzzy
+msgid "Name of one bitch"
+msgstr "Nome do bordel"
 
 #: src/gui_client/optdialog.c:897
-msgid "Name of several clerics"
-msgstr ""
+#, fuzzy
+msgid "Name of several bitches"
+msgstr "Nome do agiota"
 
 #: src/gui_client/optdialog.c:903
 msgid "Web browser"
@@ -2502,6 +2725,7 @@ msgstr "_Ajudar"
 msgid "You can't start the game without giving a name first!"
 msgstr "Você não pode iniciar um jogo antes de dar a ele um nome!"
 
+#. Title of 'New Game' dialog
 #: src/gui_client/newgamedia.c:67 src/gui_client/newgamedia.c:238
 msgid "New Game"
 msgstr "Novo Jogo"
@@ -2514,20 +2738,28 @@ msgstr "Status: Esperando por algo do usuário"
 msgid "Connection closed by remote host"
 msgstr "Conexão encerrada pelo host remoto"
 
+#. Error: GTK+ client could not connect to the given Church Wars server
 #: src/gui_client/newgamedia.c:97
 #, c-format
 msgid "Status: Could not connect (%s)"
 msgstr "Status: Não foi possível conectar (%s)"
 
+#. Tell the user that we've successfully connected to a SOCKS server,
+#. and are now ready to tell it to initiate the "real" connection
 #: src/gui_client/newgamedia.c:134
 #, c-format
 msgid "Status: Connected to SOCKS server %s..."
 msgstr "Status: Conectado ao servidor SOCKS %s..."
 
+#. Tell the user that the SOCKS server is asking us for a username
+#. and password
 #: src/gui_client/newgamedia.c:142
 msgid "Status: Authenticating with SOCKS server"
 msgstr "Statis: Autenticando com o servidor SOCKS"
 
+#. Tell the user that all necessary SOCKS authentication has been
+#. completed, and now we're going to try to have it connect to
+#. the final destination
 #: src/gui_client/newgamedia.c:149
 #, c-format
 msgid "Status: Asking SOCKS for connect to %s..."
@@ -2537,49 +2769,60 @@ msgstr "Status: Pedindo ao SOCKS para conectar a %s.."
 msgid "Greetings Trader, what's your _name?"
 msgstr "Ei carinha, qual o seu _nome?"
 
+#. Button to start a new single-player (standalone, non-network) game
 #: src/gui_client/newgamedia.c:273
 msgid "_Start single-player game"
 msgstr "_Iniciar jogo de um jogador"
 
-#: src/gtkport/gtkport.c:5508
+#: src/gtkport/gtkport.c:5482
 msgid "_Select"
 msgstr "_Selecionar"
 
-#: src/winmain.c:307
+#. Informational comment placed at the start of the Windows log file
+#. (this is used for messages printed during processing of the config
+#. files - under Unix these are just printed to stdout)
+#: src/winmain.c:329
 msgid ""
-"# This is the dopewars startup log, containing any\n"
+"# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
 "# file processing and the like.\n"
 "\n"
 msgstr ""
 
-#: src/winmain.c:348 src/serverside.c:1621
-msgid "dopewars server"
-msgstr "servidor Church Wars"
+#. Title of Church Wars server window (if used)
+#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#, fuzzy
+msgid "Church Wars server"
+msgstr "servidor Church Wars encerrando."
 
-#: src/winmain.c:369
-msgid "dopewars AI"
-msgstr "IA Church Wars"
+#. Title of the Windows window used for AI player output
+#: src/winmain.c:391
+msgid "Church Wars AI"
+msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:73
+#: src/serverside.c:74
 msgid "was attacked"
 msgstr ""
 
-#: src/serverside.c:79
+#. The two keys that are valid answers to the Attack/Evade question. If
+#. you wish to translate them, do so in the same order as they given here.
+#. You will also need to translate the answers given by the clients.
+#: src/serverside.c:80
 msgid "AE"
 msgstr ""
 
-#: src/serverside.c:129
+#. Help on various general server commands
+#: src/serverside.c:130
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2618,48 +2861,51 @@ msgstr ""
 "Variáveis válidas são mostradas abaixo:-\n"
 "\n"
 
-#: src/serverside.c:160
+#: src/serverside.c:161
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Falha ao conectar com metaservidor em %s (%s)"
 
-#: src/serverside.c:168 src/serverside.c:1053
+#: src/serverside.c:169 src/serverside.c:1051
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Meta servidor: %s"
 
-#: src/serverside.c:198
+#: src/serverside.c:199
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Tentativa de conectar ao metaservidor muito frequentemente - aguardando o "
 "próximo timeout"
 
-#: src/serverside.c:240
+#: src/serverside.c:241
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Aguardando para conectar ao metaservidor em %s..."
 
-#: src/serverside.c:298
+#: src/serverside.c:299
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
-"latest version from the^dopewars website, https://dopewars.sourceforge.io/."
+"latest version from the^Church Wars website, https://dopewars.sourceforge."
+"io/."
 msgstr ""
 
-#: src/serverside.c:307
+#: src/serverside.c:308
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
-"For the full \"experience\", get^the latest version of dopewars from "
+"For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:392
+#: src/serverside.c:386
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClientes (%d) excedido - cancelando conexão"
 
-#: src/serverside.c:398
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:392
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2667,7 +2913,9 @@ msgstr ""
 "Desculpe, mas este servidor tem um limite de 1 jogador, ao qual foi "
 "alcançado. Por favor tente conectar mais tarde."
 
-#: src/serverside.c:405
+#. Message sent to a player if the
+#. server is full
+#: src/serverside.c:399
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2676,55 +2924,63 @@ msgstr ""
 "Desculpe, mas este servidor tem um limite de %d jogadores, ao qual foi "
 "alcançado. Por favor tente conectar mais tarde."
 
-#: src/serverside.c:421
+#. A player changed their name during the game (unusual, and not
+#. really properly supported anyway) - notify all players of the
+#. change
+#: src/serverside.c:415
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s será conhecido como %s"
 
-#: src/serverside.c:436
+#: src/serverside.c:439
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: RECUSADO ir para local inválido %s"
 
-#: src/serverside.c:455
+#. Message displayed when a player reaches their maximum number of
+#. turns
+#: src/serverside.c:458
 msgid "Your trading time is up..."
 msgstr "Seu tempo de tráfico acabou..."
 
-#: src/serverside.c:474
+#. A player has tried to jet to a new location, but we don't allow
+#. them to. (e.g. they're still fighting someone, or they're
+#. supposed to be dead)
+#: src/serverside.c:477
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: RECUSADO ir para %s"
 
-#: src/serverside.c:533
+#: src/serverside.c:531
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensagem desconhecida: %s:%c:%s:%s"
 
-#: src/serverside.c:685
+#: src/serverside.c:683
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Mantendo o arquivo pid %s"
 
-#: src/serverside.c:691
+#: src/serverside.c:689
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Não foi possível criar o arquivo pid %s: %s"
 
-#: src/serverside.c:739
+#: src/serverside.c:737
 #, c-format
 msgid "Cannot create server (listening) socket (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:757
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot bind to port %u (%s) Aborting."
 msgstr ""
 
-#: src/serverside.c:765
+#: src/serverside.c:763
 msgid "Cannot listen to network socket. Aborting."
 msgstr ""
 
-#: src/serverside.c:771
+#: src/serverside.c:769
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -2732,116 +2988,119 @@ msgstr ""
 "servidor Church Wars versão %s pronto e esperando conexões\n"
 "na porta %d."
 
-#: src/serverside.c:784
+#. Warning messages displayed if we fail to trap various signals
+#: src/serverside.c:782
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGUSR1!"
 
-#: src/serverside.c:790
+#: src/serverside.c:788
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGHUP!"
 
-#: src/serverside.c:796
+#: src/serverside.c:794
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGINT!"
 
-#: src/serverside.c:799
+#: src/serverside.c:797
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGTERM!"
 
-#: src/serverside.c:804
+#: src/serverside.c:802
 msgid "Cannot install pipe handler!"
 msgstr "Não foi possível instalar o sinal de pipe!"
 
-#: src/serverside.c:868
+#: src/serverside.c:866
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Arquivo de configuração gravado OK como %s\n"
 
-#: src/serverside.c:902
+#: src/serverside.c:898
 msgid "Users currently logged on:-\n"
 msgstr "Usuários atualmente logados:-\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:906
 msgid "No users currently logged on!\n"
 msgstr "Nenhum usuário atualmente logado!\n"
 
-#: src/serverside.c:914
+#: src/serverside.c:910
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Retirando %s\n"
 
-#: src/serverside.c:917 src/serverside.c:928
+#: src/serverside.c:913 src/serverside.c:924
 msgid "No such user!\n"
 msgstr "Este usuário não existe!\n"
 
-#: src/serverside.c:923
+#. The named user has been removed from the server following
+#. a "kill" command
+#: src/serverside.c:919
 #, c-format
 msgid "%s killed\n"
 msgstr "%s morto\n"
 
-#: src/serverside.c:930
+#: src/serverside.c:926
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Comando desconhecido - tente \"help\" para ajuda...\n"
 
-#: src/serverside.c:949
+#: src/serverside.c:945
 #, c-format
 msgid "got connection from %s"
 msgstr "conexão de %s"
 
-#: src/serverside.c:962
+#: src/serverside.c:958
 msgid "Church Wars server terminating."
 msgstr "servidor Church Wars encerrando."
 
-#: src/serverside.c:971
+#: src/serverside.c:967
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s saiu do servidor!"
 
-#: src/serverside.c:1056
+#: src/serverside.c:1054
 msgid "MetaServer: (closed)"
 msgstr "MetaServidor: (fechado)"
 
-#: src/serverside.c:1155
+#: src/serverside.c:1153
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1235
-#, c-format
+#: src/serverside.c:1233
+#, fuzzy, c-format
 msgid ""
-"dopewars server version %s ready for admin commands; try \"help\" for help"
+"Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
-"servidor Church Wars versão %s pronto para comandos de administração; tente \\"
-"\"help\\\" para ajuda"
+"servidor Church Wars versão %s pronto para comandos de administração; tente "
+"\\\"help\\\" para ajuda"
 
-#: src/serverside.c:1238
+#: src/serverside.c:1236
 msgid "New admin connection"
 msgstr "Nova conexão de administrador"
 
-#: src/serverside.c:1249
+#: src/serverside.c:1247
 #, c-format
 msgid "Admin command: %s"
 msgstr "Comando de administração: %s"
 
-#: src/serverside.c:1255
+#: src/serverside.c:1253
 msgid "Admin connection closed"
 msgstr "Conexão de administrador encerrada"
 
-#: src/serverside.c:1504 src/serverside.c:1523 src/serverside.c:1530
+#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
 #: src/serverside.c:1668
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1510
+#: src/serverside.c:1508
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1519
+#: src/serverside.c:1517
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1545
+#: src/serverside.c:1543
 msgid "Failed to start NT Service"
 msgstr ""
 
@@ -2849,19 +3108,33 @@ msgstr ""
 msgid "Command:"
 msgstr "Comando:"
 
-#: src/serverside.c:1851
+#: src/serverside.c:1833
+#, fuzzy, c-format
+msgid ""
+"Cannot truncate backup (%s) of the\n"
+"high score file: %s."
+msgstr ""
+"Não foi possível criar backup (%s) do\n"
+"arquivo de recordes: %s."
+
+#: src/serverside.c:1857
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Não foi possível ler o arquivo de pontuação %s"
 
-#: src/serverside.c:1856
+#: src/serverside.c:1862
+#, fuzzy, c-format
+msgid "Cannot truncate high score file %s: %s."
+msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
+
+#: src/serverside.c:1868
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1864
+#: src/serverside.c:1877
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -2870,12 +3143,12 @@ msgstr ""
 "Não foi possível criar backup (%s) do\n"
 "arquivo de recordes: %s."
 
-#: src/serverside.c:1873
+#: src/serverside.c:1886
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
 
-#: src/serverside.c:1978
+#: src/serverside.c:1991
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -2887,132 +3160,139 @@ msgstr ""
 "Veja se você tem permissões para acessar este arquivo e diretório, ou\n"
 "especifique um arquivo de pontuação alternativo com a opção -f."
 
-#: src/serverside.c:1992
+#: src/serverside.c:2005
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
 "high score file - please check it. If it is a high score file\n"
-"from an older version of dopewars, then first convert it to the\n"
-"new format by running \"dopewars -C %s\"\n"
+"from an older version of Church Wars, then first convert it to the\n"
+"new format by running \"Church Wars -C %s\"\n"
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2002
+#: src/serverside.c:2015
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
-"file \"dopewars-log.txt\" for further details."
+"file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2007
+#: src/serverside.c:2020
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2084
+#: src/serverside.c:2066
+#, fuzzy, c-format
+msgid "Cannot truncate high score file: %s."
+msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
+
+#: src/serverside.c:2104
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Não foi possível ler o arquivo de pontuação %s"
 
-#: src/serverside.c:2114
+#: src/serverside.c:2134
 msgid "Congratulations! You made the high scores!"
 msgstr "Parabéns! Você entrou nas melhores pontuações!"
 
-#: src/serverside.c:2127
+#: src/serverside.c:2147
 msgid "You didn't even make the high score table..."
 msgstr "Você nem conseguiu entrar na tabela de melhores pontuações..."
 
-#: src/serverside.c:2148
+#: src/serverside.c:2168
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Não foi possível escrever no arquivo de pontuação %s"
 
-#: src/serverside.c:2175
+#: src/serverside.c:2195
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2237
+#: src/serverside.c:2257
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "A moça próxima a você no metrô lhe diz,^ \"%s\"%s"
 
-#: src/serverside.c:2241
+#: src/serverside.c:2261
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (ao menos, você -pensa- que foi o que ela disse)"
 
-#: src/serverside.c:2244
+#: src/serverside.c:2264
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Você escuta alguém tocando %s"
 
-#: src/serverside.c:2253 src/serverside.c:2262 src/serverside.c:2271
-#: src/serverside.c:2280
+#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
+#: src/serverside.c:2300
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Você gostaria de visitar %tde?"
 
-#: src/serverside.c:2293
+#: src/serverside.c:2313
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Você gostaria de contratar %tde por %P?"
 
-#: src/serverside.c:2306
+#: src/serverside.c:2326
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s está aqui!^Você Ataca, ou Evacua?"
 
-#: src/serverside.c:2373
+#: src/serverside.c:2393
 msgid "No Amirs or weapons!"
 msgstr "Nenhum policial ou armas!"
 
-#: src/serverside.c:2379
+#: src/serverside.c:2399
 msgid "Amirs cannot attack other amirs!"
 msgstr "Policiais não podem atacar outros policiais"
 
-#: src/serverside.c:2421
+#: src/serverside.c:2441
 msgid "Players are already in a fight!"
 msgstr "Jogadores já estão brigando!"
 
-#: src/serverside.c:2423
+#: src/serverside.c:2443
 msgid "Players are already in separate fights!"
 msgstr "Jogadores estão em lutas separadas!"
 
-#: src/serverside.c:2428
+#: src/serverside.c:2448
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Não é possível começar briga - nenhuma arma para usar!"
 
-#: src/serverside.c:2657
+#: src/serverside.c:2677
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2888
+#: src/serverside.c:2908
 msgid "You're dead! Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2897
+#: src/serverside.c:2917
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2926
+#: src/serverside.c:2946
 msgid "You were mugged outside Holy Mass!"
 msgstr "Você foi massacrado no metrô!"
 
-#: src/serverside.c:2938
+#: src/serverside.c:2958
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Você encontrou um amigo! Ele lhe dá %d %tde."
 
-#: src/serverside.c:2944
+#: src/serverside.c:2964
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Você encontrou um amigo! Você dá a ele %d %tde."
 
-#: src/serverside.c:2957
+#. Debugging message: we would normally have a random drug-related
+#. event here, but "Sanitized" mode is turned on
+#: src/serverside.c:2977
 msgid "Sanitized away a RandomOffer"
 msgstr "Sanitized away a RandomOffer"
 
-#: src/serverside.c:2962
+#: src/serverside.c:2982
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3020,42 +3300,42 @@ msgstr ""
 "Cães policiais caçam você por %d blocos! Você largou algum %tde! Que droga, "
 "cara!"
 
-#: src/serverside.c:2979
+#: src/serverside.c:2999
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Você acha %d %tde em um cara morto no metrô!"
 
-#: src/serverside.c:2994
+#: src/serverside.c:3014
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Sua mamãe fez comida com algumas de suas %tde! Ela estava ótima!"
 
-#: src/serverside.c:3004
+#: src/serverside.c:3024
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 "YN^Tem uma maconha aqui que cheira muito bem!^Parece bom! Você irá fumar? "
 
-#: src/serverside.c:3011
+#: src/serverside.c:3031
 #, c-format
 msgid "You stopped to %s."
 msgstr "Você parou para %s."
 
-#: src/serverside.c:3036
+#: src/serverside.c:3056
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Você gostaria de comprar um colete por %P?"
 
-#: src/serverside.c:3044
+#: src/serverside.c:3064
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Ei carinha! Eu posso ajudar você carregar %tde por meros %P. Sim ou não?"
 
-#: src/serverside.c:3057
+#: src/serverside.c:3077
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Você gostaria de comprar %tde por %P?"
 
-#: src/serverside.c:3239
+#: src/serverside.c:3262
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3063,29 +3343,29 @@ msgstr ""
 "Você alucionou por três dias na viagem mais louca que você jamais imaginou!"
 "^Então você morreu porque seu cérebro desintegrou!"
 
-#: src/serverside.c:3265
+#: src/serverside.c:3288
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Muito tarde - %s já saiu!"
 
-#: src/serverside.c:3339
+#: src/serverside.c:3362
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3575
+#: src/serverside.c:3602
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando atualizações pendentes ao metaservidor..."
 
-#: src/serverside.c:3580
+#: src/serverside.c:3607
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3589
+#: src/serverside.c:3616
 msgid "Player removed due to idle timeout"
 msgstr "Jogador removido por ter ficado muito tempo parado"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3629
 msgid "Player removed due to connect timeout"
 msgstr "Jogador removido por expiração da conexão"
 
@@ -3102,6 +3382,8 @@ msgstr ""
 msgid "Internal error code %d"
 msgstr "Código interno de erro %d"
 
+#. These are the explanations of the various
+#. Windows Sockets error codes
 #: src/error.c:154
 msgid "WinSock has not been properly initialized"
 msgstr ""
@@ -3166,6 +3448,7 @@ msgstr "Protocolo não suportado"
 msgid "Socket type not supported"
 msgstr "Tipo de socket não suportado"
 
+#. These are the explanations of the various name server error codes
 #: src/error.c:170 src/error.c:208
 msgid "Host not found"
 msgstr "Host não encontrado"
@@ -3206,150 +3489,150 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr "Nenhum servidor listado no metaservidor"
 
-#: src/message.c:1123
+#: src/message.c:1122
 msgid "Do you run?"
 msgstr "Você corre?"
 
-#: src/message.c:1126
+#: src/message.c:1125
 msgid "Do you run, or fight?"
 msgstr "Você corre, ou luta?"
 
-#: src/message.c:1325
+#: src/message.c:1321
 msgid "pitifully armed"
 msgstr "muito pouco armado"
 
-#: src/message.c:1326
+#: src/message.c:1322
 msgid "lightly armed"
 msgstr "pouco armado"
 
-#: src/message.c:1327
+#: src/message.c:1323
 msgid "moderately well armed"
 msgstr "moderamente bem armado"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "heavily armed"
 msgstr "pesadamente armado"
 
-#: src/message.c:1328
+#: src/message.c:1324
 msgid "armed to the 3rd heavens"
 msgstr "armado até os dentes"
 
-#: src/message.c:1332
+#: src/message.c:1328
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - está te perseguindo, cara!"
 
-#: src/message.c:1336
+#: src/message.c:1332
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s e %d %tde - %s - estão te perseguindo, cara!"
 
-#: src/message.c:1340
+#: src/message.c:1336
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s chega com %d %tde, %s!"
 
-#: src/message.c:1347
+#: src/message.c:1343
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s fica e pega"
 
-#: src/message.c:1349
+#: src/message.c:1345
 msgid "You stand there like a dummy."
 msgstr "Você fica parado como um panaca."
 
-#: src/message.c:1354
+#: src/message.c:1350
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s tenta escapar, mas falha."
 
-#: src/message.c:1357
+#: src/message.c:1353
 msgid "Panic! You can't get away!"
 msgstr "Pânico! Você não consegue escapar!"
 
-#: src/message.c:1366
+#: src/message.c:1362
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s fugiu para %tde!"
 
-#: src/message.c:1369
+#: src/message.c:1365
 #, c-format
 msgid "%s has got away!"
 msgstr "%s fugiu!"
 
-#: src/message.c:1372
+#: src/message.c:1368
 msgid "You got away!"
 msgstr "Você fugiu!"
 
-#: src/message.c:1378
+#: src/message.c:1374
 msgid "Weapons readied..."
 msgstr "Armas recarregadas..."
 
-#: src/message.c:1383
+#: src/message.c:1379
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s atira em %s... e erra!"
 
-#: src/message.c:1386
+#: src/message.c:1382
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s atira em você... e erra!"
 
-#: src/message.c:1389
+#: src/message.c:1385
 #, c-format
 msgid "You missed %s!"
 msgstr "Você errou em %s!"
 
-#: src/message.c:1395
+#: src/message.c:1391
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata %s."
 
-#: src/message.c:1398
+#: src/message.c:1394
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s atira em %s e mata uma %tde!"
 
-#: src/message.c:1401
+#: src/message.c:1397
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s é %s"
 
-#: src/message.c:1406
+#: src/message.c:1402
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1410
+#: src/message.c:1406
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s atirou em você... e matou uma %tde!"
 
-#: src/message.c:1413
+#: src/message.c:1409
 #, c-format
 msgid "%s hits you!"
 msgstr "%s acertou você, carinha!"
 
-#: src/message.c:1417
+#: src/message.c:1413
 #, c-format
 msgid "You killed %s!"
 msgstr "Você matou %s!"
 
-#: src/message.c:1419
+#: src/message.c:1415
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Você acertou %s, e matou uma %tde!"
 
-#: src/message.c:1422
+#: src/message.c:1418
 #, c-format
 msgid "You hit %s!"
 msgstr "Você acertou %s!"
 
-#: src/message.c:1425
+#: src/message.c:1421
 msgid " You find %P on the body!"
 msgstr "Você achou %P no corpo!"
 
-#: src/message.c:1427
+#: src/message.c:1423
 msgid " You prayerfully loot the body!"
 msgstr " Você roubou o corpo!"
 
@@ -3358,95 +3641,98 @@ msgstr " Você roubou o corpo!"
 msgid "Cannot initialize WinSock (%s)!"
 msgstr ""
 
-#: src/network.c:383
+#. SOCKS version 5 error messages
+#: src/network.c:400
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:384
+#: src/network.c:401
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:385
+#: src/network.c:402
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:386
+#: src/network.c:403
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:387
+#: src/network.c:404
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:388
+#: src/network.c:405
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:389
+#: src/network.c:406
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:390
+#: src/network.c:407
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:391
+#: src/network.c:408
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:392
+#: src/network.c:409
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:393
+#: src/network.c:410
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:394
+#: src/network.c:411
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
-#: src/network.c:397
+#. SOCKS version 4 error messages
+#: src/network.c:414
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:398
+#: src/network.c:415
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:400
+#: src/network.c:417
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
-#: src/network.c:403
+#. SOCKS errors due to protocol violations
+#: src/network.c:420
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:421
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:422
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:428
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1282
+#: src/network.c:1308
 msgid "Could not init curl"
 msgstr ""
 
 #: src/admin.c:52
 #, c-format
 msgid ""
-"Attempting to connect to local dopewars server via Unix domain\n"
+"Attempting to connect to local Church Wars server via Unix domain\n"
 " socket %s...\n"
 msgstr ""
 
-#: src/admin.c:70
+#: src/admin.c:74
 msgid ""
 "Connection established; use Ctrl-D to close your session.\n"
 "\n"
@@ -3454,19 +3740,30 @@ msgstr ""
 "Conexão estabelecida; use Ctrl-D para fechar sua sessão.\n"
 "\n"
 
-#: src/configfile.c:238
+#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
+#: src/configfile.c:265
+#, fuzzy, c-format
+msgid "Could not write to config file: %s"
+msgstr "Não foi possível abrir o arquivo %s: %s"
+
+#: src/configfile.c:225
+#, fuzzy, c-format
+msgid "Could not truncate config file: %s"
+msgstr "Não foi possível abrir o arquivo %s: %s"
+
+#: src/configfile.c:306
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:250
+#: src/configfile.c:318
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Não foi possível abrir o arquivo %s: %s"
 
 #: src/AIPlayer.c:76
-#, c-format
+#, fuzzy, c-format
 msgid ""
-"Could not connect to dopewars server\n"
+"Could not connect to Church Wars server\n"
 "(%s)\n"
 "AI Player terminating abnormally."
 msgstr ""
@@ -3519,93 +3816,94 @@ msgstr "Usando o nome %s\n"
 msgid "Players in this game:-\n"
 msgstr "Jogadores neste jogo:-\n"
 
-#: src/AIPlayer.c:352
+#: src/AIPlayer.c:345
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s entra no jogo.\n"
 
-#: src/AIPlayer.c:356
+#: src/AIPlayer.c:349
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s sai do jogo.\n"
 
-#: src/AIPlayer.c:360
+#: src/AIPlayer.c:353
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Indo para %tde com %P de dinheiro e %P de débito\n"
 
-#: src/AIPlayer.c:384
+#: src/AIPlayer.c:377
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jogador com IA morto. Terminando normalmente.\n"
 
-#: src/AIPlayer.c:405
+#: src/AIPlayer.c:398
 msgid "Game time is up. Leaving game.\n"
 msgstr "Tempo de jogo esgotando. Saindo do jogo.\n"
 
-#: src/AIPlayer.c:408
+#: src/AIPlayer.c:401
 msgid "AI Player pushed from the server.\n"
 msgstr "Jogador com IA retirado do servidor.\n"
 
-#: src/AIPlayer.c:411
+#: src/AIPlayer.c:404
 msgid "The server has terminated.\n"
 msgstr "O servidor foi acabado.\n"
 
-#: src/AIPlayer.c:480
+#: src/AIPlayer.c:473
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendendo %d %tde por %P\n"
 
-#: src/AIPlayer.c:495
+#: src/AIPlayer.c:488
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde por %P\n"
 
-#: src/AIPlayer.c:528
+#: src/AIPlayer.c:521
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando um %tde por %P na loja de armas\n"
 
-#: src/AIPlayer.c:579
+#: src/AIPlayer.c:576
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Débito de %P pago ao agiota\n"
 
-#: src/AIPlayer.c:611
+#: src/AIPlayer.c:608
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Agiota localizado em %s\n"
 
-#: src/AIPlayer.c:619
+#: src/AIPlayer.c:616
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Loja de armas localizada em %s\n"
 
-#: src/AIPlayer.c:627
+#: src/AIPlayer.c:624
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Bordel localizado em %s\n"
 
-#: src/AIPlayer.c:642
+#: src/AIPlayer.c:639
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Banco localizado em %s\n"
 
-#: src/AIPlayer.c:671
+#. Random messages to send from the AI player to other players
+#: src/AIPlayer.c:668
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vocês se acham traficantes de drogas?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:669
 msgid "A trained monkey could do better..."
 msgstr "Um macaco treinado pode até fazer melhor..."
 
-#: src/AIPlayer.c:673
+#: src/AIPlayer.c:670
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Acham que vocês são duros o bastante para lidar com gente como eu?"
 
-#: src/AIPlayer.c:674
+#: src/AIPlayer.c:671
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... vocês estão traficando doces ou o que?"
 
-#: src/AIPlayer.c:675
+#: src/AIPlayer.c:672
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Droga eu vou ter que simplesmente atirar em você pro seu próprio bem."
 
-#: src/AIPlayer.c:690
+#: src/AIPlayer.c:685
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3615,12 +3913,12 @@ msgstr ""
 "como um jogador com IA.\n"
 "Recompile passando a opção --enable-networking para o script configure."
 
-#: src/sound.c:216
+#: src/sound.c:220
 #, c-format
 msgid "Failed to open sound driver \"%s\"."
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: src/sound.c:225
+#: src/sound.c:229
 #, c-format
 msgid ""
 "Invalid plugin \"%s\" selected.\n"
@@ -3629,6 +3927,24 @@ msgstr ""
 "Plugin inválido \"%s\" selecionado.\n"
 "(%s disponível; agora usando \"%s\".)"
 
+#~ msgid "The command used to start your web browser"
+#~ msgstr "O comando usado para iniciar seu navegador"
+
+#~ msgid "Whom do you want to page (talk privately to) ? "
+#~ msgstr "Quem você quer pagear (falar privadamente) ? "
+
+#~ msgid "Talk: "
+#~ msgstr "Fale: "
+
+#~ msgid "dopewars"
+#~ msgstr "Church Wars"
+
+#~ msgid "dopewars server"
+#~ msgstr "servidor Church Wars"
+
+#~ msgid "dopewars AI"
+#~ msgstr "IA Church Wars"
+
 #~ msgid ""
 #~ "\n"
 #~ "For information on the command line options, type dopewars -h at your\n"
@@ -3636,8 +3952,8 @@ msgstr ""
 #~ "options.\n"
 #~ msgstr ""
 #~ "\n"
-#~ "Para informações sobre opções de linha de comando, digite Church Wars -h no "
-#~ "seu\n"
+#~ "Para informações sobre opções de linha de comando, digite Church Wars -h "
+#~ "no seu\n"
 #~ "prompt Unix. Isto irá mostrar a tela de ajuda, listando as opções "
 #~ "disponíveis.\n"
 
@@ -3682,7 +3998,6 @@ msgstr ""
 
 #~ msgid "SOCKS Authentication Required"
 #~ msgstr "Autenticação SOCKS Necessária"
-
 
 #~ msgid "gun"
 #~ msgstr "arma"
@@ -3947,8 +4262,8 @@ msgstr ""
 #~ "You\n"
 #~ "have one month of game time to make your fortune.\n"
 #~ msgstr ""
-#~ "Baseado no velho jogo Drug Wars de John E. Dell, Church Wars é uma simulação "
-#~ "de\n"
+#~ "Baseado no velho jogo Drug Wars de John E. Dell, Church Wars é uma "
+#~ "simulação de\n"
 #~ "um mercado de drogas imaginário. Church Wars é um jogo americano onde se "
 #~ "pode\n"
 #~ "comprar, vender, e tentar se safar dos policiais!\n"

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2475,7 +2475,7 @@ Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -a, --antique           \"antique\" Church Wars - keep as closely to the original\n\
                             version as possible (no networking)\n\
   -f, --scorefile=FILE    specify a file to use as the high score table (by\n\
-                            default %s/dopewars.sco is used)\n\
+                            default %s/churchwars.sco is used)\n\
   -o, --hostname=ADDR     specify a hostname where the server for multiplayer\n\
                             Church Wars can be found\n\
   -s, --public-server     run in server mode (note: see the -A option for\n\
@@ -2512,7 +2512,7 @@ Drug dealing game based on \"Drug Wars\" by John E. Dell\n\
   -a       \"antique\" Church Wars - keep as closely to the original version as\n\
               possible (no networking)\n\
   -f file  specify a file to use as the high score table\n\
-              (by default %s/dopewars.sco is used)\n\
+              (by default %s/churchwars.sco is used)\n\
   -o addr  specify a hostname where the server for multiplayer Church Wars\n\
               can be found\n\
   -s       run in server mode (note: see the -A option for configuring a\n\
@@ -2690,10 +2690,10 @@ struct CMDLINE *GeneralStartup(int argc, char *argv[])
   /* First, open the hard-coded high score file with possibly
    * elevated privileges */
 #ifdef CYGWIN
-  priv_hiscore = g_strdup_printf("%s/dopewars.sco",
+  priv_hiscore = g_strdup_printf("%s/churchwars.sco",
                                  appdata_path ? appdata_path : DPSCOREDIR);
 #else
-  priv_hiscore = g_strdup_printf("%s/dopewars.sco", DPSCOREDIR);
+  priv_hiscore = g_strdup_printf("%s/churchwars.sco", DPSCOREDIR);
 #endif
   HiScoreFile = g_strdup(priv_hiscore);
   OpenHighScoreFile();

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -1914,9 +1914,9 @@ static FILE *OpenHighScoreAppData(int *error, gboolean *empty)
         GString *str = g_string_sized_new(keylen + 40);
         g_string_assign(str, keyval);
         g_free(keyval);
-        g_string_append(str, "\\dopewars");
+        g_string_append(str, "\\churchwars");
         CreateDirectory(str->str, NULL);
-        g_string_append(str, "\\dopewars.sco");
+        g_string_append(str, "\\churchwars.sco");
         fp = fopen(str->str, "r+");
         if (!fp) {
           fp = fopen(str->str, "w+");


### PR DESCRIPTION
## Summary
- rename default scorefile references from dopewars.sco to churchwars.sco
- adjust server-side Windows path for private high score file
- regenerate translation catalogs for updated filename

## Testing
- `python3 tests/test_gun_balance.py`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689cab0fc4d083269e46adb58bbe584f