### PR TITLE
Avoid ignoring g_string_free return value

### DIFF
--- a/src/tstring.c
+++ b/src/tstring.c
@@ -262,9 +262,8 @@ gchar *HandleTFmt(gchar *format, va_list va)
       break;
     }
   }
-  retstr = string->str;
   g_array_free(arr, TRUE);
-  g_string_free(string, FALSE);
+  retstr = g_string_free(string, FALSE);
   g_string_free(tmpfmt, TRUE);
   return retstr;
 }


### PR DESCRIPTION
## Summary
- fix HandleTFmt to capture return from `g_string_free` and prevent warning about unused result

## Testing
- `gcc -c src/tstring.c -Isrc` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d060f5dcc832688bedbf0b5c1b303