### PR TITLE
Simplify GetPluginList return

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -62,7 +62,6 @@ gchar *GetPluginList(void)
 {
   GSList *listpt;
   GString *plugins;
-  gchar *retstr;
 
   plugins = g_string_new("\""NOPLUGIN"\"");
   for (listpt = driverlist; listpt; listpt = g_slist_next(listpt)) {
@@ -72,9 +71,7 @@ gchar *GetPluginList(void)
       g_string_append_printf(plugins, ", \"%s\"", drivpt->name);
     }
   }
-  retstr = plugins->str;
-  g_string_free(plugins, FALSE);
-  return retstr;
+  return g_string_free(plugins, FALSE);
 }
 
 static void AddPlugin(InitFunc ifunc, void *module)


### PR DESCRIPTION
## Summary
- simplify GetPluginList by returning g_string_free result directly

## Testing
- `gcc -Wall -Wextra -Isrc -c src/sound.c` *(fails: glib.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689e223a0c3883268d06b9d9c69a7e4b