### PR TITLE
Propagate errors instead of exiting in network and server code

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2697,7 +2697,9 @@ struct CMDLINE *GeneralStartup(int argc, char *argv[])
 #endif
   HiScoreFile = g_strdup(priv_hiscore);
   OpenHighScoreFile();
-  DropPrivileges();
+  if (!DropPrivileges()) {
+    g_warning("Failed to drop privileges");
+  }
 
   /* Initialize variables */
   Log.File = g_strdup("");

--- a/src/message.c
+++ b/src/message.c
@@ -965,7 +965,21 @@ void InitNetwork(void)
 {
   netconv = Conv_New();
 #ifdef NETWORKING
-  StartNetworking();
+  {
+    LastError *error = NULL;
+    GString *errstr;
+    if (!StartNetworking(&error)) {
+      errstr = g_string_new("");
+      if (error)
+        g_string_assign_error(errstr, error);
+      g_log(NULL, G_LOG_LEVEL_CRITICAL,
+            _("Cannot initialize networking (%s)!"), errstr->str);
+      g_string_free(errstr, TRUE);
+      if (error)
+        FreeError(error);
+      return;
+    }
+  }
 #endif
 }
 

--- a/src/network.c
+++ b/src/network.c
@@ -49,7 +49,7 @@
 
 #include <glib.h>
 #include <errno.h>              /* For errno and Unix error codes */
-#include <stdlib.h>             /* For exit() and atoi() */
+#include <stdlib.h>             /* For atoi() */
 #include <stdio.h>              /* For perror() */
 
 #include "error.h"
@@ -77,22 +77,15 @@ static gboolean StartConnect(int *fd, const gchar *bindaddr, gchar *RemoteHost,
 
 #ifdef CYGWIN
 
-void StartNetworking()
+gboolean StartNetworking(LastError **error)
 {
   WSADATA wsaData;
-  LastError *error;
-  GString *errstr;
 
   if (WSAStartup(MAKEWORD(1, 0), &wsaData) != 0) {
-    error = NewError(ET_WINSOCK, WSAGetLastError(), NULL);
-    errstr = g_string_new("");
-    g_string_assign_error(errstr, error);
-    g_log(NULL, G_LOG_LEVEL_CRITICAL, _("Cannot initialize WinSock (%s)!"),
-          errstr->str);
-    g_string_free(errstr, TRUE);
-    FreeError(error);
-    exit(EXIT_FAILURE);
+    SetError(error, ET_WINSOCK, WSAGetLastError(), NULL);
+    return FALSE;
   }
+  return TRUE;
 }
 
 void StopNetworking()
@@ -100,15 +93,17 @@ void StopNetworking()
   WSACleanup();
 }
 
-void SetReuse(SOCKET sock)
+gboolean SetReuse(SOCKET sock, LastError **error)
 {
   BOOL i = TRUE;
 
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&i,
                  sizeof(i)) == -1) {
-    perror("setsockopt");
-    exit(EXIT_FAILURE);
+    if (error)
+      SetError(error, ET_WINSOCK, WSAGetLastError(), NULL);
+    return FALSE;
   }
+  return TRUE;
 }
 
 gboolean SetBlocking(SOCKET sock, gboolean blocking)
@@ -121,22 +116,26 @@ gboolean SetBlocking(SOCKET sock, gboolean blocking)
 
 #else
 
-void StartNetworking()
+gboolean StartNetworking(LastError **error)
 {
+  (void)error;
+  return TRUE;
 }
 
 void StopNetworking()
 {
 }
 
-void SetReuse(int sock)
+gboolean SetReuse(int sock, LastError **error)
 {
   int i = 1;
 
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i)) == -1) {
-    perror("setsockopt");
-    exit(EXIT_FAILURE);
+    if (error)
+      SetError(error, ET_ERRNO, errno, NULL);
+    return FALSE;
   }
+  return TRUE;
 }
 
 gboolean SetBlocking(int sock, gboolean blocking)

--- a/src/network.h
+++ b/src/network.h
@@ -217,16 +217,16 @@ void SetCurlCallback(CurlConnection *conn, GSourceFunc timer_cb,
 int CreateTCPSocket(LastError **error);
 gboolean BindTCPSocket(int sock, const gchar *addr, unsigned port,
                        LastError **error);
-void StartNetworking(void);
+gboolean StartNetworking(LastError **error);
 void StopNetworking(void);
 
 #ifdef CYGWIN
 #define CloseSocket(sock) closesocket(sock)
-void SetReuse(SOCKET sock);
+gboolean SetReuse(SOCKET sock, LastError **error);
 gboolean SetBlocking(SOCKET sock, gboolean blocking);
 #else
 #define CloseSocket(sock) close(sock)
-void SetReuse(int sock);
+gboolean SetReuse(int sock, LastError **error);
 gboolean SetBlocking(int sock, gboolean blocking);
 #endif
 

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -734,16 +734,25 @@ static gboolean StartServer(void)
     errstr = g_string_new("");
     g_string_assign_error(errstr, sockerr);
     g_log(NULL, G_LOG_LEVEL_CRITICAL,
-          _("Cannot create server (listening) socket (%s) Aborting."),
+          _("Cannot create server (listening) socket (%s)"),
           errstr->str);
     g_string_free(errstr, TRUE);
     FreeError(sockerr);
-    exit(EXIT_FAILURE);
+    return FALSE;
   }
 
   /* This doesn't seem to work properly under Win32 */
 #ifndef CYGWIN
-  SetReuse(ListenSock);
+  if (!SetReuse(ListenSock, &sockerr)) {
+    errstr = g_string_new("");
+    g_string_assign_error(errstr, sockerr);
+    g_log(NULL, G_LOG_LEVEL_CRITICAL,
+          _("Cannot set socket reuse option (%s)"), errstr->str);
+    g_string_free(errstr, TRUE);
+    FreeError(sockerr);
+    CloseSocket(ListenSock);
+    return FALSE;
+  }
 #endif
 
   SetBlocking(ListenSock, FALSE);
@@ -752,16 +761,18 @@ static gboolean StartServer(void)
     errstr = g_string_new("");
     g_string_assign_error(errstr, sockerr);
     g_log(NULL, G_LOG_LEVEL_CRITICAL,
-          _("Cannot bind to port %u (%s) Aborting."), Port, errstr->str);
+          _("Cannot bind to port %u (%s)"), Port, errstr->str);
     g_string_free(errstr, TRUE);
     FreeError(sockerr);
-    exit(EXIT_FAILURE);
+    CloseSocket(ListenSock);
+    return FALSE;
   }
 
   if (listen(ListenSock, 10) == SOCKET_ERROR) {
     g_log(NULL, G_LOG_LEVEL_CRITICAL,
-          _("Cannot listen to network socket. Aborting."));
-    exit(EXIT_FAILURE);
+          _("Cannot listen to network socket."));
+    CloseSocket(ListenSock);
+    return FALSE;
   }
 
   /* Initial startup message for the server */
@@ -940,7 +951,7 @@ Player *HandleNewConnection(void)
   if ((ClientSock = accept(ListenSock, (struct sockaddr *)&ClientAddr,
                             &cadsize)) == -1) {
     perror("accept socket");
-    exit(EXIT_FAILURE);
+    return NULL;
   }
   dopelog(2, LF_SERVER, _("got connection from %s"),
           inet_ntoa(ClientAddr.sin_addr));
@@ -1450,7 +1461,8 @@ static gboolean GuiNewConnect(GIOChannel *source, GIOCondition condition,
 
   if (condition & G_IO_IN) {
     Play = HandleNewConnection();
-    SetNetworkBufferCallBack(&Play->NetBuf, SocketStatus, (gpointer)Play);
+    if (Play)
+      SetNetworkBufferCallBack(&Play->NetBuf, SocketStatus, (gpointer)Play);
   }
   return TRUE;
 }
@@ -1754,24 +1766,25 @@ void CloseHighScoreFile()
  * If we're running setuid/setgid, drop down to the privilege level of the
  * user that started the Church Wars process.
  */
-void DropPrivileges()
+gboolean DropPrivileges()
 {
 #ifndef CYGWIN
 
 #ifdef HAVE_ISSETUGID
-  if (issetugid() == 0) return;
+  if (issetugid() == 0) return TRUE;
 #endif
 
   if (setregid(getgid(), getgid()) != 0) {
     perror("setregid");
-    exit(EXIT_FAILURE);
+    return FALSE;
   }
 
   if (setreuid(getuid(), getuid()) != 0) {
     perror("setreuid");
-    exit(EXIT_FAILURE);
+    return FALSE;
   }
 #endif
+  return TRUE;
 }
 
 static const gchar SCOREHEADER[] = "DOPEWARS SCORES V.";

--- a/src/serverside.h
+++ b/src/serverside.h
@@ -69,7 +69,7 @@ void RunFromCombat(Player *Play, int ToLocation);
 gboolean CanPlayerFire(Player *Play);
 gboolean CanRunHere(Player *Play);
 Player *GetNextShooter(Player *Play);
-void DropPrivileges(void);
+gboolean DropPrivileges(void);
 
 #ifdef GUI_SERVER
 void GuiServerLoop(struct CMDLINE *cmdline, gboolean is_service);


### PR DESCRIPTION
## Summary
- Replace `exit()` calls in networking and server setup with error propagation
- Clean up sockets on failure and allow callers to handle initialization errors
- Return status from privilege drop and handle failures gracefully

## Testing
- `pytest` *(fails: SystemExit: 0)*
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689cb26760ac8326b564481a4b6d37c6