### PR TITLE
Fix SOCKS5 CONNECT buffer length calculation

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -503,7 +503,7 @@ static gboolean Socks5Connect(NetworkBuffer *NetBuf)
   netport = htons(NetBuf->port);
   g_assert(sizeof(netport) == 2);
 
-  addlen = hostlen + 8;
+  addlen = hostlen + 7;
   addpt = ExpandWriteBuffer(conn, addlen, &NetBuf->error);
   if (!addpt)
     return FALSE;
@@ -514,7 +514,6 @@ static gboolean Socks5Connect(NetworkBuffer *NetBuf)
   addpt[4] = (guchar)hostlen;           /* Length of address */
   memcpy(&addpt[5], NetBuf->host, hostlen);
   memcpy(&addpt[5 + hostlen], &netport, sizeof(netport));
-  addpt[5 + hostlen + sizeof(netport)] = '\0';
 
   NetBuf->sockstat = NBSS_CONNECT;
 


### PR DESCRIPTION
## Summary
- Correct SOCKS5 CONNECT request buffer length calculation
- Remove unnecessary trailing null byte in SOCKS5 CONNECT request

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc -DNETWORKING tests/test_socks5.c src/network.c src/util.c src/error.c src/tstring.c src/message.c src/log.c -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0 2>/dev/null) -lcurl` *(fails: glib.h missing)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1cced308326a1bfcedcb09a869f