### PR TITLE
Clean up AI player on connection failure

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -162,6 +162,9 @@ void AIPlayerLoop(struct CMDLINE *cmdline)
 
   if (!StartNetworkBufferConnect(netbuf, NULL, ServerName, Port)) {
     AIConnectFailed(netbuf);
+    g_warning(_("Failed to connect to server; cleaning up."));
+    g_string_free(errstr, TRUE);
+    FirstClient = RemovePlayer(AIPlay, FirstClient);
     return;
   } else {
     SetNetworkBufferUserPasswdFunc(netbuf, NetBufAuth, NULL);


### PR DESCRIPTION
## Summary
- Free error string and player when network connection fails in AIPlayerLoop
- Log warning before exiting to aid diagnostics

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689cb01494e88326971e3a0df96ec74f