### PR TITLE
Remove unused text variable in curses client ConnectToServer

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -688,7 +688,6 @@ static gboolean ConnectToServer(Player *Play)
 {
   gboolean MetaOK = TRUE, NetOK = TRUE, firstrun = FALSE;
   GString *errstr;
-  gchar *text;
   int c, top = get_ui_area_top();
 
   errstr = g_string_new("");


### PR DESCRIPTION
## Summary
- remove unused `text` pointer from `ConnectToServer`

## Testing
- `./autogen.sh` *(fails: automake not installed)*
- `gcc -Wall -Wextra -c src/curses_client/curses_client.c -I./src -I./src/curses_client` *(fails: glib.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689cbebb809883268ebb128418644222