### PR TITLE
docs: update score file path and -f option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -41,7 +41,8 @@ with a command similar to the following:-
 	LDFLAGS="-s" ./configure
 
 The churchwars high score file is written as /usr/local/var/churchwars.sco on
-Unix systems or ./churchwars.sco on Win32 systems by default. On Unix systems,
+Unix systems or ./churchwars.sco on Win32 systems by default. An alternative
+score file can be specified with the `-f` command-line option. On Unix systems,
 translations, documentation, sounds and graphics are installed in the
 locale, doc, churchwars and pixmaps directories respectively under
 /usr/local/share. (On Windows systems, these directories are under the

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Or...
 Once you're done, you can safely delete the RPM, tarball and churchwars
 directory. The churchwars binary is all you need!
 
-Church Wars stores its high score files by default in `/usr/share/churchwars.sco`
-This will be created by make install or by RPM installation. A different high 
-score file can be selected with the `-f` switch.
+Church Wars stores its high score files by default in `/usr/local/var/churchwars.sco`.
+This will be created by `make install` or by RPM installation. Use the `-f`
+command-line option to specify an alternative score file.
 
 ## Windows installation
 


### PR DESCRIPTION
## Summary
- fix README to show default score file path
- document `-f` option for alternate score file in INSTALL

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689ce97d8fa88326a45ee85cd22ae080