### PR TITLE
Fix AI player compile warnings

### DIFF
--- a/src/AIPlayer.c
+++ b/src/AIPlayer.c
@@ -98,8 +98,7 @@ static void DisplayConnectStatus(NetworkBuffer *netbuf, NBStatus oldstatus,
   status = netbuf->status;
   sockstat = netbuf->sockstat;
   if (oldstatus == status && oldsocks == sockstat)
-    status = FALSE;
-    goto cleanup;
+    return;
 
   switch (status) {
   case NBS_PRECONNECT:
@@ -675,7 +674,7 @@ void AIHandleQuestion(char *Data, AICode AI, Player *AIPlay, Player *From)
  */
 void AISendRandomMessage(Player *AIPlay)
 {
-  char *RandomInsult[5] = {
+  const char *RandomInsult[5] = {
     /* Random messages to send from the AI player to other players */
     N_("Call yourselves Trader-Saints?"),
     N_("A trained monkey could do better..."),
@@ -683,7 +682,10 @@ void AISendRandomMessage(Player *AIPlay)
     N_("Zzzzz... are you trading in pennies or what?"),
     N_("Reckon I'll just have to kill you for your own good.")
   };
+  const char *msg;
 
+  msg = _(RandomInsult[brandom(0, 5)]);
+  SendClientMessage(AIPlay, C_NONE, C_MSG, NULL, (char *)msg);
 }
 
 #else /* NETWORKING */


### PR DESCRIPTION
## Summary
- Remove stray `goto` from AI connect status handler
- Implement AISendRandomMessage and eliminate unused variable warning

## Testing
- `gcc -DHAVE_CONFIG_H -I.  -I. -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/x86_64-linux-gnu -I/usr/include/webp -I/usr/include/gio-unix-2.0 -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -pthread     -g -O2 -D_GNU_SOURCE  -Wall -c -o AIPlayer.o AIPlayer.c` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cb911779c83269b5f6f879a58ff84