### PR TITLE
Graceful AI select error handling

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -132,13 +132,14 @@ static void NetBufAuth(NetworkBuffer *netbuf, gpointer data)
  * Main loop for AI players. Connects to server, plays game,
  * and then disconnects.
  */
-void AIPlayerLoop(struct CMDLINE *cmdline)
+gboolean AIPlayerLoop(struct CMDLINE *cmdline)
 {
   GString *errstr;
   gchar *msg;
   Player *AIPlay;
   fd_set readfs, writefs;
   gboolean DoneOK, QuitRequest, datawaiting;
+  gboolean status = TRUE;
   int MaxSock;
   NBStatus oldstatus;
   NBSocksStatus oldsocks;
@@ -162,7 +163,8 @@ void AIPlayerLoop(struct CMDLINE *cmdline)
 
   if (!StartNetworkBufferConnect(netbuf, NULL, ServerName, Port)) {
     AIConnectFailed(netbuf);
-    return;
+    status = FALSE;
+    goto cleanup;
   } else {
     SetNetworkBufferUserPasswdFunc(netbuf, NetBufAuth, NULL);
     if (netbuf->status == NBS_CONNECTED) {
@@ -184,8 +186,9 @@ void AIPlayerLoop(struct CMDLINE *cmdline)
     if (bselect(MaxSock, &readfs, &writefs, NULL, NULL) == -1) {
       if (errno == EINTR)
         continue;
-      printf("Error in select\n");
-      exit(EXIT_FAILURE);
+      g_warning("Error in select: %s", g_strerror(errno));
+      status = FALSE;
+      break;
     }
 
     datawaiting =
@@ -217,12 +220,15 @@ void AIPlayerLoop(struct CMDLINE *cmdline)
     }
     if (!DoneOK) {
       g_print(_("Connection to server lost!\n"));
+      status = FALSE;
       break;
     }
   }
+cleanup:
   ShutdownNetwork(AIPlay);
   g_string_free(errstr, TRUE);
   FirstClient = RemovePlayer(AIPlay, FirstClient);
+  return status;
 }
 
 /* 

--- a/src/AIPlayer.h
+++ b/src/AIPlayer.h
@@ -27,7 +27,9 @@
 #include <config.h>
 #endif
 
+#include <glib.h>
+
 struct CMDLINE;
-void AIPlayerLoop(struct CMDLINE *cmdline);
+gboolean AIPlayerLoop(struct CMDLINE *cmdline);
 
 #endif /* __DP_AIPLAYER_H__ */

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2847,6 +2847,7 @@ static void DefaultLogMessage(const gchar *log_domain,
 int main(int argc, char *argv[])
 {
   struct CMDLINE *cmdline;
+  int retcode = 0;
 #ifdef ENABLE_NLS
   const char *charset;
   setlocale(LC_ALL, "");
@@ -2895,7 +2896,8 @@ int main(int argc, char *argv[])
                 "configure script.\n"));
 #endif /* NETWORKING */
     } else if (cmdline->ai) {
-      AIPlayerLoop(cmdline);
+      if (!AIPlayerLoop(cmdline))
+        retcode = 1;
     } else
       switch (cmdline->client) {
       case CLIENT_AUTO:
@@ -2919,7 +2921,7 @@ int main(int argc, char *argv[])
   g_free(PidFile);
   g_free(Log.File);
   SoundClose();
-  return 0;
+  return retcode;
 }
 
 #endif /* CYGWIN */

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -285,6 +285,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   gboolean is_service;
   gchar *modpath;
   struct CMDLINE *cmdline;
+  int retcode = 0;
 
 #ifdef ENABLE_NLS
   gchar *winlocale;
@@ -394,7 +395,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                         LogMask() | G_LOG_LEVEL_MESSAGE |
                         G_LOG_LEVEL_WARNING, ServerLogMessage, NULL);
       g_set_print_handler(ServerPrintFunc);
-      AIPlayerLoop(cmdline);
+      if (!AIPlayerLoop(cmdline))
+        retcode = 1;
     } else {
       switch (cmdline->client) {
       case CLIENT_AUTO:
@@ -426,7 +428,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   g_free(PidFile);
   g_free(Log.File);
   SoundClose();
-  return 0;
+  return retcode;
 }
 
 #endif /* CYGWIN */


### PR DESCRIPTION
## Summary
- Replace abrupt termination on select errors in AI player with logged warnings and graceful cleanup
- Return status from `AIPlayerLoop` and propagate errors to main callers
- Update AI player interface to use GLib types

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars.)*

------
https://chatgpt.com/codex/tasks/task_e_689cb01686f483268d94f65c3fd21909