### PR TITLE
Use size_t for write buffer expansion and enforce MAXWRITEBUF

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -893,15 +893,20 @@ gboolean ReadDataFromWire(NetworkBuffer *NetBuf)
 
 gchar *ExpandWriteBuffer(ConnBuf *conn, size_t numbytes, LastError **error)
 {
-  int newlen;
+  size_t newlen;
 
-  newlen = conn->DataPresent + (int)numbytes;
-  if (newlen > conn->Length) {
+  newlen = (size_t)conn->DataPresent + numbytes;
+  if (newlen > MAXWRITEBUF) {
+    if (error)
+      SetError(error, ET_CUSTOM, E_FULLBUF, NULL);
+    return NULL;
+  }
+  if (newlen > (size_t)conn->Length) {
     conn->Length *= 2;
-    conn->Length = MAX(conn->Length, newlen);
+    conn->Length = MAX(conn->Length, (gint)newlen);
     if (conn->Length > MAXWRITEBUF)
       conn->Length = MAXWRITEBUF;
-    if (newlen > conn->Length) {
+    if (newlen > (size_t)conn->Length) {
       if (error)
         SetError(error, ET_CUSTOM, E_FULLBUF, NULL);
       return NULL;


### PR DESCRIPTION
## Summary
- prevent write-buffer overflow by computing new length in size_t
- guard against exceeding MAXWRITEBUF prior to reallocating

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.35 8080])* 
- `gcc -c src/network.c $(pkg-config --cflags glib-2.0)` *(fails: Package 'glib-2.0', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc4925f38832680e35c1c6fcdea7e