### PR TITLE
Warn when sound playback fails

### DIFF
--- a/src/plugins/sound_cocoa.m
+++ b/src/plugins/sound_cocoa.m
@@ -54,6 +54,7 @@ static void SoundPlay_Cocoa(const gchar *snd)
     p = [[NSSound alloc] initWithContentsOfFile:sound byReference:YES];
     /* If the sound file doesn't exist, do nothing */
     if (!p) {
+      g_warning("Could not create NSSound for %s", snd);
       [sound release];
       return;
     }

--- a/src/plugins/sound_sdl.c
+++ b/src/plugins/sound_sdl.c
@@ -118,6 +118,7 @@ static void SoundPlay_SDL(const gchar *snd)
   if (!chunk) {
     chunk = Mix_LoadWAV(snd);
     if (!chunk) {
+      g_warning("Mix_LoadWAV failed for %s: %s", snd, Mix_GetError());
       return;
     }
     g_hash_table_insert(sound_cache, g_strdup(snd), chunk);


### PR DESCRIPTION
## Summary
- log a warning if NSSound cannot be created for a path on Cocoa
- warn when SDL's Mix_LoadWAV fails to load a sound

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689e1fad1cf883268c758fedba2bee72