### PR TITLE
Prevent buffer underflow on empty network messages

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -821,9 +821,12 @@ gchar *GetWaitingMessage(NetworkBuffer *NetBuf)
     return NULL;
   *SepPt = '\0';
   MessageLen = SepPt - conn->Data + 1;
+  if (SepPt == conn->Data)
+    goto skip_strip;
   SepPt--;
   if (NetBuf->StripChar && *SepPt == NetBuf->StripChar)
     *SepPt = '\0';
+skip_strip:
   NewMessage = g_new(gchar, MessageLen);
 
   memcpy(NewMessage, conn->Data, MessageLen);


### PR DESCRIPTION
## Summary
- avoid decrementing past start of buffer when stripping terminator from network messages

## Testing
- `gcc -c -DNETWORKING src/network.c` *(fails: glib.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cc48cbaac832690da361e2b9135f9