### PR TITLE
Validate random range handling

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -559,8 +559,10 @@ void AIJet(Player *AIPlay)
              AIPlay->Cash > MINSAFECASH * 5) {
     NewLocation = RealGunShop;
   }
-  while (NewLocation == AIPlay->IsAt)
-    NewLocation = brandom(0, NumLocation);
+  if (NumLocation > 1) {
+    while (NewLocation == AIPlay->IsAt)
+      NewLocation = brandom(0, NumLocation);
+  }
   int ret = snprintf(text, sizeof(text), "%d", NewLocation);
   if (ret < 0 || ret >= (int)sizeof(text)) {
     g_warning("AIJet: failed to format new location");

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -799,6 +799,10 @@ static gboolean SetConfigValue(int GlobalIndex, int StructIndex,
  */
 int brandom(int bot, int top)
 {
+  if (top <= bot) {
+    dopelog(1, 0, "brandom called with invalid range: bot=%d top=%d", bot, top);
+    return bot;
+  }
   return (int)((float)(top - bot) * rand() / (RAND_MAX + 1.0)) + bot;
 }
 
@@ -807,6 +811,12 @@ int brandom(int bot, int top)
  */
 price_t prandom(price_t bot, price_t top)
 {
+  if (top <= bot) {
+    dopelog(1, 0,
+            "prandom called with invalid range: bot=%" G_GINT64_FORMAT " top=%" G_GINT64_FORMAT,
+            (gint64) bot, (gint64) top);
+    return bot;
+  }
   return (price_t)((float)(top - bot) * rand() / (RAND_MAX + 1.0)) + bot;
 }
 
@@ -1362,6 +1372,9 @@ void TruncateInventoryFor(Inventory *Guns, Inventory *Drugs, Player *Play)
 int IsCarryingRandom(Player *Play, int amount)
 {
   int i, ind;
+
+  if (NumDrug <= 0)
+    return -1;
 
   for (i = 0; i < 5; i++) {
     ind = brandom(0, NumDrug);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2957,6 +2957,9 @@ int RandomOffer(Player *To)
   int r, amount, ind;
   GString *text;
 
+  if (NumDrug <= 0)
+    return 0;
+
   r = brandom(0, 100);
 
   text = g_string_new(NULL);
@@ -3115,6 +3118,9 @@ static void GenerateDrugsHere(Player *To, enum DealType *Deal)
 {
   int NumEvents, NumDrugs, NumRandom, i;
 
+  if (NumDrug <= 0)
+    return;
+
   for (i = 0; i < NumDrug; i++) {
     To->Drugs[i].Price = 0;
     Deal[i] = DT_NORMAL;
@@ -3145,8 +3151,11 @@ static void GenerateDrugsHere(Player *To, enum DealType *Deal)
       NumEvents--;
     }
   }
-  NumRandom = brandom(Location[To->IsAt].MinDrug,
-                      Location[To->IsAt].MaxDrug);
+  int mindrug = Location[To->IsAt].MinDrug;
+  int maxdrug = Location[To->IsAt].MaxDrug;
+  if (maxdrug <= mindrug)
+    maxdrug = mindrug + 1;
+  NumRandom = brandom(mindrug, maxdrug);
   if (NumRandom > NumDrug)
     NumRandom = NumDrug;
 
@@ -3453,11 +3462,13 @@ int LoseBitch(Player *Play, Inventory *Guns, Inventory *Drugs)
         TotalGunsCarried(Play) * 100 / (Play->Bitches.Carried + 2)) {
       for (i = 0; i < NumGun; i++)
         GunIndex[i] = i;
-      for (i = 0; i < NumGun * 5; i++) {
-        num = brandom(0, NumGun - 1);
-        tmp = GunIndex[num + 1];
-        GunIndex[num + 1] = GunIndex[num];
-        GunIndex[num] = tmp;
+      if (NumGun > 1) {
+        for (i = 0; i < NumGun * 5; i++) {
+          num = brandom(0, NumGun - 1);
+          tmp = GunIndex[num + 1];
+          GunIndex[num + 1] = GunIndex[num];
+          GunIndex[num] = tmp;
+        }
       }
       for (i = 0; i < NumGun; i++) {
         if (Play->Guns[GunIndex[i]].Carried > 0) {


### PR DESCRIPTION
## Summary
- Guard random-number helpers against invalid ranges and log when encountered
- Prevent random selections from empty lists and avoid shuffling when only one gun exists
- Handle limited location lists when choosing AI travel destinations

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `gcc -fsyntax-only src/dopewars.c src/serverside.c src/AIPlayer.c` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cb54cd8e883269f18900d0338f924