### PR TITLE
Increase GTK client default window size

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2172,7 +2172,7 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   /* Title of main window in GTK+ client */
   gtk_window_set_title(GTK_WINDOW(window), _("Church Wars"));
-  gtk_window_set_default_size(GTK_WINDOW(window), 450, 390);
+  gtk_window_set_default_size(GTK_WINDOW(window), 600, 450);
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(MainDelete), NULL);
   g_signal_connect(G_OBJECT(window), "destroy",


### PR DESCRIPTION
## Summary
- expand the GTK client's default window size to 600x450 so the UI opens wide enough for content

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars.)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689df649db6c8326b7dba81308e7e723