### PR TITLE
Handle allocation failures when adding player

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -862,11 +862,32 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
   NewPlayer->EventNum = E_NONE;
   NewPlayer->FightTimeout = NewPlayer->ConnectTimeout =
       NewPlayer->IdleTimeout = 0;
-  NewPlayer->Guns = (Inventory *)g_malloc0(NumGun * sizeof(Inventory));
-  NewPlayer->Drugs = (Inventory *)g_malloc0(NumDrug * sizeof(Inventory));
+  NewPlayer->Guns = (Inventory *)g_try_malloc0(NumGun * sizeof(Inventory));
+  if (!NewPlayer->Guns) {
+    g_warning("Unable to allocate guns for new player");
+    g_free(NewPlayer->Name);
+    g_free(NewPlayer);
+    return First;
+  }
+  NewPlayer->Drugs = (Inventory *)g_try_malloc0(NumDrug * sizeof(Inventory));
+  if (!NewPlayer->Drugs) {
+    g_warning("Unable to allocate drugs for new player");
+    g_free(NewPlayer->Name);
+    g_free(NewPlayer->Guns);
+    g_free(NewPlayer);
+    return First;
+  }
   NewPlayer->Turn = 1;
-  NewPlayer->date = g_date_new_dmy(StartDate.day, StartDate.month,
-                                   StartDate.year);
+  NewPlayer->date =
+      g_date_new_dmy(StartDate.day, StartDate.month, StartDate.year);
+  if (!NewPlayer->date) {
+    g_warning("Unable to allocate date for new player");
+    g_free(NewPlayer->Name);
+    g_free(NewPlayer->Guns);
+    g_free(NewPlayer->Drugs);
+    g_free(NewPlayer);
+    return First;
+  }
   NewPlayer->Cash = StartCash;
   NewPlayer->Debt = StartDebt;
   NewPlayer->Bank = 0;


### PR DESCRIPTION
## Summary
- Validate memory allocation and date creation when initializing a new player
- Log and clean up on allocation failure before returning unchanged player list

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars.)*
- `python3 tests/test_gun_balance.py`
- `gcc tests/test_socks5.c -Isrc $(pkg-config --cflags glib-2.0) $(pkg-config --libs glib-2.0) -o tests/test_socks5` *(fails: Package glib-2.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_689cb556e8148326a5958ed02d9b8baa