### PR TITLE
Support selling via negative amounts

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -927,6 +927,19 @@ int GetNextInt(gchar **Data, int Default)
   return Default;
 }
 
+int GetNextSignedInt(gchar **Data, int Default)
+{
+  gchar *Word = GetNextWord(Data, NULL);
+
+  if (Word) {
+    char *endptr;
+    long val = strtol(Word, &endptr, 10);
+    if (*endptr == '\0' && val >= G_MININT && val <= G_MAXINT)
+      return (int)val;
+  }
+  return Default;
+}
+
 price_t GetNextPrice(gchar **Data, price_t Default)
 {
   gchar *Word = GetNextWord(Data, NULL);

--- a/src/message.h
+++ b/src/message.h
@@ -121,6 +121,7 @@ void ReceiveMiscData(char *Data);
 gchar *GetNextWord(gchar **Data, gchar *Default);
 void AssignNextWord(gchar **Data, gchar **Dest);
 int GetNextInt(gchar **Data, int Default);
+int GetNextSignedInt(gchar **Data, int Default);
 price_t GetNextPrice(gchar **Data, price_t Default);
 void ShutdownNetwork(Player *Play);
 void SwitchToSinglePlayer(Player *Play);

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3449,7 +3449,8 @@ gboolean BuyObject(Player *From, char *data)
   cp = data;
   type = GetNextWord(&cp, "");
   index = GetNextInt(&cp, 0);
-  amount = GetNextInt(&cp, 0);
+  /* amount may be negative to sell items */
+  amount = GetNextSignedInt(&cp, 0);
   if (strcmp(type, "drug") == 0) {
     if (index >= 0 && index < NumDrug
         && From->Drugs[index].Carried + amount >= 0

--- a/tests/test_sell_items.c
+++ b/tests/test_sell_items.c
@@ -1,0 +1,91 @@
+#include "serverside.h"
+#include "message.h"
+#include "dopewars.h"
+#include <assert.h>
+#include <glib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#define _(x) (x)
+
+/* Stub globals */
+int NumDrug = 1;
+int NumGun = 0;
+int NumCop = 0;
+gboolean Sanitized = TRUE;
+struct LOCATION Location[1];
+struct GUN Gun[1];
+struct NAMES Names = {0};
+
+/* Stub functions */
+void SendPlayerData(Player *From) { (void)From; }
+void CopsAttackPlayer(Player *From) { (void)From; }
+int TotalGunsCarried(Player *From) { (void)From; return 0; }
+void GainBitch(Player *From) { (void)From; }
+int brandom(int a, int b) { (void)b; return a; }
+gchar *dpg_strdup_printf(gchar *format, ...) {
+  va_list ap;
+  va_start(ap, format);
+  gchar *res = g_strdup_vprintf(format, ap);
+  va_end(ap);
+  return res;
+}
+void SendPrintMessage(Player *From, AICode AI, Player *To, char *Data) {
+  (void)From; (void)AI; (void)To; g_free(Data);
+}
+
+/* Minimal helpers from message.c */
+gchar *GetNextWord(gchar **Data, gchar *Default) {
+  gchar *Word = *Data;
+  if (!Word || *Word == '\0')
+    return Default;
+  while (**Data != '\0' && **Data != '^')
+    (*Data)++;
+  if (**Data != '\0') {
+    **Data = '\0';
+    (*Data)++;
+  }
+  return Word;
+}
+
+int GetNextInt(gchar **Data, int Default) {
+  gchar *Word = GetNextWord(Data, NULL);
+  if (Word) {
+    char *endptr;
+    long val = strtol(Word, &endptr, 10);
+    if (*endptr == '\0' && val >= 0 && val <= G_MAXINT)
+      return (int)val;
+  }
+  return Default;
+}
+
+int GetNextSignedInt(gchar **Data, int Default) {
+  gchar *Word = GetNextWord(Data, NULL);
+  if (Word) {
+    char *endptr;
+    long val = strtol(Word, &endptr, 10);
+    if (*endptr == '\0' && val >= G_MININT && val <= G_MAXINT)
+      return (int)val;
+  }
+  return Default;
+}
+
+int main(void) {
+  Player p;
+  memset(&p, 0, sizeof(p));
+  p.Drugs = g_malloc0(sizeof(Inventory) * NumDrug);
+  p.Drugs[0].Carried = 5;
+  p.Drugs[0].Price = 10;
+  p.Drugs[0].TotalValue = p.Drugs[0].Carried * p.Drugs[0].Price;
+  p.CoatSize = 10;
+  p.Cash = 100;
+
+  char msg[] = "drug^0^-2";
+  assert(BuyObject(&p, msg));
+  assert(p.Drugs[0].Carried == 3);
+  assert(p.Cash == 120);
+  assert(p.CoatSize == 12);
+
+  g_free(p.Drugs);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- allow signed integer parsing with new `GetNextSignedInt`
- handle selling by using signed amount in `BuyObject`
- add test covering `C_BUYOBJECT` selling scenario

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc tests/test_sell_items.c src/serverside.c -I src $(pkg-config --cflags glib-2.0) $(pkg-config --libs glib-2.0) -ffunction-sections -fdata-sections -Wl,--gc-sections -o tests/test_sell_items` *(fails: glib-2.0 not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d038787d48326af924a5fa5d6492f