### PR TITLE
Handle pre-1900 start dates in churchwars

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2541,6 +2541,11 @@ void GetDateString(GString *str, Player *Play)
 {
   gchar buf[200], *turn, *pt;
 
+  if (StartDate.year < 1900) {
+    g_string_printf(str, "Turn %d", Play->Turn);
+    return;
+  }
+
   turn = g_strdup_printf("%d", Play->Turn);
   g_string_assign(str, Names.Date);
   while ((pt = strstr(str->str, "%T")) != NULL) {

--- a/tests/test_turn_progress.c
+++ b/tests/test_turn_progress.c
@@ -1,0 +1,28 @@
+#include "dopewars.h"
+#include <assert.h>
+#include <glib.h>
+#include <string.h>
+
+/* Stub globals needed by GetDateString */
+struct DATE StartDate = {1, 1, 1095};
+struct NAMES Names = {0};
+
+int main(void) {
+    Player p = {0};
+    Names.Date = "Turn %T";
+    p.date = g_date_new_dmy(StartDate.day, StartDate.month, StartDate.year);
+    GString *out = g_string_new(NULL);
+
+    for (int i = 1; i <= 40; i++) {
+        p.Turn = i;
+        GetDateString(out, &p);
+        char buf[32];
+        snprintf(buf, sizeof(buf), "Turn %d", i);
+        assert(strcmp(out->str, buf) == 0);
+        g_date_add_days(p.date, 1);
+    }
+
+    g_string_free(out, TRUE);
+    g_date_free(p.date);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Detect start dates earlier than 1900 and avoid `g_date_strftime`, falling back to a simple turn counter
- Add regression test ensuring gameplay continues past 31 turns without date formatting issues

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc tests/test_socks5.c src/network.c -Isrc -o tests/test_socks5 $(pkg-config --cflags --libs glib-2.0 2>/tmp/pkg.log)` *(fails: glib.h: No such file or directory)*
- `gcc tests/test_sound.c src/sound.c -Isrc -o tests/test_sound $(pkg-config --cflags --libs glib-2.0 2>/tmp/pkg.log)` *(fails: glib.h: No such file or directory)*
- `gcc tests/test_sell_items.c src/serverside.c src/message.c src/dopewars.c -Isrc -o tests/test_sell_items $(pkg-config --cflags --libs glib-2.0 2>/tmp/pkg.log)` *(fails: glib.h: No such file or directory)*
- `gcc tests/test_turn_progress.c src/dopewars.c -Isrc -o tests/test_turn_progress $(pkg-config --cflags --libs glib-2.0 2>/tmp/pkg.log)` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e3b8c7ef08326bd41547f54eff40b