### PR TITLE
Remove invalid return in DisplayConnectStatus

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -599,7 +599,7 @@ static void DisplayConnectStatus(NetworkBuffer *netbuf,
     refresh();
   }
   g_string_free(text, TRUE);
-  return TRUE;
+  return;
 }
 
 void SocksAuthFunc(NetworkBuffer *netbuf, gpointer data)


### PR DESCRIPTION
## Summary
- Fix DisplayConnectStatus to no longer return a value in a void function

## Testing
- `gcc -Wall -c src/curses_client/curses_client.c -Isrc -Isrc/curses_client -Isrc/cursesport -Isrc/gtkport -Isrc -I.` *(fails: glib.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cbeb8f9a88326bc2197cb034fa57d