### PR TITLE
Handle AIPlayerLoop connection failure

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -98,7 +98,8 @@ static void DisplayConnectStatus(NetworkBuffer *netbuf, NBStatus oldstatus,
   status = netbuf->status;
   sockstat = netbuf->sockstat;
   if (oldstatus == status && oldsocks == sockstat)
-    return;
+    status = FALSE;
+    goto cleanup;
 
   switch (status) {
   case NBS_PRECONNECT:
@@ -166,7 +167,8 @@ gboolean AIPlayerLoop(struct CMDLINE *cmdline)
     g_warning(_("Failed to connect to server; cleaning up."));
     g_string_free(errstr, TRUE);
     FirstClient = RemovePlayer(AIPlay, FirstClient);
-    return;
+    status = FALSE;
+    goto cleanup;
   } else {
     SetNetworkBufferUserPasswdFunc(netbuf, NetBufAuth, NULL);
     if (netbuf->status == NBS_CONNECTED) {


### PR DESCRIPTION
## Summary
- ensure AIPlayerLoop marks failure and jumps to cleanup when initial server connection fails

## Testing
- `gcc -DNETWORKING -Isrc $(pkg-config --cflags glib-2.0) -Wreturn-type -Wunused-label -c src/AIPlayer.c -o /tmp/AIPlayer.o` *(fails: glib-2.0 headers missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cb57fe5b08326875724123a2ece8d