### PR TITLE
Increase GTK client default window width

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2172,7 +2172,7 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   /* Title of main window in GTK+ client */
   gtk_window_set_title(GTK_WINDOW(window), _("Church Wars"));
-  gtk_window_set_default_size(GTK_WINDOW(window), 620, 450);
+  gtk_window_set_default_size(GTK_WINDOW(window), 700, 450);
 
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(MainDelete), NULL);


### PR DESCRIPTION
## Summary
- widen GTK client default window from 620px to 700px for better visibility

## Testing
- `./autogen.sh` *(fails: missing automake)*
- `apt-get update` *(fails: repository not signed)*
- `src/churchwars` *(fails: libgtk-3.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e38cd7b208326a8dec4b8335d1863