### PR TITLE
Update socket and high score directory names

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -976,7 +976,7 @@ void RemovePlayerFromServer(Player *Play)
 }
 
 #ifndef CYGWIN
-static gchar sockpref[] = "/tmp/.dopewars";
+static gchar sockpref[] = "/tmp/.churchwars";
 
 static gchar *GetLocalSockDir(void)
 {
@@ -1914,7 +1914,7 @@ static FILE *OpenHighScoreAppData(int *error, gboolean *empty)
         GString *str = g_string_sized_new(keylen + 40);
         g_string_assign(str, keyval);
         g_free(keyval);
-        g_string_append(str, "\\dopewars");
+        g_string_append(str, "\\churchwars");
         CreateDirectory(str->str, NULL);
         g_string_append(str, "\\dopewars.sco");
         fp = fopen(str->str, "r+");


### PR DESCRIPTION
## Summary
- point server-side socket prefix to `/tmp/.churchwars`
- store Windows high score files under `\churchwars`

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc -DNETWORKING -I src tests/test_socks5.c src/network.c src/error.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0)` *(fails: Package glib-2.0 was not found)*
- `gcc -DNETWORKING -I src tests/test_sound.c src/sound.c -o tests/test_sound $(pkg-config --cflags --libs glib-2.0)` *(fails: Package glib-2.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cab1e0da883268fb10465557cbfc2