### PR TITLE
Replace atoi with strtol and validate input

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -389,6 +389,8 @@ void display_intro(void)
 static void SelectServerManually(void)
 {
   gchar *text, *PortText;
+  char *endptr;
+  long tmp_port;
   int top = get_ui_area_top();
 
   if (ServerName[0] == '(')
@@ -404,7 +406,12 @@ static void SelectServerManually(void)
   g_free(text);
   PortText = g_strdup_printf("%d", Port);
   text = nice_input(_("Port: "), top + 3, 1, TRUE, PortText, '\0');
-  Port = atoi(text);
+  tmp_port = strtol(text, &endptr, 10);
+  if (*endptr != '\0' || tmp_port <= 0 || tmp_port > 65535) {
+    g_warning(_("Invalid port '%s'; keeping previous port %d"), text, Port);
+  } else {
+    Port = (int) tmp_port;
+  }
   g_free(text);
   g_free(PortText);
 }
@@ -871,6 +878,8 @@ static void DropDrugs(Player *Play)
   int i, c, num, NumDrugs, top = get_ui_area_top();
   GString *text;
   gchar *buf;
+  char *endptr;
+  long tmp;
 
   attrset(TextAttr);
   clear_bottom();
@@ -903,12 +912,15 @@ static void DropDrugs(Player *Play)
         addstr(Drug[i].Name);
         buf = nice_input(_("How many do you drop? "), get_prompt_line() + 1,
                          8, TRUE, NULL, '\0');
-        num = atoi(buf);
-        g_free(buf);
-        if (num > 0) {
+        tmp = strtol(buf, &endptr, 10);
+        if (*endptr != '\0' || tmp <= 0 || tmp > G_MAXINT) {
+          g_warning(_("Invalid quantity '%s'"), buf);
+        } else {
+          num = (int) tmp;
           g_string_printf(text, "drug^%d^%d", i, -num);
           SendClientMessage(Play, C_NONE, C_BUYOBJECT, NULL, text->str);
         }
+        g_free(buf);
       }
     }
   }
@@ -927,6 +939,8 @@ static void DealDrugs(Player *Play, gboolean Buy)
   int i, c, NumDrugsHere;
   gchar *text, *input;
   int DrugNum, CanCarry, CanAfford;
+  char *endptr;
+  long tmp;
 
   NumDrugsHere = 0;
   for (c = 0; c < NumDrug; c++)
@@ -962,7 +976,13 @@ static void DealDrugs(Player *Play, gboolean Buy)
       mvaddstr(get_prompt_line() + 1, 2, text);
       input = nice_input(_("How many do you buy? "), get_prompt_line() + 1,
                          2 + strcharlen(text), TRUE, NULL, '\0');
-      c = atoi(input);
+      tmp = strtol(input, &endptr, 10);
+      if (*endptr != '\0' || tmp < 0 || tmp > G_MAXINT) {
+        g_warning(_("Invalid quantity '%s'"), input);
+        c = -1;
+      } else {
+        c = (int) tmp;
+      }
       g_free(input);
       g_free(text);
       if (c >= 0) {
@@ -978,7 +998,13 @@ static void DealDrugs(Player *Play, gboolean Buy)
       mvaddstr(get_prompt_line() + 1, 2, text);
       input = nice_input(_("How many do you sell? "), get_prompt_line() + 1,
                          2 + strcharlen(text), TRUE, NULL, '\0');
-      c = atoi(input);
+      tmp = strtol(input, &endptr, 10);
+      if (*endptr != '\0' || tmp < 0 || tmp > G_MAXINT) {
+        g_warning(_("Invalid quantity '%s'"), input);
+        c = -1;
+      } else {
+        c = (int) tmp;
+      }
       g_free(input);
       g_free(text);
       if (c >= 0) {

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -432,14 +432,16 @@ void HandleServerMessage(gchar *buf, Player *Play)
       FinishGame(Play, NULL);
     }
     break;
-  case C_REQUESTJET:
-    i = atoi(Data);
+  case C_REQUESTJET: {
+    char *endptr;
+    long tmp = strtol(Data, &endptr, 10);
     /* Make sure value is within range */
-    if (i < 0 || i >= NumLocation) {
+    if (*endptr != '\0' || tmp < 0 || tmp >= NumLocation) {
       dopelog(3, LF_SERVER, _("%s: DENIED travel to invalid location %s"),
               GetPlayerName(Play), Data);
       break;
     }
+    i = (int) tmp;
     if (Play->EventNum == E_FIGHT || Play->EventNum == E_FIGHTASK) {
       if (CanRunHere(Play)) {
         break;
@@ -478,6 +480,7 @@ void HandleServerMessage(gchar *buf, Player *Play)
               GetPlayerName(Play), Location[i].Name);
     }
     break;
+  }
   case C_REQUESTSCORE:
     SendHighScores(Play, FALSE, NULL);
     break;
@@ -1800,14 +1803,22 @@ static const guint SCOREVERSION = 1;
 static gboolean HighScoreReadHeader(FILE *fp, gint *ScoreVersion)
 {
   gchar *header;
+  char *endptr;
+  long tmp;
 
   if (read_string(fp, &header) != EOF) {
     if (header && strlen(header) > SCOREHDRLEN &&
         strncmp(header, SCOREHEADER, SCOREHDRLEN) == 0) {
-      if (ScoreVersion)
-        *ScoreVersion = atoi(header + SCOREHDRLEN);
-      g_free(header);
-      return TRUE;
+      tmp = strtol(header + SCOREHDRLEN, &endptr, 10);
+      if (*endptr == '\0' && tmp >= 0 && tmp <= G_MAXINT) {
+        if (ScoreVersion)
+          *ScoreVersion = (gint) tmp;
+        g_free(header);
+        return TRUE;
+      } else {
+        g_warning(_("Invalid score file version '%s'"),
+                  header + SCOREHDRLEN);
+      }
     }
   }
   g_free(header);


### PR DESCRIPTION
## Summary
- use `strtol` with range checks for manual port entry and drug quantities in curses client
- parse server travel requests and high score headers with `strtol`
- log warnings and keep defaults when numeric input is invalid

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cba4cc6408326821ada3f21f0f578