### PR TITLE
Attempt cocoa sound plugin before SDL on macOS

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -247,6 +247,11 @@ void SoundOpen(gchar *drivername)
     return;
   }
 #else
+#if defined(__APPLE__) || defined(HAVE_COCOA)
+  if (TryLoadPlugin("cocoa")) {
+    return;
+  }
+#endif
   if (TryLoadPlugin("sdl")) {
     return;
   }


### PR DESCRIPTION
## Summary
- Prefer the Cocoa sound plugin on macOS builds before falling back to SDL

## Testing
- `pytest -q` *(fails: SystemExit 0)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689e1fadccd48326a5364ad2d5c3c2f3