### PR TITLE
Handle curl initialization failures

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2682,7 +2682,14 @@ void CursesLoop(struct CMDLINE *cmdline)
 
   start_curses();
 #ifdef NETWORKING
-  CurlInit(&MetaConn);
+  {
+    GError *tmp_error = NULL;
+    if (!CurlInit(&MetaConn, &tmp_error)) {
+      g_warning(_("Cannot initialize networking: %s"), tmp_error->message);
+      g_error_free(tmp_error);
+      WantNetwork = FALSE;
+    }
+  }
 #endif
   Width = COLS;
   Depth = LINES;
@@ -2715,6 +2722,7 @@ void CursesLoop(struct CMDLINE *cmdline)
   FirstClient = RemovePlayer(Play, FirstClient);
   end_curses();
 #ifdef NETWORKING
-  CurlCleanup(&MetaConn);
+  if (MetaConn.h && MetaConn.multi)
+    CurlCleanup(&MetaConn);
 #endif
 }

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2268,13 +2268,20 @@ gboolean GtkLoop(int *argc, char **argv[],
   SetIcon(window, churchwars_pill_xpm);
 
 #ifdef NETWORKING
-  CurlInit(&MetaConn);
+  {
+    GError *tmp_error = NULL;
+    if (!CurlInit(&MetaConn, &tmp_error)) {
+      g_warning(_("Cannot initialize networking: %s"), tmp_error->message);
+      g_error_free(tmp_error);
+    }
+  }
 #endif
 
   gtk_main();
 
 #ifdef NETWORKING
-  CurlCleanup(&MetaConn);
+  if (MetaConn.h && MetaConn.multi)
+    CurlCleanup(&MetaConn);
 #endif
 
   /* Free the main player */

--- a/src/network.c
+++ b/src/network.c
@@ -1151,11 +1151,12 @@ static size_t MetaConnHeaderFunc(char *contents, size_t size, size_t nmemb,
   return realsize;
 }
 
-void CurlInit(CurlConnection *conn)
+gboolean CurlInit(CurlConnection *conn, GError **err)
 {
-  curl_global_init(CURL_GLOBAL_DEFAULT);
-  conn->multi = curl_multi_init();
-  conn->h = curl_easy_init();
+  CURLcode res;
+
+  conn->multi = NULL;
+  conn->h = NULL;
   conn->running = FALSE;
   conn->Terminator = '\n';
   conn->StripChar = '\r';
@@ -1163,6 +1164,32 @@ void CurlInit(CurlConnection *conn)
   conn->headers = NULL;
   conn->timer_cb = NULL;
   conn->socket_cb = NULL;
+
+  res = curl_global_init(CURL_GLOBAL_DEFAULT);
+  if (res != CURLE_OK) {
+    g_set_error_literal(err, DOPE_CURL_ERROR, res, curl_easy_strerror(res));
+    return FALSE;
+  }
+
+  conn->multi = curl_multi_init();
+  if (!conn->multi) {
+    g_set_error_literal(err, DOPE_CURLM_ERROR, 0,
+                        _("curl_multi_init failed"));
+    curl_global_cleanup();
+    return FALSE;
+  }
+
+  conn->h = curl_easy_init();
+  if (!conn->h) {
+    g_set_error_literal(err, DOPE_CURL_ERROR, 0,
+                        _("curl_easy_init failed"));
+    curl_multi_cleanup(conn->multi);
+    conn->multi = NULL;
+    curl_global_cleanup();
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 void CloseCurlConnection(CurlConnection *conn)

--- a/src/network.h
+++ b/src/network.h
@@ -200,7 +200,7 @@ GQuark dope_curl_error_quark(void);
 #define DOPE_CURLM_ERROR dope_curlm_error_quark()
 GQuark dope_curlm_error_quark(void);
 
-void CurlInit(CurlConnection *conn);
+gboolean CurlInit(CurlConnection *conn, GError **err);
 void CurlCleanup(CurlConnection *conn);
 gboolean OpenCurlConnection(CurlConnection *conn, char *URL, char *body,
                             GError **err);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -807,7 +807,12 @@ static gboolean StartServer(void)
 
 static void InitMetaServer()
 {
-  CurlInit(&MetaConn);
+  GError *tmp_error = NULL;
+  if (!CurlInit(&MetaConn, &tmp_error)) {
+    g_critical(_("Cannot initialize networking: %s"), tmp_error->message);
+    g_error_free(tmp_error);
+    exit(EXIT_FAILURE);
+  }
 #ifdef GUI_SERVER
   SetCurlCallback(&MetaConn, glib_timeout, glib_socket);
 #endif
@@ -1309,7 +1314,8 @@ void ServerLoop(struct CMDLINE *cmdline)
   StopServer();
   g_string_free(LineBuf, TRUE);
 
-  CurlCleanup(&MetaConn);
+  if (MetaConn.h && MetaConn.multi)
+    CurlCleanup(&MetaConn);
 }
 
 #ifdef GUI_SERVER


### PR DESCRIPTION
## Summary
- validate curl initialization steps and return errors on failure
- guard callers against failed curl setup and clean up only when initialized

## Testing
- ❌ `pytest tests/test_gun_balance.py` *(internal SystemExit during collection)*
- ❌ `gcc tests/test_socks5.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0)` *(missing glib-2.0 development files)*

------
https://chatgpt.com/codex/tasks/task_e_689cb25dd98c8326887f1a5661264efe