### PR TITLE
Improve sound plugin selection and SDL backend

### DIFF
--- a/src/plugins/sound_sdl.c
+++ b/src/plugins/sound_sdl.c
@@ -29,27 +29,52 @@
 #include <SDL_mixer.h>
 #include <glib.h>
 #include "../sound.h"
+#include <stdio.h>
 
 static GHashTable *sound_cache;
+static gboolean sdl_inited = FALSE;
   
 static gboolean SoundOpen_SDL(void)
 {
-  const int audio_rate = MIX_DEFAULT_FREQUENCY;
-  const int audio_format = MIX_DEFAULT_FORMAT;
-  const int audio_channels = 2;
+  int mix_flags = MIX_INIT_OGG | MIX_INIT_MP3 | MIX_INIT_FLAC;
 
-  if (SDL_Init(SDL_INIT_AUDIO) < 0) {
+  if (sdl_inited) {
+    return TRUE;
+  }
+
+  if (!g_getenv("SDL_AUDIODRIVER")) {
+#ifdef __APPLE__
+    g_setenv("SDL_AUDIODRIVER", "coreaudio", TRUE);
+#elif defined(__linux__)
+    g_setenv("SDL_AUDIODRIVER", "pulseaudio", TRUE);
+#endif
+  }
+
+  if (!(SDL_WasInit(SDL_INIT_AUDIO) & SDL_INIT_AUDIO)) {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
+      fprintf(stderr, "SDL_InitSubSystem failed: %s\n", SDL_GetError());
+      return FALSE;
+    }
+  }
+
+  if ((Mix_Init(mix_flags) & mix_flags) != mix_flags) {
+    fprintf(stderr, "Mix_Init failed: %s\n", Mix_GetError());
+    Mix_Quit();
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
     return FALSE;
   }
 
-  if (Mix_OpenAudio(audio_rate, audio_format, audio_channels, 4096) < 0) {
-    SDL_Quit();
+  if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) < 0) {
+    fprintf(stderr, "Mix_OpenAudio failed: %s\n", Mix_GetError());
+    Mix_Quit();
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
     return FALSE;
   }
-  Mix_AllocateChannels(16);
+
+  Mix_AllocateChannels(32);
 
   sound_cache = g_hash_table_new(g_str_hash, g_str_equal);
-
+  sdl_inited = TRUE;
   return TRUE;
 }
 
@@ -57,6 +82,10 @@ static void SoundClose_SDL(void)
 {
   GHashTableIter iter;
   gpointer key, value;
+
+  if (!sdl_inited) {
+    return;
+  }
 
   if (sound_cache) {
     g_hash_table_iter_init(&iter, sound_cache);
@@ -69,7 +98,9 @@ static void SoundClose_SDL(void)
   }
 
   Mix_CloseAudio();
-  SDL_Quit();
+  Mix_Quit();
+  SDL_QuitSubSystem(SDL_INIT_AUDIO);
+  sdl_inited = FALSE;
 }
 
 static void SoundPlay_SDL(const gchar *snd)
@@ -101,7 +132,7 @@ static void SoundPlay_SDL(const gchar *snd)
       }
     }
     if (chan_num < 0) {
-      g_warning("Mix_PlayChannel failed for %s: %s", snd, Mix_GetError());
+      fprintf(stderr, "Mix_PlayChannel failed for %s: %s\n", snd, Mix_GetError());
     }
   }
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <string.h>
 #include <errno.h>
+#include <stdio.h>
 
 #ifdef PLUGINS
 #include <sys/types.h>
@@ -205,34 +206,56 @@ SoundDriver *SoundGetPlugin(const gchar *drivername)
   return GetPlugin(drivername);
 }
 
+static gboolean
+TryLoadPlugin(const gchar *name)
+{
+  driver = GetPlugin(name);
+  if (!driver) {
+    if (name) {
+      fprintf(stderr, "Sound plugin '%s' not found\n", name);
+    }
+    return FALSE;
+  }
+  if (driver->open && !driver->open()) {
+    fprintf(stderr, "Sound plugin '%s' failed to initialize\n", name);
+    driver = NULL;
+    return FALSE;
+  }
+  fprintf(stderr, "Sound plugin '%s' selected\n", driver->name);
+  sound_enabled = TRUE;
+  return TRUE;
+}
+
 void SoundOpen(gchar *drivername)
 {
+  const gchar *envplug;
   sound_enabled = FALSE;
-  if (!drivername || strcmp(drivername, NOPLUGIN) != 0) {
-    driver = GetPlugin(drivername);
-    if (driver) {
-      gboolean opened = TRUE;
-      if (driver->open) {
-        dopelog(3, 0, "Using plugin %s", driver->name);
-        opened = driver->open();
-        if (!opened) {
-          g_log(NULL, G_LOG_LEVEL_CRITICAL,
-                _("Failed to open sound driver \"%s\"."), driver->name);
-          driver = NULL;
-        }
-      }
-      sound_enabled = opened && (driver != NULL);
-    } else if (drivername) {
-      gchar *plugins, *err;
 
-      plugins = GetPluginList();
-      err = g_strdup_printf(_("Invalid plugin \"%s\" selected.\n"
-                              "(%s available; now using \"%s\".)"),
-                            drivername, plugins, NOPLUGIN);
-      g_log(NULL, G_LOG_LEVEL_CRITICAL, "%s", err);
-      g_free(plugins);
-      g_free(err);
-    }
+  envplug = g_getenv("CHURCHWARS_SOUND_PLUGIN");
+  if (envplug && TryLoadPlugin(envplug)) {
+    return;
+  }
+  if (envplug && envplug[0]) {
+    fprintf(stderr, "Falling back from CHURCHWARS_SOUND_PLUGIN '%s'\n", envplug);
+  }
+
+  if (drivername && strcmp(drivername, NOPLUGIN) != 0 && TryLoadPlugin(drivername)) {
+    return;
+  }
+
+#ifdef _WIN32
+  if (TryLoadPlugin("winmm")) {
+    return;
+  }
+#else
+  if (TryLoadPlugin("sdl")) {
+    return;
+  }
+#endif
+
+  driver = GetPlugin(NULL);
+  if (driver && TryLoadPlugin(driver->name)) {
+    return;
   }
 }
 


### PR DESCRIPTION
## Summary
- Allow `CHURCHWARS_SOUND_PLUGIN` to override configured sound driver and fall back to platform defaults when loading plugins
- Harden SDL mixer backend initialization with explicit audio driver defaults, robust Mix init/open, and idempotent open/close paths
- Log playback failures via stderr and expand SDL mixer channels for more reliable SFX

## Testing
- ❌ `./autogen.sh` *(missing automake)*
- ⚠️ `apt-get update` *(403 Forbidden, unable to install build dependencies)*
- ❌ `gcc -Isrc -DPLUGINS=0 -DHAVE_SDL_MIXER=0 -DHAVE_ESD=0 -DHAVE_PULSEAUDIO=0 -DHAVE_WINMM=0 tests/test_sound.c src/sound.c -o /tmp/test_sound` *(missing glib headers)*

------
https://chatgpt.com/codex/tasks/task_e_689df9164c748326a7a436d8e6c90d3d