### PR TITLE
Use size_t for read buffer lengths

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -448,7 +448,7 @@ void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,
                           gchar *password)
 {
   gchar *addpt;
-  guint addlen;
+  size_t addlen;
   ConnBuf *conn;
 
   if (!user || !password || !user[0] || !password[0]) {
@@ -457,8 +457,8 @@ void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,
     return;
   }
 
-  guint userlen = strlen(user);
-  guint passlen = strlen(password);
+  size_t userlen = strlen(user);
+  size_t passlen = strlen(password);
 
   /* Only continue if lengths are within SOCKS5 limits */
   if (userlen > 255 || passlen > 255) {
@@ -488,7 +488,7 @@ void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,
 static gboolean Socks5Connect(NetworkBuffer *NetBuf)
 {
   gchar *addpt;
-  guint addlen, hostlen;
+  size_t addlen, hostlen;
   ConnBuf *conn;
   unsigned short int netport;
 
@@ -509,7 +509,7 @@ static gboolean Socks5Connect(NetworkBuffer *NetBuf)
   addpt[1] = 1;                 /* CONNECT */
   addpt[2] = 0;                 /* reserved - must be zero */
   addpt[3] = 3;                 /* Address type - FQDN */
-  addpt[4] = hostlen;           /* Length of address */
+  addpt[4] = (guchar)hostlen;           /* Length of address */
   memcpy(&addpt[5], NetBuf->host, hostlen);
   memcpy(&addpt[5 + hostlen], &netport, sizeof(netport));
   addpt[5 + hostlen + sizeof(netport)] = '\0';
@@ -525,12 +525,12 @@ static gboolean HandleSocksReply(NetworkBuffer *NetBuf)
 {
   gchar *data;
   guchar addrtype;
-  guint replylen;
+  size_t replylen;
   gboolean retval = TRUE;
 
   if (NetBuf->socks->version == 5) {
     if (NetBuf->sockstat == NBSS_METHODS) {
-      data = GetWaitingData(NetBuf, 2);
+      data = GetWaitingData(NetBuf, (size_t)2);
       if (data) {
         retval = FALSE;
         if (data[0] != 5) {
@@ -545,7 +545,7 @@ static gboolean HandleSocksReply(NetworkBuffer *NetBuf)
         g_free(data);
       }
     } else if (NetBuf->sockstat == NBSS_USERPASSWD) {
-      data = GetWaitingData(NetBuf, 2);
+      data = GetWaitingData(NetBuf, (size_t)2);
       if (data) {
         retval = FALSE;
         if (data[1] != 0) {
@@ -556,7 +556,7 @@ static gboolean HandleSocksReply(NetworkBuffer *NetBuf)
         g_free(data);
       }
     } else if (NetBuf->sockstat == NBSS_CONNECT) {
-      data = PeekWaitingData(NetBuf, 5);
+      data = PeekWaitingData(NetBuf, (size_t)5);
       if (data) {
         retval = FALSE;
         addrtype = data[3];
@@ -588,7 +588,7 @@ static gboolean HandleSocksReply(NetworkBuffer *NetBuf)
     }
     return retval;
   } else {
-    data = GetWaitingData(NetBuf, 8);
+    data = GetWaitingData(NetBuf, (size_t)8);
     if (data) {
       retval = FALSE;
       if (data[0] != 0) {
@@ -755,32 +755,44 @@ gint CountWaitingMessages(NetworkBuffer *NetBuf)
   return msgs;
 }
 
-gchar *PeekWaitingData(NetworkBuffer *NetBuf, int numbytes)
+gchar *PeekWaitingData(NetworkBuffer *NetBuf, size_t numbytes)
 {
   ConnBuf *conn;
 
+  if (numbytes == 0 || numbytes > MAXREADBUF) {
+    if (NetBuf)
+      SetError(&NetBuf->error, ET_CUSTOM, E_FULLBUF, NULL);
+    return NULL;
+  }
+
   conn = &NetBuf->ReadBuf;
-  if (!conn->Data || conn->DataPresent < numbytes)
+  if (!conn->Data || (size_t)conn->DataPresent < numbytes)
     return NULL;
   else
     return conn->Data;
 }
 
-gchar *GetWaitingData(NetworkBuffer *NetBuf, int numbytes)
+gchar *GetWaitingData(NetworkBuffer *NetBuf, size_t numbytes)
 {
   ConnBuf *conn;
   gchar *data;
 
+  if (numbytes == 0 || numbytes > MAXREADBUF) {
+    if (NetBuf)
+      SetError(&NetBuf->error, ET_CUSTOM, E_FULLBUF, NULL);
+    return NULL;
+  }
+
   conn = &NetBuf->ReadBuf;
-  if (!conn->Data || conn->DataPresent < numbytes)
+  if (!conn->Data || (size_t)conn->DataPresent < numbytes)
     return NULL;
 
   data = g_new(gchar, numbytes);
   memcpy(data, conn->Data, numbytes);
 
   memmove(&conn->Data[0], &conn->Data[numbytes],
-          conn->DataPresent - numbytes);
-  conn->DataPresent -= numbytes;
+          (size_t)conn->DataPresent - numbytes);
+  conn->DataPresent -= (gint)numbytes;
 
   return data;
 }
@@ -878,11 +890,11 @@ gboolean ReadDataFromWire(NetworkBuffer *NetBuf)
   return TRUE;
 }
 
-gchar *ExpandWriteBuffer(ConnBuf *conn, int numbytes, LastError **error)
+gchar *ExpandWriteBuffer(ConnBuf *conn, size_t numbytes, LastError **error)
 {
   int newlen;
 
-  newlen = conn->DataPresent + numbytes;
+  newlen = conn->DataPresent + (int)numbytes;
   if (newlen > conn->Length) {
     conn->Length *= 2;
     conn->Length = MAX(conn->Length, newlen);
@@ -900,9 +912,9 @@ gchar *ExpandWriteBuffer(ConnBuf *conn, int numbytes, LastError **error)
 }
 
 void CommitWriteBuffer(NetworkBuffer *NetBuf, ConnBuf *conn,
-                       gchar *addpt, guint addlen)
+                       gchar *addpt, size_t addlen)
 {
-  conn->DataPresent += addlen;
+  conn->DataPresent += (gint)addlen;
 
   /* If the buffer was empty before, we may need to tell the owner to
    * check the socket for write-ready status */
@@ -920,7 +932,7 @@ void CommitWriteBuffer(NetworkBuffer *NetBuf, ConnBuf *conn,
 gboolean QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data)
 {
   gchar *addpt;
-  guint addlen;
+  size_t addlen;
   ConnBuf *conn;
 
   conn = &NetBuf->WriteBuf;
@@ -961,11 +973,11 @@ static void SetAIError(LastError **error, int errcode)
 gboolean StartSocksNegotiation(NetworkBuffer *NetBuf, gchar *RemoteHost,
                                unsigned RemotePort)
 {
-  guint num_methods;
+  size_t num_methods;
   ConnBuf *conn;
   struct addrinfo hints, *res;
   gchar *addpt;
-  guint addlen, i;
+  size_t addlen, i;
   struct in_addr haddr;
   unsigned short int netport;
   gchar *username = NULL;
@@ -989,7 +1001,7 @@ gboolean StartSocksNegotiation(NetworkBuffer *NetBuf, gchar *RemoteHost,
     if (!addpt)
       goto fail;
     addpt[0] = 5;               /* SOCKS version 5 */
-    addpt[1] = num_methods;
+    addpt[1] = (guchar)num_methods;
     i = 2;
     addpt[i++] = SM_NOAUTH;
     if (NetBuf->userpasswd)

--- a/src/network.h
+++ b/src/network.h
@@ -51,6 +51,7 @@
 #endif
 #endif
 
+#include <stddef.h>
 #include <glib.h>
 
 #include "error.h"
@@ -188,11 +189,11 @@ gint CountWaitingMessages(NetworkBuffer *NetBuf);
 gchar *GetWaitingMessage(NetworkBuffer *NetBuf);
 void SendSocks5UserPasswd(NetworkBuffer *NetBuf, gchar *user,
                           gchar *password);
-gchar *GetWaitingData(NetworkBuffer *NetBuf, int numbytes);
-gchar *PeekWaitingData(NetworkBuffer *NetBuf, int numbytes);
-gchar *ExpandWriteBuffer(ConnBuf *conn, int numbytes, LastError **error);
+gchar *GetWaitingData(NetworkBuffer *NetBuf, size_t numbytes);
+gchar *PeekWaitingData(NetworkBuffer *NetBuf, size_t numbytes);
+gchar *ExpandWriteBuffer(ConnBuf *conn, size_t numbytes, LastError **error);
 void CommitWriteBuffer(NetworkBuffer *NetBuf, ConnBuf *conn, gchar *addpt,
-                       guint addlen);
+                       size_t addlen);
 
 #define DOPE_CURL_ERROR dope_curl_error_quark()
 GQuark dope_curl_error_quark(void);


### PR DESCRIPTION
## Summary
- switch network buffer data access helpers to size_t lengths
- reject zero or oversized reads to prevent invalid buffer usage
- update SOCKS negotiation code for new size_t interfaces

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689cb262a6dc8326995293b0ea38aaef