### PR TITLE
Use runtime resource path for sound files

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -60,6 +60,9 @@
 #include "util.h"
 #include "winmain.h"
 
+#ifdef APPLE
+#include "mac_helpers.h"
+#endif
 #ifdef CURSES_CLIENT
 #include "curses_client/curses_client.h"
 #endif
@@ -99,12 +102,6 @@ gboolean MinToSysTray = TRUE;
 gboolean Daemonize = TRUE;
 #endif
 
-#ifdef CYGWIN
-#define SNDPATH "sounds\\19.5degs\\"
-#else
-#define SNDPATH DPDATADIR"/dopewars/"
-#endif
-
 gint ConfigErrors = 0;
 gboolean LocaleIsUTF8 = FALSE;
 
@@ -119,6 +116,23 @@ int MaxClients = 20, AITurnPause = 5;
 price_t StartCash = 4000, StartDebt = 5500;
 int BaseCoatSize = 40;
 GSList *ServerList = NULL;
+
+static const gchar *GetSoundDir(void)
+{
+#ifdef APPLE
+  const char *path = mac_resource_path();
+  if (path)
+    return path;
+#endif
+  return DPDATADIR "/dopewars";
+}
+
+static void AssignSound(gchar **dest, const gchar *dir, const gchar *file)
+{
+  gchar *full = g_build_filename(dir, file, NULL);
+  AssignName(dest, full);
+  g_free(full);
+}
 
 GScannerConfig ScannerConfig = {
   " \t\n",                      /* Ignore these characters */
@@ -2426,16 +2440,17 @@ static void SetupParameters(GSList *extraconfigs, gboolean antique)
   AssignName(&ServerMOTD, "");
   AssignName(&BindAddress, "");
 
-  AssignName(&Sounds.FightHit, SNDPATH"colt.wav");
-  AssignName(&Sounds.EnemyBitchKilled, SNDPATH"shotdown.wav");
-  AssignName(&Sounds.BitchKilled, SNDPATH"losebitch.wav");
-  AssignName(&Sounds.EnemyKilled, SNDPATH"shotdown.wav");
-  AssignName(&Sounds.Killed, SNDPATH"die.wav");
-  AssignName(&Sounds.EnemyFlee, SNDPATH"run.wav");
-  AssignName(&Sounds.Flee, SNDPATH"run.wav");
-  AssignName(&Sounds.Jet, SNDPATH"train.wav");
-  AssignName(&Sounds.EndGame, SNDPATH"bye.wav");
-  AssignName(&Sounds.CoinBuy, SNDPATH"coinbuy.wav");
+  const gchar *snddir = GetSoundDir();
+  AssignSound(&Sounds.FightHit, snddir, "colt.wav");
+  AssignSound(&Sounds.EnemyBitchKilled, snddir, "shotdown.wav");
+  AssignSound(&Sounds.BitchKilled, snddir, "losebitch.wav");
+  AssignSound(&Sounds.EnemyKilled, snddir, "shotdown.wav");
+  AssignSound(&Sounds.Killed, snddir, "die.wav");
+  AssignSound(&Sounds.EnemyFlee, snddir, "run.wav");
+  AssignSound(&Sounds.Flee, snddir, "run.wav");
+  AssignSound(&Sounds.Jet, snddir, "train.wav");
+  AssignSound(&Sounds.EndGame, snddir, "bye.wav");
+  AssignSound(&Sounds.CoinBuy, snddir, "coinbuy.wav");
 
   LoanSharkLoc = DEFLOANSHARK;
   BankLoc = DEFBANK;

--- a/src/mac_helpers.h
+++ b/src/mac_helpers.h
@@ -30,4 +30,7 @@
 /* Open the given URL using the system-configured web browser */
 void mac_open_url(const char *url);
 
+/* Return the path to the application's Resources directory */
+const char *mac_resource_path(void);
+
 #endif /* __DP_MAC_HELPERS_H__ */

--- a/src/mac_helpers.m
+++ b/src/mac_helpers.m
@@ -27,9 +27,21 @@
 #import <AppKit/AppKit.h>
 
 #include "mac_helpers.h"
+#include <glib.h>
 
 void mac_open_url(const char *url)
 {
   NSString *urlstr = [[NSString alloc] initWithUTF8String:url];
   [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:urlstr]];
+}
+
+const char *mac_resource_path(void)
+{
+  static char *respath = NULL;
+  if (!respath) {
+    NSString *path = [[NSBundle mainBundle] resourcePath];
+    if (path)
+      respath = g_strdup([path UTF8String]);
+  }
+  return respath;
 }


### PR DESCRIPTION
## Summary
- Add mac_resource_path helper to find bundle resources on macOS
- Replace SNDPATH macro with runtime lookup and build sound paths dynamically

## Testing
- ⚠️ `./autogen.sh` (missing automake)
- ⚠️ `sudo apt-get update` (403 Forbidden)
- ⚠️ `make check` (no rule to make target)

------
https://chatgpt.com/codex/tasks/task_e_689e1fb691648326b576dfa8d5b7e406