### PR TITLE
Validate StartDate and reset invalid values

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -908,13 +908,9 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
   NewPlayer->Turn = 1;
   NewPlayer->date =
       g_date_new_dmy(StartDate.day, StartDate.month, StartDate.year);
-  if (!NewPlayer->date) {
-    g_warning("Unable to allocate date for new player");
-    g_free(NewPlayer->Name);
-    g_free(NewPlayer->Guns);
-    g_free(NewPlayer->Drugs);
-    g_free(NewPlayer);
-    return First;
+  if (!g_date_valid(NewPlayer->date)) {
+    g_warning("Invalid start date specified; resetting to 5 Jan 1900");
+    g_date_set_dmy(NewPlayer->date, 5, 1, 1900);
   }
   NewPlayer->Cash = StartCash;
   NewPlayer->Debt = StartDebt;

--- a/tests/test_start_date.c
+++ b/tests/test_start_date.c
@@ -1,0 +1,43 @@
+#include "dopewars.h"
+#include <assert.h>
+#include <glib.h>
+
+/* Stub globals to satisfy AddPlayer dependencies */
+int NumDrug = 1;
+int NumGun = 1;
+int NumCop = 0;
+gboolean Server = FALSE;
+gboolean UseSocks = FALSE;
+price_t StartCash = 0;
+price_t StartDebt = 0;
+int BaseCoatSize = 0;
+struct DATE StartDate = {31, 2, 2023}; /* intentionally invalid */
+
+/* Stub functions required by AddPlayer */
+void SetPlayerName(Player *Play, char *Name) { (void)Play; (void)Name; }
+void InitAbilities(Player *Play) { (void)Play; }
+
+int main(void) {
+    Player *p = g_malloc0(sizeof(Player));
+    GSList *list = NULL;
+    list = AddPlayer(0, p, list);
+    assert(list != NULL);
+    assert(g_date_valid(p->date));
+    assert(g_date_get_day(p->date) == 5);
+    assert(g_date_get_month(p->date) == 1);
+    assert(g_date_get_year(p->date) == 1900);
+
+    /* Ensure gameplay can progress beyond early turns */
+    for (int i = 0; i < 20; i++) {
+        g_date_add_days(p->date, 1);
+        p->Turn++;
+    }
+    assert(p->Turn > 10);
+    assert(g_date_valid(p->date));
+
+    g_date_free(p->date);
+    g_free(p->Drugs);
+    g_free(p->Guns);
+    g_free(p);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure AddPlayer validates StartDate and falls back to 5 Jan 1900
- cover invalid StartDate settings with a unit test exercising turn advancement

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc tests/test_start_date.c src/dopewars.c -I src -o /tmp/test_start_date $(pkg-config --cflags --libs glib-2.0 gmodule-2.0)` *(fails: Package glib-2.0 was not found)*
- `gcc tests/test_sound.c src/sound.c -I src -o /tmp/test_sound $(pkg-config --cflags --libs glib-2.0 gmodule-2.0)` *(fails: Package glib-2.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e3b91c3d48326854522593865a8c3