### PR TITLE
Replace drug bust wording with raid

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -330,7 +330,7 @@ normal price distribution (between Drug[x].MinPrice and Drug[x].MaxPrice) by
 <dd>Tells Church Wars that drug <i>4</i> (normally Heroin) can occasionally be
 particuarly expensive (FALSE cancels this).</dd>
 
-<dt><b>Drugs.ExpensiveStr1=<i>"Cops made a big %tde bust! Prices are
+<dt><b>Drugs.ExpensiveStr1=<i>"Cops pulled off a big %tde raid! Prices are
 outrageous!"</i></b></dt>
 <dd>Sets the string that is displayed when <b>any</b> drug is particularly
 expensive. This is similar to a standard C-style format string - i.e. the

--- a/po/churchwars.pot
+++ b/po/churchwars.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Ben Webb
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the churchwars package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: churchwars SVN\n"
-"Report-Msgid-Bugs-To: benwebb@users.sf.net\n"
-"POT-Creation-Date: 2025-08-13 20:27+0100\n"
+"Project-Id-Version: churchwars\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,28 +22,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -51,580 +51,580 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr ""
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr ""
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr ""
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr ""
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr ""
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr ""
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr ""
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr ""
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr ""
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr ""
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr ""
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr ""
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr ""
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr ""
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr ""
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr ""
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr ""
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr ""
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr ""
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr ""
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr ""
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr ""
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr ""
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr ""
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr ""
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr ""
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr ""
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr ""
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr ""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr ""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr ""
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr ""
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr ""
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr ""
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr ""
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr ""
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr ""
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr ""
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr ""
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr ""
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -632,183 +632,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr ""
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
 msgstr ""
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
@@ -817,182 +817,182 @@ msgstr ""
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr ""
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr ""
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr ""
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr ""
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr ""
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr ""
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr ""
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr ""
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr ""
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr ""
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr ""
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr ""
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr ""
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr ""
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr ""
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr ""
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr ""
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1853
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1889
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1953
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:2066
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:2091
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2096
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2102
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr ""
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2107
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2113
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
@@ -1000,66 +1000,64 @@ msgstr ""
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2122
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2177
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2183
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2192
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2230
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2414
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2418
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2543
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2546
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2550
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2556
+#: src/dopewars.c:2595
 #, c-format
 msgid "Church Wars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2565
+#: src/dopewars.c:2606
 #, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1074,7 +1072,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1104,7 +1102,7 @@ msgid ""
 "format\n"
 msgstr ""
 
-#: src/dopewars.c:2595
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1114,9 +1112,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2602
+#: src/dopewars.c:2642
 #, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1129,7 +1125,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1150,7 +1146,7 @@ msgid ""
 "  -A       connect to a locally-running server for administration\n"
 msgstr ""
 
-#: src/dopewars.c:2631
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1160,21 +1156,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2901
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2921
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2970
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1182,7 +1178,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2991 src/winmain.c:382
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1487,7 +1483,7 @@ msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
 #: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
@@ -1578,7 +1574,7 @@ msgstr ""
 #. Error - player has tried to put more money into the bank than
 #. he/she has
 #: src/curses_client/curses_client.c:1478
-#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr ""
 
@@ -1642,7 +1638,7 @@ msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr ""
 
@@ -1849,8 +1845,8 @@ msgstr ""
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2274
-#: src/serverside.c:826
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
 #, c-format
 msgid "Cannot initialize networking: %s"
 msgstr ""
@@ -1945,8 +1941,8 @@ msgid "Inventory"
 msgstr ""
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2638 src/gui_client/gtk_client.c:2774
-#: src/gui_client/gtk_client.c:3069 src/gui_client/gtk_client.c:3121
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr ""
 
@@ -2122,13 +2118,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2410
-#: src/gui_client/gtk_client.c:2579 src/gui_client/gtk_client.c:3015
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2591
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2191,49 +2187,49 @@ msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2321
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2322 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2323
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2324
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2325
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2327
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2329
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr ""
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2337
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2348
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2261,141 +2257,141 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2375
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
 "Church Wars is released under the GNU General Public License\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2403
+#: src/gui_client/gtk_client.c:2404
 msgid "Original Church Wars information here"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2508
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2463 src/gui_client/gtk_client.c:2512
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2472
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2475
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr ""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2528
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr ""
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2534
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr ""
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2537
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr ""
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2545
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr ""
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2549
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr ""
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2555
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr ""
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2586
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr ""
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2617
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr ""
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2725
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr ""
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2747
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2753
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr ""
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2768
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr ""
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2849 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2851
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr ""
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2854
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2855
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr ""
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2863
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr ""
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2869
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr ""
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2988
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr ""
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:3001
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2403,12 +2399,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3046
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3105
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2682,7 +2678,7 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:371 src/serverside.c:1635 src/serverside.c:1642
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 msgid "Church Wars server"
 msgstr ""
 
@@ -2693,27 +2689,27 @@ msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2736,27 +2732,27 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:169 src/serverside.c:1070
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr ""
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2764,21 +2760,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2786,7 +2782,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2796,235 +2792,235 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr ""
 
-#: src/serverside.c:440
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:460
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr ""
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:479
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr ""
 
-#: src/serverside.c:534
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:686
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr ""
 
-#: src/serverside.c:692
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr ""
 
-#: src/serverside.c:740
+#: src/serverside.c:742
 #, c-format
 msgid "Cannot create server (listening) socket (%s)"
 msgstr ""
 
-#: src/serverside.c:753
+#: src/serverside.c:755
 #, c-format
 msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
-#: src/serverside.c:767
+#: src/serverside.c:769
 #, c-format
 msgid "Cannot bind to port %u (%s)"
 msgstr ""
 
-#: src/serverside.c:776
+#: src/serverside.c:778
 msgid "Cannot listen to network socket."
 msgstr ""
 
-#: src/serverside.c:783
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:796
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:802
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:808
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:811
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:816
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr ""
 
-#: src/serverside.c:885
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:917
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr ""
 
-#: src/serverside.c:925
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr ""
 
-#: src/serverside.c:929
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr ""
 
-#: src/serverside.c:932 src/serverside.c:943
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr ""
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:938
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr ""
 
-#: src/serverside.c:945
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr ""
 
-#: src/serverside.c:964
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr ""
 
-#: src/serverside.c:977
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr ""
 
-#: src/serverside.c:986
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr ""
 
-#: src/serverside.c:1073
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1172
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1252
+#: src/serverside.c:1263
 #, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 
-#: src/serverside.c:1255
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1266
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1272
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1523 src/serverside.c:1542 src/serverside.c:1549
-#: src/serverside.c:1689
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1529
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1538
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1564
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1653
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1808
+#: src/serverside.c:1819
 #, c-format
 msgid "Cannot write to high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1870
+#: src/serverside.c:1881
 #, c-format
 msgid "Invalid score file version '%s'"
 msgstr ""
 
-#: src/serverside.c:1914
+#: src/serverside.c:1925
 #, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1938
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr ""
 
-#: src/serverside.c:1943
+#: src/serverside.c:1954
 #, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1949
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1958
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1967
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:2072
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3033,7 +3029,7 @@ msgid ""
 "-f command line option."
 msgstr ""
 
-#: src/serverside.c:2086
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3043,196 +3039,196 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2096
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2101
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2159
+#: src/serverside.c:2170
 #, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr ""
 
-#: src/serverside.c:2200
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr ""
 
-#: src/serverside.c:2230
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr ""
 
-#: src/serverside.c:2243
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr ""
 
-#: src/serverside.c:2264
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr ""
 
-#: src/serverside.c:2291
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2353
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr ""
 
-#: src/serverside.c:2357
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr ""
 
-#: src/serverside.c:2360
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr ""
 
-#: src/serverside.c:2369 src/serverside.c:2378 src/serverside.c:2387
-#: src/serverside.c:2396
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2409
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2422
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2489
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2495
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2537
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2539
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2544
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2773
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:3004
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:3013
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:3045
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:3057
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:3063
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:3076
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:3081
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:3098
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:3113
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3123
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3130
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3155
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3163
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3176
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3367
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3393
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3467
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3709
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3714
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3723
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3736
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3356,155 +3352,155 @@ msgstr ""
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:976
+#: src/message.c:989
 #, c-format
 msgid "Cannot initialize networking (%s)!"
 msgstr ""
 
-#: src/message.c:1156
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr ""
 
-#: src/message.c:1159
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr ""
 
-#: src/message.c:1355
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr ""
 
-#: src/message.c:1356
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr ""
 
-#: src/message.c:1357
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr ""
 
-#: src/message.c:1358
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr ""
 
-#: src/message.c:1358
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr ""
 
-#: src/message.c:1362
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1366
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1370
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr ""
 
-#: src/message.c:1377
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr ""
 
-#: src/message.c:1379
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr ""
 
-#: src/message.c:1384
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1387
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr ""
 
-#: src/message.c:1396
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr ""
 
-#: src/message.c:1399
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr ""
 
-#: src/message.c:1402
+#: src/message.c:1415
 msgid "You got away!"
 msgstr ""
 
-#: src/message.c:1408
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr ""
 
-#: src/message.c:1416
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr ""
 
-#: src/message.c:1419
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr ""
 
-#: src/message.c:1425
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr ""
 
-#: src/message.c:1428
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1431
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr ""
 
-#: src/message.c:1436
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1440
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr ""
 
-#: src/message.c:1443
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1447
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr ""
 
-#: src/message.c:1449
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1452
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1455
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1457
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr ""
 
@@ -3588,15 +3584,15 @@ msgstr ""
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1213
+#: src/network.c:1220
 msgid "curl_multi_init failed"
 msgstr ""
 
-#: src/network.c:1221
+#: src/network.c:1228
 msgid "curl_easy_init failed"
 msgstr ""
 
-#: src/network.c:1410
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3613,31 +3609,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/configfile.c:181 src/configfile.c:258 src/configfile.c:265
-#: src/configfile.c:290
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, c-format
 msgid "Could not write to config file: %s"
 msgstr ""
 
-#: src/configfile.c:198
+#: src/configfile.c:236
 #, c-format
 msgid "Could not stat config file: %s"
 msgstr ""
 
-#: src/configfile.c:204 src/configfile.c:238
+#: src/configfile.c:242 src/configfile.c:276
 msgid "Config file too large"
 msgstr ""
 
-#: src/configfile.c:251
+#: src/configfile.c:289
 #, c-format
 msgid "Could not truncate config file: %s"
 msgstr ""
 
-#: src/configfile.c:331
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:343
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3791,16 +3787,4 @@ msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
 "Recompile passing --enable-networking to the configure script."
-msgstr ""
-
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr ""
-
-#: src/sound.c:229
-#, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2001-04-08 15:48+0100\n"
 "Last-Translator: Benjamin Karaca <mister-freeze@web.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -23,28 +23,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -52,586 +52,586 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "den Kredithai"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "die Bank"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Netzwerk-Port zu dem verbunden werden soll"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Name der Highscore-Datei"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Server zu dem verbunden werden soll"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Begrüßungsnachricht (MOTD) des Servers"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Netzwerkadresse für den Server"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE, wenn ein SOCKS-Server für das Netzwerkspiel genutzt werden soll"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE, wenn numerische Benutzer-IDs für SOCKS4 benutzt werden sollen"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Der Benutzername für SOCKS4, wenn nicht leer"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "Der Hostname eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "Die Port-Adresse eines SOCKS-Servers, der benutzt werden soll"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Die Version des zu verwendenden SOCKS-Protokolls (4 oder 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Benutzername für die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Passwort für  die Bestätigung von SOCKS5"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE wenn der Server bei einem MetaServer Meldung erstatten soll"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 "Name des Metaservers, zu/von dem Server-Details gesendet/erhalten werden "
 "sollen"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Bevorzugter Hostname deines Servers"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Bestätigung für LocalName mit dem Metaserver"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Server-Beschreibung, die an den Metaserver gemeldet wird"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Wenn TRUE wird der Server zur Taskleiste minimiert"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Wenn TRUE läuft der Server im Hintergrund"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Anzahl der Spielrunden (0 = unbegrenzt)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Tag des Monats an dem das Spiel beginnt"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Monat in dem das Spiel beginnt"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Jahr in dem das Spiel beginnt"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr "Das Währungssymbol (z.B. $)"
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Wenn TRUE wird das Währungssymbol dem Preis vorangestellt"
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Datei in welche die Log-Nachrichten geschrieben werden sollen"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Kontrolliert die Anzahl der erzeugten Log-Nachrichten"
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "strftime() Format-String für Zeitstempel in den Log-Nachrichten"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Zufallsereignisse sind entschärft"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE wenn der Wert gekaufter Drogen gespeichert werden soll"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Für die Fehlersuche hilfreiche Nachrichten erzeugen"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Anzahl der Orte im Spiel"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Anzahl der Polizisten im Spiel"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Anzahl der Waffen im Spiel"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Anzahl der Drogen im Spiel"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Position des Kredithais"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Position der Bank"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Position des Waffenladens"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Position des Pubs"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Täglicher Zinssatz beim Kredithai"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Täglicher Zinssatz deines Bankguthabens"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Name des Kredithais"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Name der Bank"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Name des Waffenladens"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Name des Pubs"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE wenn Sounds aktiviert werden sollen"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Sound-Datei für einen Treffer"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Sound-Datei für einen verfehlten Schuss"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Sound-Datei für das Nachladen einer Waffe"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 "Sound-Datei für das Ableben eines feindlichen Klerikers oder Hilfssheriffs"
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr "Sound-Datei für das Ableben eines eigenen Klerikers"
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr "Sound-Datei für das Ableben eines anderen Spielers oder Polizisten"
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Sound-Datei für DEIN Ableben"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Sound-Datei für eine erfolglose Flucht eines anderen Spielers"
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Sound-Datei für eine erfolglose Flucht von dir"
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr "Sound-Datei für eine gelungene Flucht eines anderen Spielers"
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr "Sound-Datei für eine gelungene Flucht von dir"
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Sound-Datei für die Ankunft an einem neuen Ort"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr "Sound-Datei für den Beitritt eines Spielers zu einem Spiel"
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr "Sound-Datei für den Ausstieg eines Spielers aus einem Spiel"
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr "Sound-Datei für den Start des Spieles"
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr "Sound-Datei für das Ende des Spieles"
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Taste für das Sortieren der Liste der vorhandenen Drogen"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Sekundenanzahl in denen zurückgeschossen werden muss"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Spieler werden nach Ablauf dieser Sekunden getrennt"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Sekundenanzahl um Verbindungen herzustellen oder zu beenden"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maximale Anzahl der TCP/IP-Verbindungen"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Sekundenanzahl zwischen den Runden der KI-Spieler"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Startkapital der einzelnen Spieler"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Startschulden der einzelnen Spieler"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Namen der einzelnen Orte"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Polizeipräsenz an den einzelnen Orten (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Mindestanzahl an Drogen an jedem Ort"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Maximale Anzahl an Drogen an jedem Ort"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% Trefferresistenz jedes Spielers"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% Trefferresistenz jedes Klerikers"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Namen der einzelnen Polizisten"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Name des Hilfssheriffs jedes einzelnen Polizisten"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Name der Hilfssheriffs jedes einzelnen Polizisten"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% Trefferresistenz jedes Polizisten"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% Trefferresistenz jedes Hilfssheriffs"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Angriffserschwernis im Verhältnis zu einem Spieler"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Verteidigungserschwernis im Verhältnis zu einem Spieler"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Minimale Anzahl der begleitenden Hilfssheriffs"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Maximale Anzahl der begleitenden Hilfssheriffs"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Index der Waffe mit der Polizisten bewaffnet sind (Null-basiert)"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Anzahl der Waffen die jeder Polizist trägt"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Anzahl der Waffen die jeder Hilfssheriff trägt"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Name jeder Droge"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Minimaler Standardpreis jeder Droge"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Maximaler Standardpreis jeder Droge"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE wenn diese Droge extrem billig sein kann"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE wenn diese Droge extrem teuer sein kann"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Nachricht die angezeigt wird wenn diese Droge extrem billig ist"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 "Format-String der mit 50%-iger Wahrscheinlichkeit für teure Drogen benutzt "
 "wird "
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 "Teiler der für den Drogenpreis benutzt wird wenn dieser extrem billig ist"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplikationsfaktor bei extrem hohen Drogenpreisen"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Namen der einzelnen Orte"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Preis jeder Waffe"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Platzverbrauch jeder Waffe"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Schaden jeder Waffe"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Wie soll ein einzelner Kleriker bezeichnet werden?"
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Wie sollen zwei oder mehrere Kleriker bezeichnet werden?"
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Wie soll eine einzelne Waffe oder Ähnliches bezeichnet werden?"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Wie sollen zwei oder mehrere Waffen bezeichnet werden?"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Wie soll eine einzelne Droge oder Ähnliches bezeichnet werden?"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Wie sollen zwei oder mehrere Drogen bezeichnet werden?"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() Format-String für das Anzeigen der Spielrunden"
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Kosten, damit ein Kleriker den Feind ausspioniert"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Kosten, damit ein Kleriker die Polizei über einen Feind informiert"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Minimaler Geldbetrag für das Anheuern eines Klerikers"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Maximaler Geldbetrag fuer das Anheuern eines Klerikers"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Liste der Dinge die du in der U-Bahn aufschnappen kannst"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Anzahl der Dinge"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Liste der Lieder die du spielen hören kannst"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Anzahl der Lieder"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Liste der Dinge die du machen kannst"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Anzahl der Dinge die du machen kannst"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -639,139 +639,139 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 "Der Markt wird mit billigem, selbst hergestelltem Acid geradezu überflutet!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
@@ -780,47 +780,45 @@ msgstr ""
 "Weed ist ins bodenlose gefallen!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Nachricht"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr ""
-"Die Polizei hat eine große Menge %tde konfisziert! Die Preise schießen in "
-"die Höhe!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Die Polizei hat eine große %tde-Razzia durchgeführt! Die Preise schießen in die Höhe!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Junkies kaufen %tde für horrende Summen!"
@@ -829,144 +827,144 @@ msgstr "Junkies kaufen %tde für horrende Summen!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Wäre es nicht cool, wenn alle plötzlich mal zittern würden?"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "Der Papst war mal jüdisch, weißte?"
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Ich möchte wetten, dass du interessante Träume hast."
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Ich glaub' ich fahr' dieses Jahr mal wieder nach Amsterdam."
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Mein Sohn, du brauchst 'nen gelben Haarschnitt."
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ich finde es wundervoll was man heutzutage mit Düften alles anstellt."
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "Ich war nicht immer ne Frau, weißte?"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Weiß deine Mami, dass du'n Dealer bist"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "Bist du bekifft?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Oh, du musst aus Kalifornien kommen."
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Ich war selber mal 'n Hippie."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Es geht einfach nichts über 'nen riesen Haufen Zaster!"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "Du siehst aus wie 'n Erdferkel!"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Ich glaube nicht an Ronald Reagan!"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Verbreitet die Wahrheit! Bush ist eine Nudel!"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Hab' ich dich nich' mal im Fernsehen gesehen?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Wir gewinnen den Kampf um die Drogen!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Ein Tag ohne Drogen ist so dunkel wie die Nacht."
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Man benutzt ohnehin nur 20% seines Gehirns, warum soll man sich da nicht die "
 "restlichen 80% zudröhnen?!"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Ich erbitte Spenden für Zombies... für Jesus!"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Darf ich dir diesen hochgestylten Pudel verkaufen?"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Gewinner nehmen keine Drogen... es sei denn, sie nehmen welche!"
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus liebt dich mehr als du glaubst."
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "Magst du ein Gummibärchen?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Ausführen der Konfigurationsdatei %s in Zeile %d abgebrochen"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Fehler beim Öffnen der Datei %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -977,40 +975,40 @@ msgstr ""
 "oder entferne sie mit dem push oder kill Kommando und versuche es dann noch "
 "mal"
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Index in Array %s sollte zwischen 1 und %d sein"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s ist %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s ist %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s ist %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s ist \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] ist %s\n"
@@ -1018,66 +1016,64 @@ msgstr "%s[%d] ist %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s ist { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kann nicht kleiner sein als %d  ignorieren!"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kann nicht größer sein als %d  ignorieren!"
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Optimierte Struktur-Liste von %d Elementen\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Erwarteter Boolean-Wert (0, FALSE, 1, TRUE"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1092,7 +1088,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1150,7 +1146,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1160,9 +1156,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1175,7 +1169,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1223,7 +1217,7 @@ msgstr ""
 "Melde Programmierfehler dem Autor Ben Webb, benwebb@users.sf.net\n"
 "Melde übersetzungsfehler an Benjamin Karaca, mister-freeze@web.de\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1233,7 +1227,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1243,7 +1237,7 @@ msgstr ""
 "Option \"--enable-curses-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den GTK+-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1253,7 +1247,7 @@ msgstr ""
 "Option \"--enable-gui-client\" mit dem Programm \"configure\"\n"
 "neu kompilieren oder Du benutzt den curses-Klient falls er verfügbar ist.\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1264,7 +1258,7 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben\n"
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1272,32 +1266,32 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Deutsche Übersetzung         Benjamin Karaca"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 "Dieses Spiel basiert auf dem alten Spiel Drug Wars von John E. Dell und"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr "simuliert einen imaginären Drogenmarktes. Das Ziel ist es"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "Drogen zu kaufen und zu verkaufen und den Cops zu entwischen!"
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1305,59 +1299,59 @@ msgid ""
 msgstr ""
 "Zuerst solltest du beim Örtlichen Kredithai deine Schulden begleichen. Danach"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 "musst du versuchen möglichst viel Geld zu verdienen (und zu überleben)!"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Dir bleibt ein ganzer Monat Spielzeit um dein Glück zu machen."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Version %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Drugwars wurde unter der GNU General Public License veröffentlicht"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Symbole und Grafiken         Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Sounds                       Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testspieler                  Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Exzessives Testspielen       Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Unkonstruktive Kritk         James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Unkonstruktive Kritk         James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr "Für Informationen über die Startparameter tipp Church Wars -h in"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1365,60 +1359,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Bitte gib den Hostnamen und Port des Church Wars servers an:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Hostname: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Port: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Bitte warten... Erstelle Verbindung zu Metaserver..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Server : %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Port   : %d "
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Version    : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Spieler: -unbekannt- (maximal %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Spieler: %d (maximal %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "Online seit: %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Kommentar: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>ächster ; V>orheriger ; W>ähle diesen Server... "
 
@@ -1426,212 +1425,201 @@ msgstr "N>ächster ; V>orheriger ; W>ähle diesen Server... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "NVW"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Verbinde zu SOCKS-Server %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Authentifiziere bei SOCKS Server"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Frage SOCKS nach Verbindung zu %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 "SOCKS Authentifizierung benötigt (Benutzername leer lassen um abzubrechen)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Benutzername: "
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Passwort: "
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Bitten warten... versuche Church Wars-Server zu kontaktieren..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "Bekomme keine Details des Metaserver"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Kann den Multiplayer-Modus nicht starten"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Öffne V>erbindug zu einem Server, "
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "L>iste Server des Metaserver auf und wähle einen aus"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "möchtest Du das Spiel B>eenden"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr " oder möchtest Du als E>inzelspieler spielen "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "VLBE"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Wohin soll's gehen, Kumpel? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Du kannst keine Kohle für die folgenden Drogen kriegen %tde :"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "Was willst du wegwerfen? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Wie viel schmeißt du weg? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "Was willst du kaufen? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "Was möchtest du verscherbeln? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Du kannst dir %d leisten, und %d tragen. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Wie viel kaufst du? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Du hast %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Wieviel verkaufst du? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Willst du wirklich aufhören? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "JN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Neuer Name: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Du wurdest vom Server geworfen. Kehre zum Einzelspieler-Modus zurück."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre zum Einzelspieler-Modus zurück"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s betritt das Spiel!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s hat das Spiel verlassen."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s ist nun bekannt als %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Derzeitiger Aufenthaltsort/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Leider benutzt schon jemand anders \"deinen\" Namen. Bitte ändere Ihn"
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "B E S T E N L I S T E"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Du hast keine %tde die du verkaufen könntest!"
 
@@ -1639,27 +1627,27 @@ msgstr "Du hast keine %tde die du verkaufen könntest!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du brauchst mehr %tde Platz um noch mehr %tde tragen zu können!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du hast nicht genug Platz um eine %tde zu tragen!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du hast nicht genug Kohle für eine %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 
@@ -1667,41 +1655,41 @@ msgstr "Willst du E>inkaufen, V>erkaufen, oder G>ehen? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "EVG"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Wieviel Geld möchtest Du zurückzahlen?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "Soviel Kohle hast Du nicht!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Möchtest Du E>inzahlen, A>bheben, oder die Bank V>erlassen? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "EAV"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Wie viel Kohle?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "So viel Knete hast du gar nicht..."
 
@@ -1709,47 +1697,47 @@ msgstr "So viel Knete hast du gar nicht..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "J:Ja"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Nein"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "R:Rennen"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "K:Kämpfen"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Angriff"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "V:Verschwinden"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Drück irgend'ne Taste..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Nachrichten (-/+ zum Scrollen)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Statistik"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Bargeld"
 
@@ -1757,41 +1745,41 @@ msgstr "Bargeld"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Gesundheit"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Konto"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Schulden"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Platz %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Platz %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Mantel"
 
@@ -1799,131 +1787,131 @@ msgstr "Mantel"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogen/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogen/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Tja, Du bist alleine auf der Welt!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Eingeloggte Mitspieler:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hey Kleiner, die %tde Preise von hier:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kann den SIGWINCH Interrupt Handler nicht installieren"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Hey Kleiner, wie lautet dein Name? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "Willst Du E>inkaufen"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", V>erkaufen"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", W>egwerfen"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", S>prechen, F>lüstern"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", L>iste"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", K>ämpfen"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", R>eisen"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", oder B>eenden? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Willst Du "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "K>ämpfen, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "S>tehen bleiben, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "R>ennen, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "mit %tde H>andeln, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "oder B>eenden? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 "Verbindung zum Server unterbrochen! Kehre in den Einzelspieler-Modus zurück"
@@ -1931,27 +1919,33 @@ msgstr ""
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "EVWSFLAKRB"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "HRKSE"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Zeige S>pieler oder P>unkte? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Kann WinSock nicht initialisieren (%s)"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Möchtest du noch mal spielen? "
 
@@ -2041,8 +2035,8 @@ msgid "Inventory"
 msgstr "Inventar"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Schließen"
 
@@ -2223,13 +2217,13 @@ msgstr "Wieviel Verkaufen?"
 msgid "Drop how many?"
 msgstr "Wieviel Wegwerfen?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2287,54 +2281,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Deutsche Übersetzung"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Symbole und Grafiken"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sounds"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Drogen Handel und Nachforschung"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testspieler"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Exzessives Testspielen"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Konstruktive Kritik"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Unkonstruktive Kritik"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2362,7 +2356,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2371,134 +2365,135 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars wurde unter der GNU General Public License veröffentlicht.\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Kredithai Fenstertitel/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/BankName Fenstertitel/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "Sie müßen einen positiven Geldbetrag eingeben!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Ein B?nker spricht: \"Soviel Geld haben Sie nicht.\""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Bargeld: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Schulden: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Konto: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Zurückzahlen:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Einzahlen"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Abheben"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Bezahle alles"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Spieler Liste"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Rede mit Spieler(n)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Rede mit allen Spielern"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Nachricht:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Senden"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Name"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preis"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Anzahl"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Einkaufen ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Verkaufen"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Wegwerfen <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde hier"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde dabei"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Ändere Name"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2506,12 +2501,12 @@ msgstr "Leider benutzt schon jemand anders \"deinen\" Namen, ändere Ihn bitte."
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Waffenladen Fenstertitel/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2778,7 +2773,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
@@ -2787,39 +2782,39 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "Der Server wurde beendet."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2860,27 +2855,27 @@ msgstr ""
 "Verfügbare Variablen werden hier aufgelistet :-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Konnte nicht zu Metaserver verbinden %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServer : %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Warte auf Verbindung zu Metaserver %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2888,21 +2883,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxKlients (%d) erreicht - verwerfe Verbindung"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2910,7 +2905,7 @@ msgstr "Sorry, aber hier dürfen max. 1 spielen.^Bitte versuchs später nochmal.
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2921,60 +2916,66 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s ist nun bekannt als %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: VERWEIGERT Reise zu %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Deine Zeit als Dealer ist vorbei..."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: VERWEIGERT Reise zu %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Unbekannte Nachricht: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Pflege PID Datei %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Kann PID Datei nicht erstellen %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
-msgstr ""
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
+msgstr "Kann PID Datei nicht erstellen %s: %s"
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr "Kann nicht auf Port %u (%s) starten. Breche ab."
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
-msgstr "Kann nicht am Netzwerksockeln horchen. Breche ab."
+msgid "Cannot set socket reuse option (%s)"
+msgstr ""
 
 #: src/serverside.c:769
+#, fuzzy, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr "Kann nicht auf Port %u (%s) starten. Breche ab."
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "Kann nicht am Netzwerksockeln horchen. Breche ab."
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -2982,125 +2983,135 @@ msgstr ""
 "Church Wars server version %s klar und wartet auf verbindungen auf port %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kann SIGUSR1 nicht installieren, breche ab"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Kann SIGHUP nicht installieren, breche ab"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Kann SIGINT nicht installieren, breche ab"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Kann SIGTERM nicht installieren, breche ab"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Kann pipe handler nicht installieren"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Eingelogte Spieler:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Du bist ganz allein auf der Welt!\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Drücke %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Kein solcher Benutzer!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s getötet\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Unbekanntes Kommando - versuch mal \"help\" für Hilfe...\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "bekommt Verbindung von %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "Der Server wurde beendet."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s verlässt den Server!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 "Church Wars server version %s klar und wartet auf verbindungen auf port %d."
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Neue Admin verbindung"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Admin Befehl: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Admin Verbindung geschlossen"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr "Kann NT Dienst Status nicht setzen"
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr "Konnte Service Benachrichtigung nicht senden"
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr "Kann Dienst handler nicht registrieren"
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr "Kann NT Dienst nicht starten"
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Befehl:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3109,17 +3120,17 @@ msgstr ""
 "Kann kein Backup (%s) der\n"
 "Bestenliste-Datei %s erstellen."
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Fehler beim Lesen der Punkte aus %s."
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -3128,7 +3139,7 @@ msgstr ""
 "Die Bestenliste-Datei %s wurde in das neue Format konvertiert.\n"
 "Ein Backup der alten Datei wurde als %s erstellt.\n"
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3137,12 +3148,12 @@ msgstr ""
 "Kann kein Backup (%s) der\n"
 "Bestenliste-Datei %s erstellen."
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3155,7 +3166,7 @@ msgstr ""
 "auf die Datei/das Verzeichnis hast oder gib eine andere Bestenliste-Datei\n"
 "mit derm -f Kommandozeilen-Parameter an."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3170,7 +3181,7 @@ msgstr ""
 "mit Hilfe des Parameters \"Church Wars -C %s\"\n"
 "in der Kommandozeile."
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 #, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
@@ -3181,7 +3192,7 @@ msgstr ""
 "werden einige Einstellungen vielleicht nicht wie erwartet funktionieren.\n"
 "Ziehe die Datei \"Church Wars-log.txt\" für weitere Details zu Rate."
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -3191,116 +3202,116 @@ msgstr ""
 "werden einige Einstellungen vielleicht nicht wie erwartet funktionieren.\n"
 "Schau dir die Nachrichten unter Standard Output für weitere Details an."
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Kann die Bestenliste-Datei nicht öffnen %s: %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Kann die Bestenliste-Datei %s nicht lesen."
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Glückwunsch! Du hast Dir einen Platz in der Bestenliste erkämpft!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Tja, besser spielen, dann gibt's auch 'nen Highscore..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Kann Bestenliste-Datei %s nicht schreiben."
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Die Lady neben dir in der U-Bahn sagte,^ \"%s\"%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (Zumindest -glaubst- du, sie hätte das gesagt)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Du hörst jemanden %s spielen"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Möchtest du %tde besuchen?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Willst Du eine %tde für %P anwerben?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s ist schon hier!^Willst du angreifen, oder dich verdrücken?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "Keine Bullen oder Waffen!"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "Polizisten können sich nicht gegenseitig angreifen."
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "Spieler kämpfen bereits!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "Spieler kämpfen bereits in verschieden Kämpfen!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kann nicht kämpfen - keine Waffen vorhanden!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Du bist tot! Game over."
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 "YN^Willst du einem Doktor %P blechen, damit er dich wieder zusammenflickt?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du wurdest in der U-Bahn bestohlen!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du triffst einen Freund! Er gibt dir %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du triffst einen Freund! Du gibst ihm %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3308,17 +3319,17 @@ msgstr ""
 "Polizeihunde jagend dich %d Blocks entlang! Du hast ein wenig %tde "
 "weggeworfen! So'n Scheiß."
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du findest %d %tde bei einem toten Penner in der U-Bahn!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Deine Mama hat aus deinem %tde Brownies gemacht! Die waren super!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3326,24 +3337,24 @@ msgstr ""
 "YN^Du findest etwas Weed, das wie wie übelstes Rattengift stinkt!^Sieht aber "
 "sonst ganz gut aus! Willst Du es rauchen?"
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du machst eine kleine Pause um %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Möchtest Du einen größeren Mantel für %P kaufen?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hey Kumpel! Ich trage dir %tde für %P. Wie wär's? Ja oder Nein?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Willst Du eine %tde für %P kaufen?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3352,29 +3363,29 @@ msgstr ""
 "alles, was du bisher erlebt hast. Dann bist du abgekratzt, weil dein Gehirn "
 "in tausend Teile zersprungen ist."
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Zu spät - %s hat sich verpisst!"
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Die Cops haben dich gesehen als du %tde wegwerfen wolltest!"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sende Update an Metaserver..."
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sende Erinnerungsnachricht an Metaserver..."
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Spieler entfernt aufgrund von Idle Timeout"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Spieler entfernt aufgrund von Timeout bei Verbindungsaufbau"
 
@@ -3494,243 +3505,251 @@ msgstr "Interner Metaserver Fehler \"%s\""
 msgid "Bad metaserver reply \"%s\""
 msgstr "Falsche Antwort des Metaservers \"%s\""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Kann WinSock nicht initialisieren (%s)"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Willst Du abhauen?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Willst Du Rennen, oder Kämpfen?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "ärmlich bewaffnet"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "leicht bewaffnet"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "recht gut bewaffnet"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "schwer bewaffnet"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "bis an die Zähne bewaffnet"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - verfolgt dich Mann!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s und %d %tde - %s - verfolgen dich, Mann!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s trifft mit %d %tde ein, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s steht rum und kriegt's voll ab."
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Du bleibst stehen und fängst die Kugeln"
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s versucht erfolglos zu fliehen."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "Verdammt! Du wirst sie nicht los!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s ist geflohen nach %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "%s ist abgehauen!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "Du entkommst!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Waffen nachgeladen..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s schiesst auf %s... und verfehlt!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s schießt auf dich... und verfehlt!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "Du triffst %s nicht!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s erledigt %s."
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s schießt auf %s und tötet eine %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s ist %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s schießt auf dich und tötet eine %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "%s trifft dich, Mann!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "Du triffst und tötest %s"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Du triffst %s und tötest eine %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "Du schießt, und triffst %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr "Du findest %P in der Leiche!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr "Du plünderst die verdammte Leiche!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "Kann WinSock nicht initialisieren (%s)"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr "SOCKS-Server allgemeiner Fehler"
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Verbindung von SOCKS ruleset abgelehnt"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Netzwerk unerreichbar"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Host unerreichbar"
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Verbindung abgelehnt"
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL abgelaufen"
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Befehl nicht unterstützt"
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Addressen-Typ nicht unterstützt"
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS: Server hat alle angebotenen Methoden abgelehnt"
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr "Unbekannter SOCKS Addressentyp zurückgekehrt"
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-Bestätigung fehlgeschlagen"
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-Bestätigung vom Benutzer abgebrochen"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Nachfrage abgelehnt oder fehlgeschlagen"
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Abgelehnt  unmöglich identd zu kontaktieren"
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Abgelehnt  identd meldet andere Benutzer-ID"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr "Unbekannter SOCKS Antwort-Code"
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr "Unbekannter SOCKS Antwort-Version-Code"
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr "Unbekannte SOCKS Server-Version"
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS Fehler Code %d"
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3749,22 +3768,31 @@ msgid ""
 "\n"
 msgstr "Verbindung hergestellt. Beende deine Session mit Strg+D.\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Kann Datei nicht öffnen %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Kann Datei nicht öffnen %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Kann Datei nicht öffnen %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr "Konnte lokale Konfigurationsdatei nicht bestimmen"
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Kann Datei nicht öffnen %s: %s"
@@ -3803,116 +3831,121 @@ msgid ""
 msgstr ""
 "Benutze Socks.Auth.User und Socks.Auth.Password für SOCK5-Bestätigung\n"
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "KI Spieler gestartet; erstelle Verbindung zu Server bei %s:%d ..."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "Konnte nicht zu Metaserver verbinden %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "KI Spieler beendet OK.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Verbindung zu Server verloren!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Benutze Name %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Spieler im Spiel:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s betritt das Spiel.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s verlassst das Spiel.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Reise von %tde mit %P Bargeld und %P Schulden\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "KI Spieler wurde getötet. Beende normal.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Spielzeit ist um. Verlasse Spiel.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "KI Spieler wurde vom Server geworfen.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "Der Server wurde beendet.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Verkaufe %d %tde in %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Kaufe %d %tde für %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kaufe eine %tde für %P im Waffenladen\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "%P Schulden an den Kredithai zurückgezahlt.\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Kredithai ist in %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Waffenladen ist in%s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Pub ist in %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Bank ist in %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Ihr nennt euch Drogendealer?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Selbst ein trainierter Affe könnte das besser"
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Denkste Du bist hart genug um mit Leuten wie mir zu handeln?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... handelst du mit Schokoriegeln oder was?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Kleiner, ich muss dich töten - zu deinem eigenen Besten!"
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3922,19 +3955,24 @@ msgstr ""
 " und kann dadurch nicht als KI Spieler eingesetzt werden.\n"
 "Neu kompilieren und --enable-networking bei ./configure angeben"
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "Fehler beim Öffnen der Datei %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "Bekomme keine Details des Metaserver"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Kann den Multiplayer-Modus nicht starten"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Ungültiges Plugin \"%s\" ausgewählt.\n"
-"(%s verfügbar; verwende nun \"%s\".)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "Fehler beim Öffnen der Datei %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Ungültiges Plugin \"%s\" ausgewählt.\n"
+#~ "(%s verfügbar; verwende nun \"%s\".)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "Das Kommando, welches zum Starten deines Web-Browsers benutzt wird"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the dopewars package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: dopewars\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,28 +22,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -51,580 +51,580 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr ""
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr ""
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr ""
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr ""
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr ""
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr ""
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr ""
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr ""
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr ""
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr ""
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr ""
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr ""
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr ""
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr ""
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr ""
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr ""
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr ""
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr ""
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr ""
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr ""
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr ""
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr ""
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr ""
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr ""
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr ""
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr ""
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr ""
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr ""
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr ""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr ""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr ""
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr ""
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr ""
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr ""
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr ""
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr ""
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr ""
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr ""
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr ""
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr ""
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -632,183 +632,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr ""
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
 msgstr ""
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
@@ -817,182 +817,182 @@ msgstr ""
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr ""
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr ""
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr ""
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr ""
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr ""
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr ""
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr ""
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr ""
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr ""
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr ""
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr ""
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr ""
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr ""
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr ""
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr ""
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr ""
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr ""
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr ""
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
@@ -1000,66 +1000,64 @@ msgstr ""
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, c-format
 msgid "Church Wars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1074,7 +1072,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1104,7 +1102,7 @@ msgid ""
 "format\n"
 msgstr ""
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1114,9 +1112,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1129,7 +1125,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1150,7 +1146,7 @@ msgid ""
 "  -A       connect to a locally-running server for administration\n"
 msgstr ""
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1160,21 +1156,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1182,7 +1178,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1190,145 +1186,150 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr ""
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr ""
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
 "Collector. After"
 msgstr ""
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr ""
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr ""
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr ""
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
@@ -1336,206 +1337,196 @@ msgstr ""
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr ""
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer Church Wars"
-msgstr ""
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr ""
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr ""
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr ""
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr ""
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr ""
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr ""
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr ""
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr ""
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr ""
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr ""
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr ""
 
@@ -1543,27 +1534,27 @@ msgstr ""
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
@@ -1571,41 +1562,41 @@ msgstr ""
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr ""
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr ""
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr ""
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr ""
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
@@ -1613,47 +1604,47 @@ msgstr ""
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr ""
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr ""
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr ""
 
@@ -1661,41 +1652,41 @@ msgstr ""
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr ""
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr ""
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr ""
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr ""
 
@@ -1703,158 +1694,164 @@ msgstr ""
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr ""
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr ""
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ""
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr ""
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, c-format
+msgid "Cannot initialize networking: %s"
+msgstr ""
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr ""
 
@@ -1944,8 +1941,8 @@ msgid "Inventory"
 msgstr ""
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr ""
 
@@ -2121,13 +2118,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2185,54 +2182,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr ""
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2260,141 +2257,141 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
 "Church Wars is released under the GNU General Public License\n"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+msgid "Original Church Wars information here"
 msgstr ""
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr ""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr ""
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr ""
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr ""
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr ""
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr ""
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr ""
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr ""
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr ""
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr ""
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr ""
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr ""
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr ""
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr ""
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr ""
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr ""
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr ""
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2402,12 +2399,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2672,7 +2669,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
@@ -2681,38 +2678,38 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 msgid "Church Wars server"
 msgstr ""
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2735,27 +2732,27 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr ""
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2763,21 +2760,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2785,7 +2782,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2795,220 +2792,235 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr ""
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr ""
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr ""
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr ""
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr ""
 
-#: src/serverside.c:737
+#: src/serverside.c:742
 #, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+msgid "Cannot create server (listening) socket (%s)"
 msgstr ""
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr ""
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
+msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
 #: src/serverside.c:769
+#, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr ""
+
+#: src/serverside.c:778
+msgid "Cannot listen to network socket."
+msgstr ""
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr ""
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr ""
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr ""
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr ""
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr ""
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr ""
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr ""
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr ""
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr ""
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr ""
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, c-format
+msgid "Cannot write to high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr ""
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3017,7 +3029,7 @@ msgid ""
 "-f command line option."
 msgstr ""
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3027,196 +3039,196 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr ""
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr ""
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr ""
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr ""
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr ""
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr ""
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr ""
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr ""
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3336,243 +3348,251 @@ msgstr ""
 msgid "Bad metaserver reply \"%s\""
 msgstr ""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr ""
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr ""
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr ""
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr ""
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr ""
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr ""
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr ""
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr ""
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr ""
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
-msgstr ""
-
-#: src/message.c:1350
-#, c-format
-msgid "%s tries to get away, but fails."
-msgstr ""
-
-#: src/message.c:1353
-msgid "Panic! You can't get away!"
-msgstr ""
-
-#: src/message.c:1362
-#, c-format
-msgid "%s has got away to %tde!"
-msgstr ""
-
-#: src/message.c:1365
-#, c-format
-msgid "%s has got away!"
-msgstr ""
-
-#: src/message.c:1368
-msgid "You got away!"
-msgstr ""
-
-#: src/message.c:1374
-msgid "Weapons readied..."
-msgstr ""
-
-#: src/message.c:1379
-#, c-format
-msgid "%s attacks %s... and fails!"
-msgstr ""
-
-#: src/message.c:1382
-#, c-format
-msgid "%s swings at you... and misses!"
-msgstr ""
-
-#: src/message.c:1385
-#, c-format
-msgid "You missed %s!"
-msgstr ""
-
-#: src/message.c:1391
-#, c-format
-msgid "%s charges %s to death."
-msgstr ""
-
-#: src/message.c:1394
-#, c-format
-msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
 #: src/message.c:1397
 #, c-format
-msgid "%s attacks %s."
+msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1402
-#, c-format
-msgid "%s killed you! The Angels carry you home."
-msgstr ""
-
-#: src/message.c:1406
-#, c-format
-msgid "%s charges at you... and kills a %tde!"
+#: src/message.c:1400
+msgid "Panic! You can't get away!"
 msgstr ""
 
 #: src/message.c:1409
 #, c-format
+msgid "%s has got away to %tde!"
+msgstr ""
+
+#: src/message.c:1412
+#, c-format
+msgid "%s has got away!"
+msgstr ""
+
+#: src/message.c:1415
+msgid "You got away!"
+msgstr ""
+
+#: src/message.c:1421
+msgid "Weapons readied..."
+msgstr ""
+
+#: src/message.c:1426
+#, c-format
+msgid "%s attacks %s... and fails!"
+msgstr ""
+
+#: src/message.c:1429
+#, c-format
+msgid "%s swings at you... and misses!"
+msgstr ""
+
+#: src/message.c:1432
+#, c-format
+msgid "You missed %s!"
+msgstr ""
+
+#: src/message.c:1438
+#, c-format
+msgid "%s charges %s to death."
+msgstr ""
+
+#: src/message.c:1441
+#, c-format
+msgid "%s attacks at %s and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1444
+#, c-format
+msgid "%s attacks %s."
+msgstr ""
+
+#: src/message.c:1449
+#, c-format
+msgid "%s killed you! The Angels carry you home."
+msgstr ""
+
+#: src/message.c:1453
+#, c-format
+msgid "%s charges at you... and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1456
+#, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr ""
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr ""
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr ""
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3589,22 +3609,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, c-format
 msgid "Could not write to config file: %s"
 msgstr ""
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, c-format
+msgid "Could not stat config file: %s"
+msgstr ""
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, c-format
 msgid "Could not truncate config file: %s"
 msgstr ""
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3640,130 +3669,122 @@ msgid ""
 "Using Socks.Auth.User and Socks.Auth.Password for SOCKS5 authentication\n"
 msgstr ""
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr ""
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+msgid "Failed to connect to server; cleaning up."
+msgstr ""
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr ""
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr ""
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr ""
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr ""
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr ""
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr ""
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr ""
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr ""
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr ""
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr ""
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr ""
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr ""
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr ""
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr ""
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
 "Recompile passing --enable-networking to the configure script."
-msgstr ""
-
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr ""
-
-#: src/sound.c:229
-#, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars SVN\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2020-12-09 12:02-0800\n"
 "Last-Translator: Ben Webb <benwebb@users.sf.net>\n"
 "Language-Team: British English <en@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -49,580 +49,580 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr ""
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr ""
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr ""
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr ""
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr ""
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr ""
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr ""
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr ""
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr ""
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr ""
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr ""
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr ""
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr ""
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr ""
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr ""
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr ""
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr ""
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr ""
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr ""
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr ""
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr ""
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr ""
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr ""
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr ""
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr ""
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr ""
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr ""
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr ""
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr ""
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr ""
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr ""
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr ""
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr ""
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr ""
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr ""
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr ""
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr ""
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr ""
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr ""
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr ""
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr ""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr ""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr ""
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr ""
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr ""
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr ""
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr ""
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr ""
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr ""
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr ""
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr ""
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr ""
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr ""
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr ""
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr ""
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -630,183 +630,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr ""
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr ""
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr ""
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr ""
@@ -815,182 +815,182 @@ msgstr ""
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr ""
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr ""
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr ""
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr ""
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr ""
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr ""
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr ""
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr ""
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr ""
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr ""
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr ""
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr ""
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr ""
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr ""
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr ""
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr ""
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr ""
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr ""
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
 "them with the push or kill commands, and try again."
 msgstr ""
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr ""
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr ""
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr ""
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr ""
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr ""
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr ""
@@ -998,66 +998,64 @@ msgstr ""
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr ""
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr ""
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, c-format
 msgid "Church Wars version %s\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1072,7 +1070,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1142,7 +1140,7 @@ msgstr ""
 "  -C, --convert=FILE      convert an \"old format\" score file to the new "
 "format\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1152,9 +1150,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1167,7 +1163,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1218,7 +1214,7 @@ msgstr ""
 "  -C file  convert an \"old format\" score file to the new format\n"
 "  -A       connect to a locally-running server for administration\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1228,21 +1224,21 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
 "client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
 "use the curses client (if available) instead!\n"
 msgstr ""
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1250,7 +1246,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1258,145 +1254,150 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr ""
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr ""
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
 "Collector. After"
 msgstr ""
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr ""
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars is released under the GNU General Public Licence"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr ""
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr ""
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr ""
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr ""
 
@@ -1404,206 +1405,196 @@ msgstr ""
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr ""
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-msgid "Could not start multiplayer Church Wars"
-msgstr ""
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr ""
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr ""
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr ""
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr ""
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr ""
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr ""
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr ""
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr ""
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr ""
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr ""
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr ""
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr ""
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr ""
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr ""
 
@@ -1611,27 +1602,27 @@ msgstr ""
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr ""
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr ""
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr ""
 
@@ -1639,41 +1630,41 @@ msgstr ""
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr ""
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr ""
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr ""
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr ""
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr ""
 
@@ -1681,47 +1672,47 @@ msgstr ""
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr ""
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr ""
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr ""
 
@@ -1729,41 +1720,41 @@ msgstr ""
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr ""
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr ""
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr ""
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr ""
 
@@ -1771,158 +1762,164 @@ msgstr ""
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr ""
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr ""
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr ""
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ""
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr ""
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr ""
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr ""
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr ""
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Cannot initialise WinSock (%s)!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr ""
 
@@ -2012,8 +2009,8 @@ msgid "Inventory"
 msgstr ""
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr ""
 
@@ -2189,13 +2186,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2253,54 +2250,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr ""
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2328,7 +2325,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2337,134 +2334,135 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars is released under the GNU General Public Licence\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr ""
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr ""
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr ""
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr ""
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr ""
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr ""
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr ""
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr ""
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr ""
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr ""
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr ""
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr ""
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr ""
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr ""
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr ""
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr ""
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr ""
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr ""
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2472,12 +2470,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2742,7 +2740,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
@@ -2751,38 +2749,38 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 msgid "Church Wars server"
 msgstr ""
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2805,27 +2803,27 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr ""
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2833,21 +2831,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2855,7 +2853,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2865,220 +2863,235 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr ""
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr ""
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr ""
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr ""
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr ""
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr ""
 
-#: src/serverside.c:737
+#: src/serverside.c:742
 #, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+msgid "Cannot create server (listening) socket (%s)"
 msgstr ""
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr ""
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
+msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
 #: src/serverside.c:769
+#, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr ""
+
+#: src/serverside.c:778
+msgid "Cannot listen to network socket."
+msgstr ""
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr ""
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr ""
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr ""
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr ""
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr ""
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr ""
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr ""
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr ""
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr ""
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr ""
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr ""
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr ""
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr ""
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, c-format
+msgid "Cannot write to high score file: %s."
+msgstr ""
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr ""
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3087,7 +3100,7 @@ msgid ""
 "-f command line option."
 msgstr ""
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3097,196 +3110,196 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr ""
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr ""
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr ""
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr ""
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr ""
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr ""
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr ""
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr ""
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr ""
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr ""
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr ""
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr ""
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr ""
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr ""
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr ""
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr ""
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr ""
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
 msgstr ""
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr ""
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr ""
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr ""
 
@@ -3406,243 +3419,251 @@ msgstr ""
 msgid "Bad metaserver reply \"%s\""
 msgstr ""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Cannot initialise WinSock (%s)!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr ""
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr ""
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr ""
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr ""
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr ""
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr ""
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr ""
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr ""
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr ""
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
-msgstr ""
-
-#: src/message.c:1350
-#, c-format
-msgid "%s tries to get away, but fails."
-msgstr ""
-
-#: src/message.c:1353
-msgid "Panic! You can't get away!"
-msgstr ""
-
-#: src/message.c:1362
-#, c-format
-msgid "%s has got away to %tde!"
-msgstr ""
-
-#: src/message.c:1365
-#, c-format
-msgid "%s has got away!"
-msgstr ""
-
-#: src/message.c:1368
-msgid "You got away!"
-msgstr ""
-
-#: src/message.c:1374
-msgid "Weapons readied..."
-msgstr ""
-
-#: src/message.c:1379
-#, c-format
-msgid "%s attacks %s... and fails!"
-msgstr ""
-
-#: src/message.c:1382
-#, c-format
-msgid "%s swings at you... and misses!"
-msgstr ""
-
-#: src/message.c:1385
-#, c-format
-msgid "You missed %s!"
-msgstr ""
-
-#: src/message.c:1391
-#, c-format
-msgid "%s charges %s to death."
-msgstr ""
-
-#: src/message.c:1394
-#, c-format
-msgid "%s attacks at %s and kills a %tde!"
 msgstr ""
 
 #: src/message.c:1397
 #, c-format
-msgid "%s attacks %s."
+msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1402
-#, c-format
-msgid "%s killed you! The Angels carry you home."
-msgstr ""
-
-#: src/message.c:1406
-#, c-format
-msgid "%s charges at you... and kills a %tde!"
+#: src/message.c:1400
+msgid "Panic! You can't get away!"
 msgstr ""
 
 #: src/message.c:1409
 #, c-format
+msgid "%s has got away to %tde!"
+msgstr ""
+
+#: src/message.c:1412
+#, c-format
+msgid "%s has got away!"
+msgstr ""
+
+#: src/message.c:1415
+msgid "You got away!"
+msgstr ""
+
+#: src/message.c:1421
+msgid "Weapons readied..."
+msgstr ""
+
+#: src/message.c:1426
+#, c-format
+msgid "%s attacks %s... and fails!"
+msgstr ""
+
+#: src/message.c:1429
+#, c-format
+msgid "%s swings at you... and misses!"
+msgstr ""
+
+#: src/message.c:1432
+#, c-format
+msgid "You missed %s!"
+msgstr ""
+
+#: src/message.c:1438
+#, c-format
+msgid "%s charges %s to death."
+msgstr ""
+
+#: src/message.c:1441
+#, c-format
+msgid "%s attacks at %s and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1444
+#, c-format
+msgid "%s attacks %s."
+msgstr ""
+
+#: src/message.c:1449
+#, c-format
+msgid "%s killed you! The Angels carry you home."
+msgstr ""
+
+#: src/message.c:1453
+#, c-format
+msgid "%s charges at you... and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1456
+#, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr ""
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr ""
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "Cannot initialise WinSock (%s)!"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS authentication cancelled by user"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3659,22 +3680,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, c-format
 msgid "Could not write to config file: %s"
 msgstr ""
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, c-format
+msgid "Could not stat config file: %s"
+msgstr ""
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, c-format
 msgid "Could not truncate config file: %s"
 msgstr ""
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3710,132 +3740,124 @@ msgid ""
 "Using Socks.Auth.User and Socks.Auth.Password for SOCKS5 authentication\n"
 msgstr ""
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr ""
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+msgid "Failed to connect to server; cleaning up."
+msgstr ""
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr ""
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr ""
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr ""
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr ""
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr ""
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr ""
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr ""
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr ""
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr ""
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr ""
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr ""
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr ""
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr ""
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr ""
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr ""
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr ""
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr ""
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
 "Recompile passing --enable-networking to the configure script."
-msgstr ""
-
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr ""
-
-#: src/sound.c:229
-#, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
 msgstr ""
 
 #~ msgid "Deputy armor"

--- a/po/es.po
+++ b/po/es.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2003-12-10 09:29+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -29,28 +29,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -58,589 +58,589 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de su servidor"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Número de rondas de juego (si es 0, el juego nunca termina)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Día del mes en el que empieza el juego"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Mes en el que empieza el juego"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Año en el que empieza el juego"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr "El símbolo de dinero (por ejemplo, $)"
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si TRUE, el símbolo de dinero va antes que el precio"
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Fichero en el que escribir los mensajes de registro"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Controla el número de mensajes de registro producidos"
 
 # timestamps: dataciones estampilla marcas temporales
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "formato de la cadena strftime() para las marcas de tiempo"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Se limpian los eventos aleatorios"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE si se debe guardar el valor de las drogas compradas"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Ser prolijo al procesar el fichero de configuración"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Número de sitios en el juego"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de policía en el juego"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Número de armas en el juego"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Número de drogas en el juego"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Ubicación del usurero"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Ubicación del banco"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Ubicación de la armería"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Ubicación del bar"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Tasa de interés diaria de la deuda con el usurero"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Tipo de interés diario de su saldo en el banco"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nombre del usurero"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nombre del banco"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nombre de la armería"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nombre del bar"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE si se debe habilitar el sonido"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Fichero de sonido que suena cuando un disparo hace blanco"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Fichero de sonido que suena cuando un disparo yerra su objetivo"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 "Fichero de sonido que suena cuando se mata a un ayudante o a un clérigo "
 "enemigo"
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr "Fichero de sonido reproducido cuando muere uno de sus clérigos"
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Fichero de sonido reproducido cuando se mata a otro jugador o a un policía"
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Fichero de sonido reproducido cuando le matan a usted"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 "Fichero de sonido reproducido cuando un jugador intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 "Fichero de sonido reproducido cuando usted intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr "Fichero de sonido reproducido cuando un jugador logra escapar"
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr "Fichero de sonido reproducido cuando usted logra escapar"
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr "Fichero de sonido que suena cuando un jugador abandona el juego"
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr "Fichero de sonido reproducido al empezar el juego"
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr "Fichero de sonido reproducido al acabar el juego"
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Orden de las drogas disponibles"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos para devolver disparos"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Los jugadores son desconectados después de este número de segundos"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tiempo en segundos para que las conexiones sean establecidas o rotas"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexiones TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre los turnos de los jugadores automáticos"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Cantidad de dinero con la que empieza cada jugador"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Importe de la deuda con la que empieza cada jugador"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Presencia policial en cada sitio (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas en cada sitio"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Máximo número de drogas en cada lugar"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% de resistencia a disparos de cada clérigo"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Nombre de cada policía"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Nombre del ayudante de cada policía"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Nombre de los ayudantes de cada policía"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistencia a disparos de cada policía"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistencia a disparos de cada ayudante"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Penalización de ataque relativa a un jugador"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Penalización de defensa relativa a un jugador"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ayudantes acompañantes"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ayudantes acompañantes"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 "Índice basado en cero de la pistola con la que están armados los policías"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Número de pistolas que porta cada policía"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Número de pistolas con las que carga cada ayudante"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nombre de cada droga"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Precio mínimo normal de cada droga"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Precio máximo normal de cada droga"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE si esta droga puede ser especialmente barata"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE si esta droga puede ser especiamente cara"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensaje a mostrar cuando esta droga sea especialmente barata"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Línea utilizada para drogas que sean caras el 50% de las veces"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor del precio de la droga cuando es especialmente barata"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Precio de cada arma"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Espacio que ocupa cada arma"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Palabra usada para designar un solo \"clérigo\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Palabra usada para designar dos o más \"clérigos\""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palabra usada para designar una sola arma"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Palabra usada para designar dos o más armas"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palabra usada para designar una sola droga"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Palabra usada para designar dos o más drogas"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar la ronda del juego"
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Coste para que un clérigo espíe al enemigo"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Coste para que un clérigo delate a la policía a un enemigo"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Precio mínimo de contratar un clérigo"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Precio máximo de contratar un clérigo"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de cosas que se oyen en el metro"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Número de cosas que se dicen en el metro"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Lista de canciones que se oyen tocar"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Número de canciones que se tocan"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Lista de cosas que puede dejar de hacer"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puede dejar de hacer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -648,184 +648,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "¡El mercado está inundado de LSD casero barato!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Mensaje"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr ""
-"¡Los polis han hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "¡Los polis han hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los adictos están comprando %tde a precios absurdos!"
@@ -834,147 +833,147 @@ msgstr "¡Los adictos están comprando %tde a precios absurdos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite!"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "De todo lo que he perdido, lo que más echo de menos es la cabeza."
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Apuesto a que tiene sueños superinteresantes"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Creo que voy a ir a Amsterdam este año"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Chico, deberías teñirte el pelo de color amarillo"
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Pero ¿por qué llevas gafas de sol si es de noche?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "Yo no he sido siempre una mujer, ¿sabes?"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "¿Su madre sabe que es un camello?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "¿Está drogado o qué?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, usted debe ser gallego"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 "Hmmm... ¡qué almuerzo! Mi madre me ha preparado unas galletas de... "
 "chocolate."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Poderoso caballero es Don Dinero"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr ""
 "Sólo usamos el 10% de nuestro cerebro. ¡Destruyamos con drogas el 90% "
 "sobrante!"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "No puedo más, me voy a la cama. ¿Me acompaña?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "¡Ánimo! El imperio estadounidense caerá como cayó el imperio romano"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Usted sale en la televisión, ¿verdad?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "¿Sabe que tiene los ojos muy enrojecidos, joven?"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "¿Se imagina como sería la vida si no hubiera drogas?"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "En las hamburgueserías usan carne de rata. Por eso la dan picada."
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 "`Cuestionemos la autoridad; pensemos por nosotros mismos` dijo Tim Leary"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Le vendo una cámara de fotos nueva a mitad de precio"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Los triunfadores no usan drogas... salvo..."
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Espero que no le importe, pero voy a rezar por usted."
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "La telepatía existe. ¿No siente la energía del universo?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -985,40 +984,40 @@ msgstr ""
 "jugador conectado. Espere a que se desconecten todos los jugadores, o\n"
 "elimínelos con las órdenes echar o matar, e inténtelo otra vez."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
@@ -1026,42 +1025,42 @@ msgstr "%s[%d] es %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1069,7 +1068,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1077,19 +1076,17 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars versión %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1104,7 +1101,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1181,7 +1178,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1197,9 +1194,7 @@ msgstr ""
 "GNU GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1212,7 +1207,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1263,7 +1258,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1279,7 +1274,7 @@ msgstr ""
 "GNU GPL\n"
 "Informe de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1289,7 +1284,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o use una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1299,7 +1294,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o use el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1307,7 +1302,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1318,35 +1313,35 @@ msgstr ""
 "no se puede ejecutar en modo servidor. Recompile pasando\n"
 "la opción --enable-networking al script configure.\n"
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 "Basado en el juego Drug Wars de John E. Dell, Church Wars es una simulación"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr ""
 "de un mercado de la droga imaginario. Church Wars es un juego para toda la"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr ""
 "familia que consiste en ganar dinero con la compraventa (y eludir a la "
 "policía)."
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1354,59 +1349,59 @@ msgid ""
 msgstr ""
 "Lo primero que tiene que hacer es saldar la deuda con su usurero. Después"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr "su objetivo es hacer tanto dinero como sea posible (¡y seguir vivo!)"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Tiene un mes de tiempo de juego para amasar su fortuna."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Version %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars está publicado bajo la GNU General Public License"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Iconos y gráficos             Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Sonidos                       Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testeo del juego              Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Testeo intensivo del juego    Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Para conocer las opciones en la línea de órdenes, escriba Church Wars -h"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1415,60 +1410,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Introduzca el nombre y puerto de un servidor Church Wars:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Nombre del servidor: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Puerto: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espere... intentando contactar con el metaservidor..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Servidor: %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Puerto  : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Versión    : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Jugadores: -desconocido- (máximo %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Jugadores: %d (máximo %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "En funcionamiento desde: %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Comentario: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
@@ -1476,214 +1476,203 @@ msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "SAE"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Conectado al servidor SOCKS %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Autenticando contra el servidor SOCKS"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Pidiendo SOCKS para conectarse a %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 "Se requiere autenticación SOCKS (nombre de usuario en blanco para cancelar)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Nombre de usuario: "
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Contraseña: "
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 "Por favor, espere... intentando contactar con el servidor Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "No se pueden obtener los detalles del metaservidor"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "No se puede iniciar Church Wars en modo multijugador"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "¿Quiere... C>onectarte a un servidor Church Wars determinado"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr ""
 "            L>istar los servidores que hay en el metaservidor, y elegir uno"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 "            S>alir (puede iniciar un servidor tecleando «Church Wars -s»)"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "CLSJ"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "¿Dónde quiere ir, caballero? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "No puede conseguir ni una moneda por estas %tde que lleva:"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "¿Qué quiere tirar? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "¿Cuántas quiere tirar? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "¿Qué quiere comprar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "¿Qué quiere vender? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Tiene dinero para comprar %d, y espacio para llevar %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "¿Cuánto quiere? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Tiene %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "¿Cuánto quiere vender? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "¿Está seguro de que quiere salir? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "SN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nuevo nombre: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Ha sido expulsado del servidor. Pasando al modo 1 jugador."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s es ahora conocido como %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Desgraciadamente ya hay alguien usando «su» nombre. Elija otro."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tiene ningún %tde que vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "¡No tiene ninguna que vender!"
 
@@ -1691,27 +1680,27 @@ msgstr "¡No tiene ninguna que vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesita más %tde para que le guarden más %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tiene suficiente espacio para llevar ese %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tiene suficiente dinero para comprar ese %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 
@@ -1719,41 +1708,41 @@ msgstr "¿Quiere C>omprar, V>ender o I>rse? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "CVI"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quiere devolver? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "¡No tiene tanto dinero!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quiere I>ngresar dinero, O>btener dinero o S>alir?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "IOS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "No tiene tanto dinero en el banco..."
 
@@ -1761,47 +1750,47 @@ msgstr "No tiene tanto dinero en el banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "S:Sí"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:No"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "E:Enfrentarse"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "H:Huir"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Pulse cualquier tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Situación"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Dinero"
 
@@ -1809,41 +1798,41 @@ msgstr "Dinero"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Salud"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Deuda"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
@@ -1851,158 +1840,164 @@ msgstr "Gabardina"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, oiga. Los precios de las %tde aquí son:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Eh oiga, ¿cómo se llama? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "¿Quiere C>omprar"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", E>nfrentarse"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", I>r a otro sitio"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "¿Quiere "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>ender %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "CVTHJLMEIS"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "VCLES"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quiere? ¿J>ugadores o P>untuaciones? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "¡No se puede inicializar WinSock (%s)!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
@@ -2092,8 +2087,8 @@ msgid "Inventory"
 msgstr "Inventario"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
@@ -2273,13 +2268,13 @@ msgstr "¿Cuánto quiere vender?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quiere tirar?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2337,54 +2332,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2412,7 +2407,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2421,134 +2416,135 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está publicado bajo la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tiene que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "No tiene tanto dinero en el banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Dinero en efectivo: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Deuda: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Saldar:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Ingresar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Sacar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Pagar todo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Lista de jugadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Mensaje:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Enviar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde que tiene"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2556,12 +2552,12 @@ msgstr "Desgraciadamente ya hay otro jugador usando «su» nombre. Elija otro"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2828,7 +2824,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 #, fuzzy
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
@@ -2842,39 +2838,39 @@ msgstr ""
 "\n"
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "cerrando el servidor Church Wars."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr "AH"
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2919,29 +2915,29 @@ msgstr ""
 "Las variables válidas son:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "No se ha podido conectar al metaservidor en %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaservidor: %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Intentos para conectarse al metaservidor demasiado frecuentes - esperando al "
 "siguiente turno"
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Esperando para conectarse al metaservidor en %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 #, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
@@ -2954,7 +2950,7 @@ msgstr ""
 "estarán soportadas. Obtenga la última versión del sitio web de Church Wars,^ "
 "https://dopewars.sourceforge.io/."
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 #, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
@@ -2966,7 +2962,7 @@ msgstr ""
 "consiga la última versión de Church Wars del servidor web,^ http://dopewars."
 "sourceforge.net/."
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
@@ -2974,7 +2970,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2984,7 +2980,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2996,61 +2992,67 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s es ahora conocido como %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO irse a %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Se acabó su tiempo para traficar..."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: DENEGADO irse a %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensaje desconocido: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Manteniendo el fichero pid %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "No se puede crear el fichero pid %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
 msgstr ""
 "No se puede crear el socket (%s) (a la escucha) del servidor. Cancelando."
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr "No se puede conectar al puerto %u (%s). Cancelando."
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
-msgstr "No se puede escuchar el socket de red. Cancelando."
+msgid "Cannot set socket reuse option (%s)"
+msgstr ""
 
 #: src/serverside.c:769
+#, fuzzy, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr "No se puede conectar al puerto %u (%s). Cancelando."
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "No se puede escuchar el socket de red. Cancelando."
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -3059,78 +3061,78 @@ msgstr ""
 "puerto %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGHUP!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGINT!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGTERM!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "¡No se puede instalar el gestor de tuberías!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "El fichero de configuración se ha guardado con éxito como %s\n"
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Usuarios conectados:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "No hay ningún usuario conectado.\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Echando a %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s asesinado\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Orden desconocida - use «help» para obtener ayuda\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "recibida una conexión de %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "cerrando el servidor Church Wars."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "¡%s deja el servidor!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -3138,7 +3140,7 @@ msgstr ""
 "No se ha podido establecer el socket de dominio Unix para conexiones de "
 "administración - compruebe los permisos en /tmp."
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3146,41 +3148,51 @@ msgstr ""
 "el servidor de Church Wars versión %s está listo para recibir órdenes de "
 "administración; use «help» para obtener ayuda"
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Nueva conexión de administración"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Orden de administración: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Conexión de administración cerrada"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr "No se ha podido establecer el estado del Servicio NT"
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr "No se ha podido enviar el mensaje de notificación de servicio"
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr "No se ha podido registrar el gestor de servicio"
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr "No se ha podido iniciar el Servicio NT"
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Orden:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3189,17 +3201,17 @@ msgstr ""
 "No se ha podido crear la copia de respaldo (%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "No se ha podido leer la tabla de puntuaciones del fichero %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -3209,7 +3221,7 @@ msgstr ""
 "al nuevo formato. Se ha creado una copia de respaldo del\n"
 "fichero antiguo, que se ha llamado %s.\n"
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3218,12 +3230,12 @@ msgstr ""
 "No se ha podido crear la copia de respaldo (%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3236,7 +3248,7 @@ msgstr ""
 "a este fichero o directorio, o bien indique otro fichero de\n"
 "puntuaciones con la opción -f en la línea de órdenes."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3251,7 +3263,7 @@ msgstr ""
 "formato ejecutando la orden «Church Wars -C %s» en la\n"
 "línea de órdenes."
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 #, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
@@ -3263,7 +3275,7 @@ msgstr ""
 "la manera esperada. Puede consultar el fichero «Church Wars-log.txt»\n"
 "para conocer los detalles."
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -3274,115 +3286,115 @@ msgstr ""
 "de la manera esperada. Puede mirar los mensajes en la\n"
 "salida estándar para conocer más detalles."
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "No se puede leer el fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "¡Enhorabuena! ¡Ha conseguido una de las máximas puntuaciones!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Ni siquiera ha conseguido entrar en la tabla de puntuaciones..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La señorita que está junto a usted en el metro dice:^ «%s»%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (al menos, eso es lo que *piensa* que ha dicho)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Oye a alguien poner %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quiere visitar %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quiere contratar a una %tde por %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quiere Atacar o Huir?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni polis!"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los polis no pueden atacar a otros polis!"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Está criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quiere pagar %P a un médico para que le cure?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Le atracan en el metro!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Se encuentra con un amigo! Le da a usted  %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Se encuentra con un amigo! Usted le da %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3390,17 +3402,17 @@ msgstr ""
 "¡Los perros de la policía le persiguen durante %d minutos! ¡Pierde algo de "
 "%tde! Maldita sea..."
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentra %d %tde en un cadáver abandonado en el metro!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Su mamacita ha hecho galletas con algo de su %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3408,24 +3420,24 @@ msgstr ""
 "YN^¡Aquí hay algo de marihuana que huele a herbicida!^¡Tiene buen aspecto! "
 "^¿Quiere fumarla? "
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Se ha parado para %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quiere comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, oiga! Le ayudo a llevar sus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quiere comprar un %tde por %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3433,29 +3445,29 @@ msgstr ""
 "¡Estuvo alucinando durante tres días en el viaje más salvaje que haya "
 "imaginado nunca!^Y entonces se murió debido a que su cerebro se derritió."
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La policía le ve tirando %tde!"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3577,243 +3589,251 @@ msgstr "Error interno del metaservidor «%s»"
 msgid "Bad metaserver reply \"%s\""
 msgstr "Respuesta del metaservidor incorrecta «%s»"
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "¡No se puede inicializar WinSock (%s)!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "¿Echa a correr?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "¿Huye o se enfrenta?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "armados de pena"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "poco armados"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "armados"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "muy armados"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "armados hasta los dientes"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "¡%s - %s - le está dando caza!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "¡%s y %d %tde - %s - le están persiguiendo!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "¡%s llega con %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s se levanta y lo coge"
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Se queda ahí como un tonto."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s intenta huir, pero no lo consigue."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "¡Pánico! ¡No puede escapar!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "¡%s ha conseguido escapar a %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "¡%s ha conseguido escapar!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "¡Ha conseguido escapar!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Armas recargadas..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s dispara a %s... ¡y falla!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s le dispara... ¡y falla!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "¡No le ha dado a %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata a %s."
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s dispara a %s ¡y mata a una %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s es %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s le dispara... ¡y mata a una %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "¡%s le ha dado!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "¡Ha matado a %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Le da a %s, y mata a un %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "¡Le da a %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr " ¡Le encuentra %P en el cuerpo!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr " ¡Le roba al cadaver!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "¡No se puede inicializar WinSock (%s)!"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3834,23 +3854,32 @@ msgstr ""
 "Conexión establecida. Use Ctrl-D para cerrar la sesión.\n"
 "\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 "No se ha podido determinar el fichero de configuración local en que escribir"
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
@@ -3890,118 +3919,123 @@ msgid ""
 msgstr ""
 "Usando Socks.Auth.User y Socks.Auth.Password para la autenticación SOCKS5\n"
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr ""
 "Iniciado el jugador automático; intentando conectarse al servidor en %s:%d."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "No se ha podido conectar al metaservidor en %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Jugador automático suicidado con éxito.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "¡Se ha roto la conexión con el servidor!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Usando el nombre %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Jugadores en esta partida:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s se une a la partida.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s ha dejado el juego.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Yendo %tal con %P en efectivo y %P de deuda\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jugador automático asesinado. Cerrando de manera normal.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Se ha agotado el tiempo de juego. Saliendo.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "El jugador automático ha sido expulsado del servidor.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "El servidor se ha apagado.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendiendo %d %tde a %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde a %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando un %tde por %P en la armería\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Deuda de %P pagada al usurero\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "El usurero está en %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "La armería está en %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "El bar está en %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y usted se hace llamar traficante?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Un mono amaestrado lo haría mejor..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "¿Cree que es lo suficientemente duro como para manejar a gente como yo?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... ¿está traficando con caramelos o qué?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Voy a tener que dispararle por su propio bien."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -4011,19 +4045,24 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompile pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "No es posible abrir el fichero %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "No se pueden obtener los detalles del metaservidor"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "No se puede iniciar Church Wars en modo multijugador"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Seleccionado módulo «%s» no válido.\n"
-"(%s disponible, ahora usando «%s».)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "No es posible abrir el fichero %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Seleccionado módulo «%s» no válido.\n"
+#~ "(%s disponible, ahora usando «%s».)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "La orden usada para iniciar su navegador web"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es_ES\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2003-12-10 09:48+0100\n"
 "Last-Translator: Quique <quique@sindominio.net>\n"
 "Language-Team: Castilian aka Spanish <es@li.org>\n"
@@ -29,28 +29,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -58,586 +58,586 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "el usurero_al_al usurero"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "el banco"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Puerto de red al que conectarse"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nombre del fichero de máximas puntuaciones"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nombre del servidor al que conectarse"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Mensaje de bienvenida del servidor"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Dirección de red del servidor al que escuchar"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE si se debe usar un servidor SOCKS para la conexión de red"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE si se deben usar ID de usuario numéricos para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si no se deja en blanco, el nombre de usuario a usar para SOCKS4"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "El nombre del servidor SOCKS a usar"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "El número de puerto del servidor SOCKS a usar"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La versión del protocolo SOCKS a usar (4 o 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Nombre de usuario para la autenticación SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Contraseña para la autenticación SOCKS5"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE si el servidor debe informar a un metaservidor"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nombre del metaservidor al que informar o del que obtener información"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "El nombre de tu servidor"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autenticación del nombre local con el metaservidor"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Descripción del servidor, que se pasa al metaservidor"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si TRUE, el servidor se minimiza a la bandeja del sistema"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Si TRUE, el servidor funciona en segundo plano"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Número de rondas de juego (si es 0, el juego nunca termina)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Día del mes en el que empieza el juego"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Mes en el que empieza el juego"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Año en el que empieza el juego"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr "El símbolo de dinero (por ejemplo, $)"
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si TRUE, el símbolo de dinero va antes del precio"
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Fichero en el que escribir los mensajes de registro"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Controla el número de mensajes de registro producidos"
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "formato de la cadena strftime() para las marcas de tiempo"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Se limpian los eventos aleatorios"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE si se debe guardar el valor de las drogas compradas"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Ser prolijo al procesar el fichero de configuración"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Número de sitios en el juego"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de poli en el juego"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Número de armas en el juego"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Número de drogas en el juego"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Ubicación del usurero"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Ubicación del banco"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Ubicación de la armería"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Ubicación del bar"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Tasa de interés diaria de la deuda con el usurero"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Tipo de interés diario de tu saldo en el banco"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nombre del usurero"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nombre del banco"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nombre de la armería"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nombre del bar"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE si se debe habilitar el sonido"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Fichero de sonido que suena cuando un disparo hace blanco"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Fichero de sonido que suena cuando un disparo yerra su objetivo"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Fichero de sonido que suena cuando se recarga un arma"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 "Fichero de sonido a reproducir cuando se mata a un ayudante o a un clérigo "
 "enemigo"
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr "Fichero de sonido reproducido cuando muere uno de tus clérigos"
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Fichero de sonido reproducido cuando se mata a otro jugador o a un policía"
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Fichero de sonido reproducido cuando te matan a ti"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 "Fichero de sonido reproducido cuando un jugador intenta escapar, pero no lo "
 "consigue"
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 "Fichero de sonido reproducido cuando intentas escapar, pero no lo consigues"
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr "Fichero de sonido reproducido cuando un jugador logra escapar"
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr "Fichero de sonido reproducido cuando tú logras escapar"
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Fichero de sonido que suena al llegar a un nuevo sitio"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr "Fichero de sonido que suena cuando se une un jugador al juego"
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr "Fichero de sonido que suena cuando un jugador abandona el juego"
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr "Fichero de sonido reproducido al empezar el juego"
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr "Fichero de sonido reproducido al acabar el juego"
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Orden de las drogas disponibles"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos para devolver disparos"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Los jugadores son desconectados después de este número de segundos"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tiempo en segundos para que las conexiones sean establecidas o rotas"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexiones TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre los turnos de los jugadores automáticos"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Cantidad de dinero con la que empieza cada jugador"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Importe de la deuda con la que empieza cada jugador"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Presencia policial en cada sitio (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas en cada sitio"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Máximo número de drogas en cada lugar"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistencia a disparos de cada jugador"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% de resistencia a disparos de cada clérigo"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Nombre de cada poli"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Nombre del ayudante de cada poli"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Nombre de los ayudantes de cada poli"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistencia a disparos de cada poli"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistencia a disparos de cada ayudante"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Penalización de ataque relativa a un jugador"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Penalización de defensa relativa a un jugador"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ayudantes acompañantes"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ayudantes acompañantes"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Índice basado en cero de la pistola con la que están armados los polis"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Número de pistolas que porta cada poli"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Número de pistolas con las que carga cada ayudante"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nombre de cada droga"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Precio mínimo normal de cada droga"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Precio máximo normal de cada droga"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE si esta droga puede ser especialmente barata"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE si esta droga puede ser especiamente cara"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensaje a mostrar cuando esta droga sea especialmente barata"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Línea utilizada para drogas que sean caras el 50% de las veces"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor del precio de la droga cuando es especialmente barata"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nombre de cada lugar"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Precio de cada arma"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Espacio que ocupa cada arma"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Daño ocasionado por cada arma"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Palabra usada para designar un solo \"clérigo\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Palabra usada para designar dos o más \"clérigos\""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palabra usada para designar una sola arma"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Palabra usada para designar dos o más armas"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palabra usada para designar una sola droga"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Palabra usada para designar dos o más drogas"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr "cadena de formato strftime() para mostrar el turno del juego"
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Coste para que un clérigo espíe al enemigo"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Coste para que un clérigo delate a la policía a un enemigo"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Precio mínimo de contratar un clérigo"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Precio máximo de contratar un clérigo"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de cosas que oyes en el metro"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Número de cosas que se dicen en el metro"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Lista de canciones que oyes tocar"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Número de canciones que se tocan"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Lista de cosas que puedes dejar de hacer"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Número de cosas que puedes dejar de hacer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -645,185 +645,184 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr ""
 "¡El mercado está inundado de tripis baratos recién llegados de Amsterdam!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Mensaje"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr ""
-"¡La pestañí ha hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "¡La pestañí ha hecho una gran redada de %tde! ¡Los precios son exorbitantes!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
@@ -832,145 +831,145 @@ msgstr "¡Los yonquis están comprando %tde a precios absurdos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "¡Vivamos al límite, co!"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "De todo lo que he perdido, lo que más echo de menos es la cabeza."
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Apuesto a que tienes sueños superinteresantes"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Este verano no sé si bajar al moro o irme a Amsterdam"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Tío, tienes que hacerte una cresta."
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Pero ¿por qué llevas gafas de sol si es de noche?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "Yo no he sido siempre una mujer, ¿sabes?"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "¿Tu madre sabe que eres un camello?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "¿Te has metido algo?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, tú debes ser gallego"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr ""
 "Hmmm... ¡qué almuerzo! Mi madre me ha preparado unas galletas de... "
 "chocolate."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Con dinero, chufletes."
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr ""
 "Sólo usamos el 10% de nuestro cerebro. ¡Destruye con drogas el 90% sobrante!"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Estoy hecha polvo, me voy a la cama. ¿Vienes?"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "El PP es lo más rancio y retrógrado que ha parido madre. ¿O no?"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Tú sales en la tele, ¿verdad?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "¿Sabe que tiene los ojos muy enrojecidos, joven?"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "¿Te imaginas como sería la vida si no hubiera drogas?"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "En las hamburgueserías usan carne de rata. Por eso la dan picada."
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "`Cuestiona la autoridad; piensa por ti mismo` dijo Tim Leary"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Te vendo una chupa de cuero por 30 euros."
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Los triunfadores no usan drogas... salvo..."
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Espero que no te importe, pero voy a rezar por ti."
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "La telepatía existe. ¿No sientes la energía del universo?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "No se ha podido procesar el fichero de configuración %s, línea %d"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "No es posible abrir el fichero %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -981,40 +980,40 @@ msgstr ""
 "jugador conectado. Espera a que se desconecten todos los jugadores, o\n"
 "elimínalos con las órdenes echar o matar, e inténtalo otra vez."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "El índice en la cadena %s debe estar entre 1 y %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s es %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s es %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s es %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s es \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] es %s\n"
@@ -1022,42 +1021,42 @@ msgstr "%s[%d] es %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s es { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s no puede ser menor de %d - se ignora"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estructura lista redimensionada a %d elementos\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Se esperaba un valor booleano (uno de 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1065,7 +1064,7 @@ msgstr ""
 "  -u, --plugin=FICHERO    usar módulo de sonido \"FICHERO\"\n"
 "                            "
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1073,19 +1072,17 @@ msgstr ""
 "  -u fichero   usar módulo de sonido \"fichero\"\n"
 "\t          "
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars versión %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1100,7 +1097,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1177,7 +1174,7 @@ msgstr ""
 "\"formato\n"
 "                            antiguo\" al nuevo formato\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1193,9 +1190,7 @@ msgstr ""
 "GNU GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1208,7 +1203,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1259,7 +1254,7 @@ msgstr ""
 " -A       conectarse a un servidor ejecutándose localmente para "
 "administración\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1275,7 +1270,7 @@ msgstr ""
 "GNU GPL\n"
 "Informa de fallos al autor escribiendo a benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1285,7 +1280,7 @@ msgstr ""
 "pasando la opción --enable-curses-client a configure, o usa una\n"
 "versión gráfica (si es posible) es su lugar.\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1295,7 +1290,7 @@ msgstr ""
 "el binario pasando la opción --enable-gui-client a configure,\n"
 "o usa el cliente curses (si está disponible) en su lugar.\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1303,7 +1298,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1314,34 +1309,34 @@ msgstr ""
 "no se puede ejecutar en modo servidor. Recompila pasando\n"
 "la opción --enable-networking al script configure.\n"
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Traducción al español         Quique"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 "Basado en el juego Drug Wars de John E. Dell, Church Wars es una simulación"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr ""
 "de un mercado de la droga imaginario. Church Wars es un juego para toda la"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr ""
 "familia que consiste en ganar dinero con la compraventa (y eludir a la poli)."
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1349,59 +1344,59 @@ msgid ""
 msgstr ""
 "Lo primero que tienes que hacer es saldar la deuda con tu usurero. Después"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr "tu objetivo es hacer tanto dinero como sea posible (¡y seguir vivo!)"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Tienes un mes de tiempo de juego para amasar tu fortuna."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Version %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars está publicado bajo la GNU General Public License"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Iconos y gráficos             Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Sonidos                       Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testeo del juego              Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Testeo intensivo del juego    Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Críticas destructivas         James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Para conocer las opciones en la línea de órdenes, escribe Church Wars -h"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1410,60 +1405,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Introduce el nombre y puerto de un servidor doperwars:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Nombre del servidor: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Puerto: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Por favor, espera... intentando contactar con el metaservidor..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Servidor: %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Puerto  : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Versión    : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Jugadores: -desconocido- (máximo %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Jugadores: %d (máximo %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "En funcionamiento desde: %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Comentario: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 
@@ -1471,214 +1471,203 @@ msgstr "S>iguiente servidor: A>nterior servidor; E>scoger este servidor... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "SAE"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Conectado al servidor SOCKS %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Autenticando contra el servidor SOCKS"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Pidiendo SOCKS para conectarse a %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 "Se requiere autenticación SOCKS (nombre de usuario en blanco para cancelar)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Nombre de usuario: "
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Contraseña: "
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr ""
 "Por favor, espera... intentando contactar con el servidor Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "No se pueden obtener los detalles del metaservidor"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "No se puede iniciar Church Wars en modo multijugador"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "¿Quieres... C>onectarte a un servidor Church Wars determinado"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr ""
 "            L>istar los servidores que hay en el metaservidor, y elegir uno"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr ""
 "            S>alir (puedes iniciar un servidor tecleando «Church Wars -s»)"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "          o J>ugar en modo 1 jugador? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "CLSJ"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "¿Dónde quieres ir, colega? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr "%/Location display/%tde"
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "No puedes conseguir ni un pavo por estas %tde que llevas:"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "¿Qué quieres tirar? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "¿Cuántas quieres tirar? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "¿Qué quieres pillar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "¿Qué quieres pulir? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Tienes pasta para comprar %d, y espacio para llevar %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "¿Cuánto quieres? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Tienes %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "¿Cuánto quieres vender? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "¿Estás seguro de que quieres salir? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "SN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nuevo nombre: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Has sido expulsado del servidor. Pasando al modo 1 jugador."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "El servidor se ha desconectado. Pasando al módulo 1 jugador."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "¡%s se une al juego!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s ha dejado el juego."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s es ahora conocido como %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Ubicación actual/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Desgraciadamente ya hay alguien usando «tu» nombre. Elige otro."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "P U N T U A C I O N E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "¡No tienes ningún %tde que vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "¡No tienes ninguna que vender!"
 
@@ -1686,27 +1675,27 @@ msgstr "¡No tienes ninguna que vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "¡Necesitas más %tde para que te guarden más %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "¡No tienes suficiente espacio para llevar ese %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "¡No tienes suficientes pelas para comprar ese %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 
@@ -1714,41 +1703,41 @@ msgstr "¿Quieres C>omprar, P>ulir o D>arte el piro? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "CPD"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "¿Cuánto dinero quieres devolver? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "¡No tienes tanta pasta!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "¿Quieres I>ngresar dinero, S>acar dinero o L>argarte?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "ISL"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "¿Cuánto dinero? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "No tienes tantos dineros en el banco..."
 
@@ -1756,47 +1745,47 @@ msgstr "No tienes tantos dineros en el banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "S:Sí"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:No"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "E:Enfrentarse"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "H:Huir"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Pulsa cualquier tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Mensajes (-/+ desplaza hacia arriba/abajo)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Situación"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Pasta"
 
@@ -1804,41 +1793,41 @@ msgstr "Pasta"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Salud"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Pufo"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Espacio %4d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %5d  Espacio %4d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Gabardina"
 
@@ -1846,158 +1835,164 @@ msgstr "Gabardina"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Situación: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d a %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Situación: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "¡No hay ningún otro jugador conectado en este momento!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Jugadores conectados en este momento:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Eh, tío. Los precios de las %tde aquí son:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Eh tío, ¿cómo te llamas? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "¿Quieres C>omprar"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", P>ulir"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", T>irar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", H>ablar a todos, hablar a un J>ugador"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", L>istar"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", E>nfrentarte"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", D>arte el piro"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", o S>alir? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "¿Quieres "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "L>uchar, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "E>sperar, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "P>ulir %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "o S>alir? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Se ha perdido la conexión con el servidor. Pasando al modo 1 jugador."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "CPTHJLMEDS"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "PCLES"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "¿Qué lista quieres? ¿J>ugadores o P>untuaciones? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "¡No se puede inicializar WinSock (%s)!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "¿Jugar otra vez? "
 
@@ -2087,8 +2082,8 @@ msgid "Inventory"
 msgstr "Inventario"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "Cerrar _Ventana"
 
@@ -2268,13 +2263,13 @@ msgstr "¿Cuánto quieres pulir?"
 msgid "Drop how many?"
 msgstr "¿Cuánto quieres tirar?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_Aceptar"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2332,54 +2327,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Traducción al español"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Iconos y gráficos"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sonidos"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Compraventa de drogas e investigación"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testeo del juego"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Testeo intensivo del juego"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Críticas constructivas"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Críticas destructivas"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2407,7 +2402,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2416,134 +2411,135 @@ msgstr ""
 "Versión %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está publicado bajo la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título de la ventana del usurero/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título de la ventana del banco/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "¡Tienes que introducir una cantidad positiva de dinero!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "No tienes tantos dineros en el banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Pasta en efectivo: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Pufo: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Saldar:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Ingresar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Sacar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Pagar todo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Lista de jugadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Hablar al jugador (o jugadores)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Hablar a todos los jugadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Mensaje:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Enviar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nombre"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Precio"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Pulir"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Tirar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde aquí"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde que tienes"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Cambiar nombre"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2551,12 +2547,12 @@ msgstr "Desgraciadamente ya hay otro jugador usando «tu» nombre. Elije otro"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Ventana de la armería/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2823,7 +2819,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 #, fuzzy
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
@@ -2837,39 +2833,39 @@ msgstr ""
 "\n"
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "cerrando el servidor Church Wars."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr "AH"
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2914,29 +2910,29 @@ msgstr ""
 "Las variables válidas son:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "No se ha podido conectar al metaservidor en %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaservidor: %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Intentos para conectarse al metaservidor demasiado frecuentes - esperando al "
 "siguiente turno"
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Esperando para conectarse al metaservidor en %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 #, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
@@ -2949,7 +2945,7 @@ msgstr ""
 "estarán soportadas. Obtén la última versión del sitio web de Church Wars,^ "
 "https://Church Wars.sourceforge.io/."
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 #, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
@@ -2961,7 +2957,7 @@ msgstr ""
 "obtén la última versión de Church Wars del servidor web,^ http://Church Wars."
 "sourceforge.net/."
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr ""
@@ -2969,7 +2965,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2979,7 +2975,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2991,61 +2987,67 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s es ahora conocido como %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: DENEGADO largarse a %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Se acabó tu tiempo para trapichear..."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: DENEGADO largarse a %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensaje desconocido: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Manteniendo el fichero pid %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "No se puede crear el fichero pid %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
 msgstr ""
 "No se puede crear el socket (%s) (a la escucha) del servidor. Cancelando."
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr "No se puede conectar al puerto %u (%s). Cancelando."
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
-msgstr "No se puede escuchar el socket de red. Cancelando."
+msgid "Cannot set socket reuse option (%s)"
+msgstr ""
 
 #: src/serverside.c:769
+#, fuzzy, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr "No se puede conectar al puerto %u (%s). Cancelando."
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "No se puede escuchar el socket de red. Cancelando."
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -3054,78 +3056,78 @@ msgstr ""
 "%d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGUSR1!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGHUP!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGINT!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "¡No se puede instalar el gestor de interrupción SIGTERM!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "¡No se puede instalar el gestor de tuberías!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "El fichero de configuración se ha guardado con éxito como %s\n"
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Usuarios conectados:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "No hay ningún usuario conectado.\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Echando a %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "¡No existe ese usuario!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s asesinado\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Orden desconocida - usa «help» para obtener ayuda\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "recibida una conexión de %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "cerrando el servidor Church Wars."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "¡%s deja el servidor!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -3133,7 +3135,7 @@ msgstr ""
 "No se ha podido establecer el socket de dominio Unix para conexiones de "
 "administración - comprueba los permisos en /tmp."
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3141,41 +3143,51 @@ msgstr ""
 "el servidor de Church Wars versión %s está listo para recibir órdenes de "
 "administración; usa «help» para obtener ayuda"
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Nueva conexión de administración"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Orden de administración: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Conexión de administración cerrada"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr "No se ha podido establecer el estado del Servicio NT"
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr "No se ha podido enviar el mensaje de notificación de servicio"
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr "No se ha podido registrar el gestor de servicio"
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr "No se ha podido iniciar el Servicio NT"
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Orden:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3184,17 +3196,17 @@ msgstr ""
 "No se ha podido crear la copia de respaldo(%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "No se ha podido leer la tabla de puntuaciones del fichero %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -3204,7 +3216,7 @@ msgstr ""
 "al nuevo formato. Se ha creado una copia de respaldo del\n"
 "fichero antiguo, que se ha llamado %s.\n"
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3213,12 +3225,12 @@ msgstr ""
 "No se ha podido crear la copia de respaldo(%s) del\n"
 "fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3231,7 +3243,7 @@ msgstr ""
 "a este fichero o directorio, o bien indica otro fichero de\n"
 "puntuaciones con la opción -f en la línea de órdenes."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3246,7 +3258,7 @@ msgstr ""
 "formato ejecutando la orden «Church Wars -C %s» en la\n"
 "línea de órdenes."
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 #, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
@@ -3258,7 +3270,7 @@ msgstr ""
 "la manera esperada. Puedes consultar el fichero «Church Wars-log.txt»\n"
 "para conocer los detalles."
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -3269,115 +3281,115 @@ msgstr ""
 "de la manera esperada. Puedes mirar los mensajes en la\n"
 "salida estándar para conocer más detalles."
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "No se ha podido abrir el fichero de puntuaciones %s: %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "No se puede leer el fichero de máximas puntuaciones %s."
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "¡Enhorabuena! ¡Has conseguido una de las máximas puntuaciones!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Ni siquiera has conseguido entrar en la tabla de puntuaciones..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "No se ha podido escribir en el fichero de puntuaciones %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La chavala que está junto a ti en el metro dice:^ «%s»%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (al menos, eso es lo que *piensas* que ha dicho)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Oyes a alguien poner %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^¿Quieres visitar %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^¿Quieres contratar a una %tde por %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quieres Atacar o Huir?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "¡No hay armas ni maderos!"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "¡Los maderos no pueden atacar a otros maderos!"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "¡Los jugadores ya están en una pelea!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "No se puede empezar el enfrentamiento - ¡no hay ningún arma que usar!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Estás criando malvas. Sayonara, baby."
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^¿Quieres pagar %P a un médico para que te cure?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "¡Te atracan en el metro!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "¡Te encuentras con un amigo! Te da %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "¡Te encuentras con un amigo! Le das %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Pasando de una oferta aleatoria"
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3385,17 +3397,17 @@ msgstr ""
 "¡Los perros de la bofia te persiguen durante %d manzanas! ¡Pierdes algo de "
 "%tde! Vaya mierda, macho."
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Encuentras %d %tde en el cuerpo de un tío tirado en el metro!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "¡Tu mami ha hecho galletas con algo de tu %tde! ¡Estaban geniales!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3403,24 +3415,24 @@ msgstr ""
 "YN^¡Aquí hay algo de maría que huele a herbicida!^¡Tiene buena pinta! "
 "^¿Quieres fumarla? "
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Te has parado para %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^¿Quieres comprar una gabardina más grande por %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^¡Eh, tío! Te ayudo a llevar tus %tde por sólo %P. ¿Sí o no?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^¿Quieres comprar un %tde por %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3428,29 +3440,29 @@ msgstr ""
 "¡Estuviste flipando durante tres días en el cuelgue más salvaje que hayas "
 "imaginado nunca!^Y entonces la palmaste debido a que tu cerebro se derritió."
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Demasiado tarde. %s se acaba de ir."
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "¡La bofia te ve tirando %tde!"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando actualizaciones pendientes al metaservidor..."
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr "Enviando mensaje recordatorio al metaservidor..."
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Jugador eliminado: demasiado tiempo inactivo"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Jugador eliminado debido a que se agotó el tiempo para la conexión"
 
@@ -3572,243 +3584,251 @@ msgstr "Error interno del metaservidor «%s»"
 msgid "Bad metaserver reply \"%s\""
 msgstr "Respuesta del metaservidor incorrecta «%s»"
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "¡No se puede inicializar WinSock (%s)!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "¿Echas a correr?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "¿Huyes o te enfrentas?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "armados de pena"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "poco armados"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "armados"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "muy armados"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "armados hasta los dientes"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "¡%s - %s - te está dando caza, colega!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "¡%s y %d %tde - %s - te están persiguiendo, colega!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "¡%s llega con %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s se levanta y lo coge"
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Te quedas ahí como un tonto."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s intenta huir, pero no lo consigue."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "¡Pánico! ¡No puedes escapar!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "¡%s ha conseguido escapar a %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "¡%s ha conseguido escapar!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "¡Has conseguido escapar!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Armas recargadas..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s dispara a %s... ¡y falla!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te dispara... ¡y falla!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "¡No le has dado a %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata a %s."
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s dispara a %s ¡y mata a una %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s es %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te dispara... ¡y se carga a una %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "¡%s te ha dado, co!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "¡Has matado a %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Le das a %s, y matas a un %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "¡Le das a %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr " ¡Te encuentras %P en el cuerpo!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr " ¡Le robas al cadaver!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "¡No se puede inicializar WinSock (%s)!"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr "Error general del servidor SOCKS"
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Conexión rechazada por las reglas de SOCKS"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: No se llega a la red"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: No se llega al servidor"
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Conexión rechazada"
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: se agotó el tiempo"
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Orden no soportada"
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Tipo de dirección no soportado"
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr "El servidor SOCKS rechazó todos los métodos ofrecidos"
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr "Devuelto tipo de dirección SOCKS desconocido"
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr "Error de autenticación SOCKS"
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "Autenticación SOCKS cancelada por el usuario"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Solicitud rechazada o sin éxito"
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rechazada - no se ha podido contactar identd"
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rechazada - identd informa de diferentes ID de usuario"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr "Código de respuesta de SOCKS desconocida"
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr "Código de respuesta de versión de SOCKS desconocida."
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr "Versión de servidor SOCKS desconocida"
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Código de error de SOCKS %d"
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3829,23 +3849,32 @@ msgstr ""
 "Conexión establecida. Usa Ctrl-D para cerrar la sesión.\n"
 "\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "No se ha podido abrir el fichero %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 "No se ha podido determinar el fichero de configuración local en que escribir"
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "No se ha podido abrir el fichero %s: %s"
@@ -3885,118 +3914,123 @@ msgid ""
 msgstr ""
 "Usando Socks.Auth.User y Socks.Auth.Password para la autenticación SOCKS5\n"
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr ""
 "Iniciado el jugador automático; intentando conectarse al servidor en %s:%d."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "No se ha podido conectar al metaservidor en %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Jugador automático suicidado con éxito.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "¡Se ha roto la conexión con el servidor!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Usando el nombre %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Jugadores en esta partida:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s se une a la partida.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s ha dejado el juego.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Yendo %tal con %P en efectivo y %P de deuda\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jugador automático asesinado. Cerrando de manera normal.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Se ha agotado el tiempo de juego. Saliendo.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "El jugador automático ha sido expulsado del servidor.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "El servidor se ha apagado.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendiendo %d %tde a %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde a %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando un %tde por %P en la armería\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Deuda de %P pagada al usurero\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "El usurero está en %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "La armería está en %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "El bar está en %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "El banco está en %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "¿Y tú te haces llamar camello?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Un mono amaestrado lo haría mejor..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "¿Crees que eres lo suficientemente duro como para manejar a tipos como yo?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... ¿estás traficando con caramelos o qué?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Voy a tener que dispararte por tu propio bien."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -4006,19 +4040,24 @@ msgstr ""
 "como un jugador automático.\n"
 "Recompila pasando la opción --enable-networking al script configure"
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "No es posible abrir el fichero %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "No se pueden obtener los detalles del metaservidor"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "No se puede iniciar Church Wars en modo multijugador"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Seleccionado módulo «%s» no válido.\n"
-"(%s disponible, ahora usando «%s».)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "No es posible abrir el fichero %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Seleccionado módulo «%s» no válido.\n"
+#~ "(%s disponible, ahora usando «%s».)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "La orden usada para iniciar tu navegador web"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2001-10-16 20:50+0100\n"
 "Last-Translator: leonard <triton@madchat.org>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -49,581 +49,581 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "Le Preteur a Gages"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "la banque"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Port reseau a se connecter"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur a se connecter"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "Different de zero si le serveur doit reporter a un metaserveur"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr ""
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur "
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "description du serveur, reporte au metaserveur"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Nombre de tours de jeu (avec 0, le jeu ne se termine jamais)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Les elements aleatioires sont nettoyes"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 "Different de zero si la valeur de la camme achetee doit etre sauvegardee"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Soyez verbose en passant le config file a la moulinette"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Nombre de lieux dans le jeu"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Nombre de types de flics dans le jeu"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Nombre de revolvers dans le jeu"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Nombre de drogues dans le jeu"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "L'endroit ou se trouve le Preteur a Gages"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "L'endroit ou se trouve la banque"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "l'endroit ou se trouve l'armurerie"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "l'endroit ou se trouve le bar"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nom du Preteur a Gages"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nom de la banque"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nom de l'armurerie"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nom du bar"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Touche de tri pour la liste des dopes disponibles"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Nombre de secondes apres lesquelles on peut retourner le feu"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Les joueurs sont deconnectes apres ce nombre de secondes"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Temps en secondes pour que les connections soient etablies ou cassees"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Nombre maximum de connections TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Secondes entre les tours des intelligences artificielles"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Fric donne en debutant la partie"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Montant des dettes en debutant la partie"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nom de chaque lieu"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Presence policiaire a chaque endroit (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Nombre minimum de potions magiques a chaque endroit"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Nombre maximum de potions magiques a chaque endroit"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% de resistance aux coups de fusil de chaque joueur"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% de resistance aux coups de fusil de chaque clerc"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Nom de chaque flics"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Nom de chaque sous-flic"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Nom de chaques sous-flics"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% de resistance aux coups de fusil de chaque flic"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de resistance aux coups de flingue de chaque sous-flic"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Penalite d'attaque relative a un joueur"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Penalite de deffence relative a un joueur"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Nombre minimum de sous-flics accompagnant"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Nombre MAX des adjoints accompagnant"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Index base sur zero du pistolet avec lequel le flic est arme"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Nombre de flingues que chaque flic porte"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Nombre de flingues que chaque sous-flic portes"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nom de chaque potion magique"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Prix minimum normal de chaque camme"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Prix MAX normal de chaque camme"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Different de zero si cette camme peut devenir vraiement pas chere"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Different de zero si cette drogue peut devenir particulierement chere"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Message affiche si cette camme est vraiement pas chere"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Ligne utilisee pour des drogues cheres 50% des fois"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Diviseur sur le prix des cammes devenues vraiement pas cheres"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicateur pour les drogues devenues cheres"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nom de chaque lieu"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Prix de chaque type de flingue"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Espace pris par chaque flingue"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Dommage inflige par chaque flingue"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Mot utilise pour decrire 1 \"clerc\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Mot utilise pour decrire 2 \"clercs\" ou plus"
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Mot utilise pour decrire 1 flingue ou equivalent"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Mot utlise pour decrire 2 flingues ou plus"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Mot utlise pour decrire 1 drogue "
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Mot utilise pour decrire deux drogues ou plus"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Coût pour qu'un clerc espionne l'ennemi"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Coût pour qu'un clerc dénonce un ennemi aux flics"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Prix minimum pour engager un clerc"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Prix MAX pour engager un clerc"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "liste des trucs que vous entendez dans le metro"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "nombre de choses que vous entendez dans le metro"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "liste des morceaux de zic que vous pouvez entendre de loin"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "nombre de morceaux de musique"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "liste des trucs que tu peux arreter de faire"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "nombre de trucs que tu peux arreter de faire"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -631,183 +631,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Le marche est sature de buvards"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "de la bonne herbe d'Amsterdam vient d'arriver en masse"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Message"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr "Les flics ont mis la main sur un gros stock de %tde !"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Les flics ont mené une grosse rafle de %tde ! Les prix sont exorbitants !"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les junkies achetent %tde hors de prix !"
@@ -816,144 +816,144 @@ msgstr "Les junkies achetent %tde hors de prix !"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "`Vivons dans l'extase de l'illimité`"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "Of all the things that I've lost, I miss my mind the most."
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Je parie que vous faites des reves tres interessants"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Je pense que je vais aller a Amsterdam cette annee"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "je suis un cheval, en fait"
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ca vous arrive de conduire la nuit avec des lunettes de soleil ?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "J'ai pas toujours ete une femme, tu sais"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Ta mere sait que tu est un dealer ?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "T'est defonce a quoi, la ?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Vous venez de Tunisie ?"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Ta mere vient de faire des bons gateaux avec un peu de ton Hash."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "In dust, we trust"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "On utilise 10% de nos cerveaux, alors pourquoi ne pas en crammer 90% ?"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Bon je suis trop defait, je vais me coucher."
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 "Les vrais leaders de ce monde sont george bush, keanu reeves et sandra "
 "Bullock"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "C'est vous que j'ai vu a la tele ?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Vous avez les yeux rouges, jeune homme."
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Un jour sans camme, c'est la nuit."
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "Sauvez des arbres, mangez des castors !"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "`Question authority; think for yourself`. a dit Timothy Leary"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Gnôthi seauton"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Les vainqueurs ne se droguent pas... a moins que..."
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Seulement de nos jours, les chateaux sont des entreprises."
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "La telepathie existe ! Regardez les vibrations."
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -961,40 +961,40 @@ msgid ""
 msgstr ""
 "La config peut seulement etre changee quand aucun joueur n'est connecte."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit etre entre 1 et %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
@@ -1002,66 +1002,64 @@ msgstr "%s[%d] est %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Structure liste redimentionnee a %d elements\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1076,7 +1074,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1138,7 +1136,7 @@ msgstr ""
 "Church Wars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1148,9 +1146,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1163,7 +1159,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1216,7 +1212,7 @@ msgstr ""
 "Church Wars is Copyright (C) Ben Webb 1998-2022, et distribue sous GNU GPL\n"
 "Envoyer les bugs a l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1226,7 +1222,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1236,7 +1232,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1246,7 +1242,7 @@ msgstr ""
 "--enable-curses-client pour configurer, ou utiliser un client\n"
 "fenetre (si dispo) a la place!\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1254,7 +1250,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1262,16 +1258,16 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Français Traduction           Leonard"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
@@ -1279,16 +1275,16 @@ msgstr ""
 "Base sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation "
 "d'un"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr "marche de la drogue imaginaire. Church Wars est un jeu qui comprend"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "acheter, vendre et essayer d'eviter les flics!"
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1296,59 +1292,59 @@ msgid ""
 msgstr ""
 "La premiere chose a faire est de rembourser votre dette au preteur. Apres"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr "votre but est de faire le plus de fric possible en restant vivant! Tu"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "as un mois de temps de jeu pour faire fortune."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Version %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars est distribue sous la license GPL de GNU."
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testeurs                      Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Testeurs extensifs            Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Critiques deconsctructives    James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Critiques deconsctructives    James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Pour information sur les options en ligne de commande, taper Church Wars -h"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1356,60 +1352,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Merci d'entrer le nom du host et le port du server Church Wars:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Hostname: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Port: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le metaserver..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Serveur: %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Port    : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Version     :%s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Joueurs: -inconnu- (maximun %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Joueurs: %d (maximum %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "Operationnel depuis : %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Commentaire: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>uivant server; P>recedent server; C>choisir ce serveur..."
 
@@ -1417,210 +1418,199 @@ msgstr "S>uivant server; P>recedent server; C>choisir ce serveur..."
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "SPC"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Patientez... tentative de contacter le serveur Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr ""
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Ne peux pas demarrer Church Wars en multi-joueur"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Woulez vous... C>connecter a un hote/port different"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "               L>ister les serveurs sur le meta, et en selectionner un"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "               Q>uitter (vous pouvez alors demarrer un server"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "            ou J>ouer en solo ? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "CLQJ"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Ou ca, mec ? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Tu ne peux pas faire du fric avec ce que tu portes %tde :"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "Que veux tu laisser tomber? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Combien d'unites tu laisses tomber? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "Que souhaites tu acheter? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "Que souhaites tu vendre? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Tu peux acheter %d, et porter %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Combien tu en achetes ?"
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Tu as %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Combien tu en vends? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Etes vous sur de vouloir quitter? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "ON"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nouveau nom: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Vous avez ete vire du serveur. Devient solo."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Devient solo"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitte la partie."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s est maintenant %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Malheureusement, qq d'autre utilise deja ton nom. Merci d'en changer"
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "H I G H   S C O R E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Tu n'as aucun %tde a vendre!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "T'en as aucun a vendre!"
 
@@ -1628,27 +1618,27 @@ msgstr "T'en as aucun a vendre!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour porter plus de %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Tu n'as pas assez d'espace pour porter ce %tde"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Tu n'as pas assez de fric pour achter ce %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 
@@ -1656,41 +1646,41 @@ msgstr "Souhaitez vous A>cheter, V>endre, ou P>artir?"
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "AVP"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Combien de fric tu rends ?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "Tu n'as pas assez d'argent!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Tu veux D>eposer de l'argent, R>etirer des biftons, ou P>artir ?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "DRP"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Combien d'argent?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
@@ -1698,47 +1688,47 @@ msgstr "Il n'y a pas autant d'argent dans la banque..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "O:Oui"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Non"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "C:Courrir"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "S:Se battre"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Attaquer"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "S: S'evader"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Appuyer sur une touche..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Statistiques"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Fric"
 
@@ -1746,41 +1736,41 @@ msgstr "Fric"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Sante"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banque"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Dette"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Espace %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Trenchcoat"
 
@@ -1788,158 +1778,164 @@ msgstr "Trenchcoat"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "He man, les prix du %tde sont la:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer SIGWINCH interrupt handler!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "He mec, c'est quoi ton nom? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", P>arler, R>reveiller"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", L>lister"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", dEplacer"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "C>combat, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "R>este sur place, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "S>e sauver, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>eal %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCEQ"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "DSCRQ"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Ne peut pas installer le truc qui s'occupe des pipes!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Rejouer? "
 
@@ -2029,8 +2025,8 @@ msgid "Inventory"
 msgstr "Inventaire"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Fermer"
 
@@ -2206,13 +2202,13 @@ msgstr "Vendre combien ?"
 msgid "Drop how many?"
 msgstr "Laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2270,54 +2266,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Français Traduction"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Vente de camme et Recherche"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testeur de jeu"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Testeur extensif du jeu"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2345,7 +2341,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2354,134 +2350,135 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars est diffuse sous la GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Preteur window title/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Fric: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "banque: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Rembourser:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Deposer"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Retirer"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Tout payer"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Liste des joueurs"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Parler au joueur(s)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Parler a tout les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Message:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Envoyer"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Nombre"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde ici"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde transporte"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Changer Nom"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2490,12 +2487,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Armurerie window title/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2762,7 +2759,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 #, fuzzy
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
@@ -2776,39 +2773,39 @@ msgstr ""
 "\n"
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "Le serveur has terminated."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr "AS"
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2847,27 +2844,27 @@ msgstr ""
 "Valid variables are listed below:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServeur: %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2875,21 +2872,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) exceeded - dropping connection"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2899,7 +2896,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2911,60 +2908,65 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s est maintenant %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: deplacement vers %s INTERDIT"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Votre temps de deal est termine"
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: deplacement vers %s INTERDIT"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Maintenance du pid file %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Cannot create pid file %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
-msgstr ""
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
+msgstr "Cannot create pid file %s: %s"
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr ""
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
+msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
 #: src/serverside.c:769
+#, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr ""
+
+#: src/serverside.c:778
+msgid "Cannot listen to network socket."
+msgstr ""
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -2973,84 +2975,84 @@ msgstr ""
 "sur le port %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Cannot install SIGUSR1 interrupt handler!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Cannot install SIGHUP interrupt handler!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Cannot install SIGINT interrupt handler!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Cannot install SIGTERM interrupt handler!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Ne peut pas installer le truc qui s'occupe des pipes!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Utilisateurs en ligne:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Aucun utilisateur en ligne.\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Pousser %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Cet user n'existe pas.\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s tue\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Commande inconnue - Essaye \"help\" pour l'aide...\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "recu une connection de %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "Le serveur has terminated."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s quittes le serveur!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3058,77 +3060,87 @@ msgstr ""
 "Church Wars server version %s pret et attendant les connections\n"
 "sur le port %d."
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Command:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Impossible d'ecrire le fichier des high scores %s"
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Cannot create pid file %s: %s"
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3141,7 +3153,7 @@ msgstr ""
 "repertoire\n"
 "ou specifiez un autre fichier et chemin d'acces avec la commande -f."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3151,172 +3163,172 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Impossible d'ecrire le fichier des high scores %s"
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Felicitations! Vous etes dans les high scores!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "T'as meme pas reussi a etre dans les Scores!"
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Impossible d'ecrire le fichier des high scores %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La dame a cote de vous dans le metro dit,^ \"%s\"%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (au moins, tu -penses- que c'est ce qu'elle a dit)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Tu entends quelqu'un jouer %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Voulez-vous visiter %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Voulez vous engager une %tde pour %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est deja la!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les flics ne peuvent pas attaquer d'autres flics!"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont deja en train de se battre!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont deja dans des bastons separees!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bagarre - pas de flingue a utiliser!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Vous etes mort! GamE OveR"
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Tu payes le docteur %P pour te recoudre?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu as ete attaque dans le metro!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Tu rencontres un ami! Il te donne %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Tu rencontre un ami! Tu lui donne %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aleatoire."
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens des flics te courent apres sur %d blocs! Tu laisses tomber %tde! "
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Tu trouves %d %tde sur un mec mort dans le metro!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta maman a fait des gateaux avec un peu de ton %tde! Ils sont excellents!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ca a l'air bon! Tu la fume?"
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Tu veux acheter une trenchcoat plus grande pour %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^He! mec! Je t'aiderais a porter tes %tde pour un petit %P. Oui ou non ?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Tu veux acheter un %tde pour %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3324,29 +3336,29 @@ msgstr ""
 "Tu a hallucine pendant trois jours dans le plus trip le plus sauvage "
 "que^t'aurais jamais imagine! Ensuite tu t'est mis a parler avec tes oreilles!"
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard - %s vient juste de partir!"
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Joueur enleve a cause d'inactivite trop longue"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Joueur enleve a cause de temps de connection trop long"
 
@@ -3466,243 +3478,251 @@ msgstr ""
 msgid "Bad metaserver reply \"%s\""
 msgstr ""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Ne peut pas installer le truc qui s'occupe des pipes!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Tu cours ?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Tu cours ou combat ?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "leur armement fait pitie"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "legerement armes"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "relativement bien armes"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "lourdement armes"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "armes jusqu'aux dents"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - te courent apres, mec!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s and %d %tde - %s - te courent apres, mec!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s est arrive avec %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s reste debout et le prend."
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Tu restes la comme un pantin."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s essaye de se barrer, mais echoue."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "Pannique! Tu peux pas te sauver!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s s'est barre a %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "%s se sont echappes!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "Tu t'est echappe!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Flingues recharges..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s tire a %s... et manque son coup!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te tire dessus.. et loupe!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "Tu manques %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s tire %s mort"
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s tire a %s et tue une %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s est %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te tire dessus... et tue une %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "%s te troue, mec!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "Tu as bute %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Tu touches %s, et tue une %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "Tu touches %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr "Tu trouves %P sur le corps!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr " Tu cherches le corps!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr ""
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3719,22 +3739,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Impossible d'ecrire le fichier des high scores %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Cannot create pid file %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Cannot create pid file %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3773,117 +3802,121 @@ msgid ""
 "Using Socks.Auth.User and Socks.Auth.Password for SOCKS5 authentication\n"
 msgstr ""
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "Le joueur IA a debute; essaye de contacter le server sur %s:%d..."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+msgid "Failed to connect to server; cleaning up."
+msgstr ""
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Joueur IA terminated OK\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Connection au serveur perdue!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Utiliser nom %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Joueurs dans ce jeu:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s joint le jeu.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s a quitte le jeu.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Deplacement de %tde avec %P en cash et %P en dettes\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "joueur IA tue. Teminating normallement.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Temps de jeu termine. Quitte le jeu.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "Joueur IA jette du serveur.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "Le serveur has terminated.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendre %d %tde a %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Acheter %d %tde a %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Acheter un %tde pour %P au magazin de flingues\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dettes de %P payees au preteur a gages\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Le preteur a gages est situe a %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "L'armurerie est situee a %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Le bar est situe a %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "La banque est situee a %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vous osez vous appeller des dealers?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Un singe apprivoise pourrait faire mieux..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr ""
 "Tu penses que t'est suffisament dur pour dealer avec des mecs comme moi?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzzz... tu vends des bombons ou quoi?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Je crois que je vais devoir te buter pour ton propre bien."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3893,17 +3926,9 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en utilisant --enable-networking avec le script de config."
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr ""
-
-#: src/sound.c:229
-#, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Ne peux pas demarrer Church Wars en multi-joueur"
 
 #~ msgid "Whom do you want to page (talk privately to) ? "
 #~ msgstr "A qui tu veux parler en prive ? "

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars 1.5.10\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2007-10-25 16:37+1300\n"
 "Last-Translator: François Marier <francois@debian.org>\n"
 "Language-Team: French\n"
@@ -19,28 +19,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -48,586 +48,586 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "le prêteur à gages"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "la Caisse populaire"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Port réseau auquel se connecter"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nom du fichier des scores"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nom du serveur auquel se connecter"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Message de bienvenue du serveur pour aujourd'hui"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Adresse réseau du serveur"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "VRAI si un serveur SOCKS est nécessaire pour la connexion réseau"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "VRAI si un numéro d'identification est nécessaire pour SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Si non-vide, le nom d'utilisateur à utiliser pour SOCKS4"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "Le nom d'hôte d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "Le numéro de port d'un serveur SOCKS à utiliser"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "La version du protocole SOCKS à utiliser (4 ou 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Nom d'utilisateur pour l'authentification SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Mot de passe pour l'authentification SOCKS5"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "VRAI si le serveur doit se rapporter à un méta-serveur"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nom du méta-serveur auquel envoyer/recevoir les détails du serveur"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Le nom de votre machine serveur"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Authentification du nom local avec le metaserveur"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Description du serveur, rapportée au méta-serveur"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Si VRAI, le serveur est réduit dans le System Tray"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Si VRAI, le serveur roule en arrière-plan"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Nombre de tours de jeu (avec 0, le jeu ne se termine jamais)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Jour du mois durant lequel la partie débute"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Mois durant lequel la partie débute"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Année durant laquelle la partie débute"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr "Le symbôle monétaire (example: $)"
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Si VRAI, le symbôle monétaire précède les prix"
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Fichier dans lequel écrire le journal"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Contrôle le nombre de messages dans le journal"
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "Chaîne de formattage strftime() pour les dates dans le journal"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Les éléments aléatioires sont nettoyés"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "VRAI si la valeur de la drogue achetée doit être sauvegardée"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Soyez verbose en lisant le fichier de configuration"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Nombre de lieux dans le jeu"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Nombre de types de policiers dans le jeu"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Nombre de guns dans le jeu"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Nombre de drogues dans le jeu"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Emplacement du prêteur à gages"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Emplacement de la banque"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Emplacement du marchand d'armes"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Emplacement du bar"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Taux d'intérêt quotidien sur l'emprunt avec le prêteur à gages"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Taux d'intérêt quotidien du compte de banque"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nom du prêteur à gages"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nom de la banque"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nom du marchand d'armes"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nom du bar"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "VRAI pour activer les sons"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Son d'une balle qui atteint sa cible"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Son d'une balle qui rate sa cible"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Son d'un gun qui est rechargé"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr "Son accompagnant la mort d'un clerc ou d'un adjoint ennemi"
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr "Son accompagnant la mort d'un de vos clercs"
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr "Son accompagnant la mort d'un autre joueur ou d'un policier"
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Son accompagnant votre propre mort"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Son d'un joueur qui tente de s'échapper mais qui rate"
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Son accompagnant votre fuite ratée"
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr "Son d'un joueur qui s'échappe avec succès"
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr "Son accompagnant votre fuite réussie"
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Son d'arrivée dans un nouvel endroit"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr "Son à faire jouer lorsqu'un joueur se joint à la partie"
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr "Son à faire jouer lorsqu'un joueur quitte la partie"
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr "Son de début de la partie"
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr "Son de fin de la partie"
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Touche de tri pour la liste des drogues disponibles"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Nombre de secondes après quoi on peut répliquer"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Les joueurs sont déconnectés après ce nombre de secondes"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Temps en secondes pour que les connexions soient établies ou brisées"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Nombre maximum de connexions TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr ""
 "Nombre de secondes entre les tours des joueurs contrôlés par l'ordinateur"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Argent de départ de chaque joueur"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Montant des dettes en débutant la partie"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nom de chaque endroit"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Présence policiaire à chaque endroit (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Nombre minimum de drogues à chaque endroit"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Nombre maximum de drogues à chaque endroit"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% de résistance aux coups de gun de chaque joueur"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% de résistance aux coups de gun de chaque clerc"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Nom de chaque policier"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Nom de chaque adjoint"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Nom de chaque adjoint"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% de résistance aux coups de gun de chaque policier"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% de résistance aux coups de gun de chaque adjoint"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Pénalité d'attaque relative à un joueur"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Penalité de défense relative à un joueur"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Nombre minimum d'adjoints accompagnant un policier"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Nombre maximum d'adjoints accompagnant un policier"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Numéro du gun que les policiers utilisent"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Nombre de guns que chaque policier possède"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Nombre de guns que chaque adjoint possède"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nom de chaque drogue"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Prix normal minimal de chaque drogue"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Prix normal maximum de chaque drogue"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "VRAI si cette drogue peut être offerte à prix très bas"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "VRAI si cette drogue peut être offerte à prix exhorbitants"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Message affiché si cette drogue est offerte à prix très bas"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr ""
 "Chaîne de formattage utilisée pour les drogues dispendieuses la moitié du "
 "temps"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr ""
 "Diviseur sur le prix des drogues lorsqu'elle sont offertes à prix très bas"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 "Multiplicateur pour les drogues lorsqu'elles sont offertes à prix "
 "exhorbitants"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nom de chaque endroit"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Prix de chaque type de gun"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Espace utilisé par chaque gun"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Dommage infligé par chaque gun"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Mot utilisé pour décrire un \"clerc\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Mot utilisé pour décrire deux \"clercs\" ou plus"
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Mot utilisé pour décrire une arme"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Mot utilisé pour décrire deux armes ou plus"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Mot utilisé pour décrire une drogue"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Mot utilisé pour décrire deux drogues ou plus"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr "Chaîne de formattage strftime() pour l'affichage du tour"
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Coût pour qu'un clerc espionne l'ennemi"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Coût pour qu'un clerc dénonce un ennemi aux flics"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Prix minimum pour employer un clerc"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Prix maximum pour employer un clerc"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Liste des choses que vous entendez dans le métro"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Nombre de choses que vous entendez dans le métro"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Liste des chansons que vous pouvez entendre de loin"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Nombre de chansons"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Liste des choses que vous pouvez arrêter de faire"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Nombre de choses que vous pouvez arrêter de faire"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -635,138 +635,138 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Le marché est saturé de buvards"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
@@ -775,45 +775,45 @@ msgstr ""
 "de fumer!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Message"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr "Les boeufs ont mis la main sur un gros stock de dope (%tde) !"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Les boeufs ont mené une grosse rafle de dope (%tde) ! Les prix sont exorbitants !"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
@@ -822,149 +822,149 @@ msgstr "Les accros achètent de la dope (%tde) à des prix de fou!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr ""
 "Pète pis répète sont en bateau, pète tombe à l'eau, qui est-ce qu'il reste "
 "dans le bateau?"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "Tsé, le pape a déjà été juif"
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Chu sûre que tu fais des rêves très intéressants"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Je pense que je vais aller à Vancouver cette année"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Vas te faire couper les cheveux le pouilleux!"
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Ça t'arrive tu de conduire la nuit avec des lunettes fumées ?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "J'ai pas toujours été une femme tsé"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Est-ce que ta mère sait que tu vends de la dope ?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "T'es tu gelé là ?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Toi, tu dois venir de Vancouver ?"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Ta mère vient de faire des bons gâteaux avec un peu de ton Hash."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Ya rien comme avoir full de cash"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "Sauvez des arbres, torchez-vous avec un lapin !"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Bon chu trop décriss, j'm'en vas me coucher."
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr ""
 "Les terroristes dirigent la maison blanche depuis les dernières élections."
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "C'est vous que j'ai vu à la télé ?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Vous avez les yeux rouges, jeune homme."
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Un jour sans dope, c'est la nuit."
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "On utilise 20% de nos cerveaux, alors pourquoi ne pas en détruire 80% ?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr ""
 "« Le seul moyen de se délivrer de la tentation, c'est d'y céder. » a dit "
 "Oscar Wilde"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "C'est à vous l'éléphant rose là-haut ?"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr ""
 "Les vainqueurs ne se droguent pas... à moins qu'ils prennent de la drogue"
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Jésus t'aime beaucoup plus que tu ne le sauras jamais"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "La télépathie existe ! Check les vibrations."
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Impossible de lire le fichier de configuration %s (ligne %d)"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -974,40 +974,40 @@ msgstr ""
 "joueur n'est connecté.  Attendez que tous les joueurs se déconnectent\n"
 "ou éjecter-les avec la commande push ou kill et essayer à nouveau."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "L'index dans %s doit être entre 1 et %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s est %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s est %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s est %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s est \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] est %s\n"
@@ -1015,42 +1015,42 @@ msgstr "%s[%d] est %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s est { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s ne peut pas être moins de %d!"
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Liste de structure redimentionée à %d éléments\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "valeur booléenne attendue (0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=FALSE"
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1058,7 +1058,7 @@ msgstr ""
 "  -u, --plugin=FICHIER    utiliser le plugin de son \"FICHIER\"\n"
 "                            "
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1066,19 +1066,17 @@ msgstr ""
 "  -u fichier   utiliser le plugin de son \"fichier\"\n"
 "\t          "
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s disponible)\n"
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars version %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1093,7 +1091,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1163,7 +1161,7 @@ msgstr ""
 "  -C, --convert=FILE     convertir un vieux fichier de scores au nouveau \n"
 "                           format\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1179,9 +1177,7 @@ msgstr ""
 "la GNU GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1194,7 +1190,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1244,7 +1240,7 @@ msgstr ""
 "scores au nouveau format\n"
 "  -A       se connecte au serveur local pour l'administration\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1260,7 +1256,7 @@ msgstr ""
 "GPL\n"
 "Envoyer les bugs à l'auteur : benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1270,7 +1266,7 @@ msgstr ""
 "--enable-curses-client comme configuration, ou utiliser un client\n"
 "graphique (si disponible) à la place!\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1280,7 +1276,7 @@ msgstr ""
 "--enable-gui-client comme configuration, ou utiliser un client\n"
 "curses à la place!\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1291,7 +1287,7 @@ msgstr ""
 "fonctionner en mode serveur. Recompilez avec l'option --enable-networking\n"
 "dans le script configure.\n"
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1302,16 +1298,16 @@ msgstr ""
 "fonctionner en mode serveur.  Recompilez avec l'option --enable-networking\n"
 "dans le script configure.\n"
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Traduction québécoise         François Marier"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
@@ -1319,16 +1315,16 @@ msgstr ""
 "Basé sur le jeu Drug Wars par John E. Dell, Church Wars est une simulation "
 "d'un"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr "marché de la drogue imaginaire. Church Wars est un jeu qui comprend"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "acheter, vendre et essayer d'éviter les polices!"
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1336,120 +1332,125 @@ msgid ""
 msgstr ""
 "La première chose à faire est de rembourser votre dette au prêteur. Après,"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 "votre but est de faire le plus d'argent possible (tout en restant vivant)!"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Vous avez un mois pour faire fortune."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Version·%-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars est distribué sous la license GNU GPL."
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Icônes et graphiques          Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Effets sonores                Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testeurs                      Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Testeurs maniaques            Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Critiques non-consctructives  James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Critiques non-consctructives  James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Pour afficher l'aide sur les options disponible sur la ligne de commande,"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "tapez Church Wars -h sur votre prompt UNIX."
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Merci d'entrer le nom de l'hôte et le port du serveur:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Nom: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Port: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Patientez... tentative de contacter le méta-serveur..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Serveur: %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Port    : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Version     :%s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Joueurs: -inconnu- (maximum %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Joueurs: %d (maximum %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "En ligne depuis : %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Commentaire: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "S>erveur suivant; P>récedent; C>hoisir ce serveur... "
 
@@ -1457,68 +1458,51 @@ msgstr "S>erveur suivant; P>récedent; C>hoisir ce serveur... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "SPC"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Connextion au serveur SOCKS %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Authentification avec le serveur SOCKS"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Demande de connexion SOCKS avec %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr "Authentification SOCKS requise (entrez un nom vide pour annuler)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Nom d'utilisateur: "
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Mot de passe: "
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Patientez... tentative de contacter le serveur Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "Impossible d'obtenir les détails du méta-serveur"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Ne peux pas démarrer Church Wars en mode multi-joueurs"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Voulez-vous... C>onnecter à un hôte/port différent"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "            L>iste des serveurs sur le méta, et en sélectionner un"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
@@ -1526,143 +1510,149 @@ msgstr ""
 "            Q>uitter (vous pouvez alors démarrer un server en             "
 "tapant \"Church Wars -s\")"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ouer en solo ? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "CLQJ"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Où ça, man ? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr "%/Affichage de l'endroit/%tde"
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Tu peux pas te faire de cash avec ce que tu transportes %tde :"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "Qu'est-ce que tu veux crisser à terre? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Combien d'unités veux-tu crisser à terre? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "Qu'est-ce que tu veux acheter? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "Qu'est-ce que tu veux vendre? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Tu peux en acheter %d, et en transporter %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Combien que t'en prends ? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "T'as %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Combien que tu en vends? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Êtes-vous sur de vouloir quitter? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "ON"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nouveau nom: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "La connexion avec le serveur a été terminée. Mode solo."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Le serveur est mort. Mode solo"
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s joint la partie!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s a quitté la partie."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s est maintenant %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Endroit présent/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Malheureusement, quelqu'un d'autre utilise déjà ton nom. Change-le."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "M E I L L E U R S   S C O R E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "T'as pas de %tde à vendre!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "T'en n'as pas à vendre!"
 
@@ -1670,27 +1660,27 @@ msgstr "T'en n'as pas à vendre!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Tu as besoin de plus de %tde pour transporter plus de %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "T'as pas assez d'espace pour transporter: %tde"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "T'as pas assez de cash pour acheter: %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 
@@ -1698,42 +1688,42 @@ msgstr "Veux tu A>cheter, V>endre, ou P>artir? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "AVP"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Combien de cash tu rends ? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "T'as pas assez de cash!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr ""
 "Tu veux D>époser de l'argent, R>etirer de l'argents, ou S>acrer ton camp ? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "DRS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Combien d'argent? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "Ya pas autant d'argent dans la banque..."
 
@@ -1741,47 +1731,47 @@ msgstr "Ya pas autant d'argent dans la banque..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "O:Oui"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Non"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "D:écrisser"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "S:Se battre"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Attaquer"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "S:Se sauver"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Pèse sur une touche..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Messages (-/+ avancer/reculer)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Statistiques"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Cash"
 
@@ -1789,41 +1779,41 @@ msgstr "Cash"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Santé"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banque"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Dette"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Espace %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espace %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Manteau"
 
@@ -1831,158 +1821,164 @@ msgstr "Manteau"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Stats: Drogues/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Stats: Drogues/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Aucun autre joueur est en ligne en ce moment!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Joueurs en ligne:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Heille man, les prix du %tde sont la:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Ne peux pas installer le handleur d'interruptions SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Heille man, comment tu t'appelles ? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "A>cheter"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", V>endre"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", L>aisser tomber"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", P>lacotter, R>éveiller"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", L>ister"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", C>ombattre"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", S>'en aller ailleurs"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", ou Q>uitter? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Tu "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "C>ombattre, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "R>ester sur place, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "T>e sauver, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "V>endre des %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "ou Q>uitter? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "La connection au serveur est perdue. Change en mode Solo"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "AVLPRLDCSQ"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "VTCRQ"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Lister quoi? J>oueurs ou S>cores? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "JS"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Impossible d'initialiser WinSock (%s)!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Jouer à nouveau? "
 
@@ -2072,8 +2068,8 @@ msgid "Inventory"
 msgstr "Inventaire"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Fermer"
 
@@ -2249,13 +2245,13 @@ msgstr "En vendre combien ?"
 msgid "Drop how many?"
 msgstr "En laisser tomber combien ?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2313,54 +2309,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Traduction québécoise"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Icônes et graphiques"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Effets sonores"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Vente de drogue et recherche"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testeurs de jeu"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Testeurs maniaques du jeu"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Critique constructive"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Critique non-constructive"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2388,7 +2384,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2397,134 +2393,135 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars est distribué sous la licence GNU GPL\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Prêteur window title/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banque window title/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "Vous devez entrer un montant positif!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Il n'y a pas autant d'argent dans la banque..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Argent: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Dettes: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Banque: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Rembourser:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Déposer"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Retirer"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Tout payer"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Liste des joueurs"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Parler au(x) joueur(s)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Parler à tous les joueurs"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Message:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Envoyer"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nom"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Prix"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Quantité"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Acheter ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Vendre"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Laisser tomber <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde en vente/demande ici"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde transporté(e)s"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Changer de nom"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2533,12 +2530,12 @@ msgstr ""
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Marchand d'armes window title/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2805,7 +2802,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 #, fuzzy
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
@@ -2819,39 +2816,39 @@ msgstr ""
 "\n"
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "Serveur Church Wars en train de terminer."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr "AS"
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2892,27 +2889,27 @@ msgstr ""
 "Les variables acceptées sont:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Impossible de se connecter au méta-serveur à %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "MetaServeur: %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr "Connexion au méta-serveur trop fréquente, attente du prochain timeout"
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "En attente de la connexion au méta-serveur à %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 #, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
@@ -2925,7 +2922,7 @@ msgstr ""
 "serontpas supportées.  Obtenez la dernière version sur le site web de Church "
 "Wars: https://Church Wars.sourceforge.io/"
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 #, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
@@ -2937,14 +2934,14 @@ msgstr ""
 "dernière versionsur le site web de Church Wars: https://Church Wars."
 "sourceforge.io/"
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Nombre maximum de clients (%d) dépassé - annulation de la connexion"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2954,7 +2951,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2966,60 +2963,66 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s est maintenant connu sous le nom de %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: déplacement vers %s INTERDIT"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Votre temps de dealage est terminé"
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: déplacement vers %s INTERDIT"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Message inconnu: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Maintenance du pid file %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Impossible de créer le fichier pid %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
 msgstr "Impossible de créer un socket d'écoute (%s) pour le serveur"
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr "Impossible de s'attacher au port %u (%s)"
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
-msgstr "Impossible de lire sur le socket réseau"
+msgid "Cannot set socket reuse option (%s)"
+msgstr ""
 
 #: src/serverside.c:769
+#, fuzzy, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr "Impossible de s'attacher au port %u (%s)"
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "Impossible de lire sur le socket réseau"
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -3027,78 +3030,78 @@ msgstr ""
 "Serveur Church Wars version %s attendant les connexions sur le port %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGUSR1!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGHUP!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGINT!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Impossible d'installer le handleur d'interruptions SIGTERM!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Impossible d'installer le handleur de pipeline!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Fichier de configuration enregistré comme %s\n"
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Utilisateurs en ligne:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Aucun utilisateur en ligne!\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Intimidation de %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Cet utilisateur n'existe pas.\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s tué\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Commande inconnue - essayez \"help\" pour l'aide...\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "connexion reçu de %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "Serveur Church Wars en train de terminer."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s quittes le serveur!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -3106,7 +3109,7 @@ msgstr ""
 "Impossible d'installer le socket de domaine UNIX pour les "
 "connexionsadministratives - vérifiez les permissions sur /tmp!"
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3114,41 +3117,51 @@ msgstr ""
 "Serveur Church Wars version %s en attente de commandes d'administration."
 "Essayez \"help\" pour l'aide."
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Nouvelle connexion administrative"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Commande administrative: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Connexion administrative terminée"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr "Impossible d'obtenir le status du service NT"
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr "Impossible d'envoyer un message de notification du service"
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr "Impossible d'installer un handleur de service"
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr "Impossible de démarrer le service NT"
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Commande:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3157,17 +3170,17 @@ msgstr ""
 "Impossible de créer une copie (%s) du\n"
 "fichier des scores: %s"
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Impossible de lire le fichier des meilleurs scores: %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -3176,7 +3189,7 @@ msgstr ""
 "Le fichier des scores (%s) a été converti au nouveau format.\n"
 "Une copie de l'ancien fichier a été créée: %s.\n"
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3185,12 +3198,12 @@ msgstr ""
 "Impossible de créer une copie (%s) du\n"
 "fichier des scores: %s"
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3203,7 +3216,7 @@ msgstr ""
 "répertoire\n"
 "ou specifiez un autre fichier et chemin d'accès avec la commande -f."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3218,7 +3231,7 @@ msgstr ""
 "nouveau format en utilisant la commande:\n"
 "    Church Wars -C %s"
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 #, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
@@ -3229,7 +3242,7 @@ msgstr ""
 "préférences pourraient ne pas fonctionner correctement.  Voir le\n"
 "fichier \"Church Wars-log.txt\" pour plus de détails."
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -3239,133 +3252,133 @@ msgstr ""
 "préférences pourraient ne pas fonctionner correctement.  Portez attention\n"
 "aux messages figurant sur la sortie standard pour plus de détails."
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Impossible d'ouvrir le fichier des meilleurs scores (%s): %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Impossible de lire le fichier des high scores %s"
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Félicitations! Vous êtes dans les meilleurs scores!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "T'as même pas réussi à être dans les scores!"
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Impossible d'écrire le fichier des meilleurs scores %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(Repose en Paix)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "La madame à côté de toi dans le métro te dit,^ \"%s\"%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (du moins, tu -penses- que c'est ça qu'elle a dit)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Tu entends quelqu'un jouer %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Veux-tu visiter %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Veux-tu engager une %tde pour %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est déjà là!^Tu Attaque, or t'Evade?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "Pas de boeufs ou de guns"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "Les boeufs ne peuvent pas attaquer d'autres boeufs!"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "Les joueurs sont déjà en train de se battre!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont déjà dans des batailles séparées!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Ne peut pas commencer la bataille - pas de gun à utiliser!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Tu viens de crever man!"
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Vas-tu payer le docteur %P pour te ramancher?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Tu t'es fait pété la gueule dans le métro!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "T'as rencontré un chum, il t'a donné %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "T'as rencontré ton meilleur chum pis tu lui a donné %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Tu nettoies une offre aléatoire."
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Les chiens de police te courent après sur %d blocs! T'as échappé: %tde!"
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "T'as trouvé %d %tde sur un gars mort dans le métro!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr ""
 "Ta mère a fait des gâteaux avec un peu de %tde! Y'étaient vraiment bons!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3373,26 +3386,26 @@ msgstr ""
 "YN^Il y a une sorte d'herbe qui sent bizarre ici!^Ça a l'air bon! Veux-tu la "
 "fumer? "
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Tu t'arretes pour %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Veux-tu acheter un manteau plus gros %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Heille man! J'pourrais t'aider à transporter tes %tde pour un petit %P. "
 "Qu'est-ce que t'en dis ?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Veux-tu acheter un %tde pour %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3401,29 +3414,29 @@ msgstr ""
 "^jamais pu imaginer! Ensuite t'es mort parce que ton cerveau s'est "
 "désintégré!"
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Trop tard, %s vient juste de partir!"
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Les boeufs t'ont vu jeter ton stock (%tde)!"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Envoi des mise à jours au méta-serveur..."
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr "Envoi du rappel au méta-serveur..."
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Joueur éjecté à cause d'une période d'inactivité trop longue"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Joueur éjecté à cause d'un temps de connexion trop long"
 
@@ -3543,243 +3556,251 @@ msgstr "Erreur interne du méta-serveur \"%s\""
 msgid "Bad metaserver reply \"%s\""
 msgstr "Mauvaise réponse du méta-serveur \"%s\""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Impossible d'initialiser WinSock (%s)!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Tu cours ?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Courir ou combattre ?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "leurs guns font pitié"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "légèrement armés"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "relativement bien armés"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "lourdement armés"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "armés jusqu'aux dents"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - te courent après, man!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s et %d %tde - %s - te courent après, man!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s est arrivé avec %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s reste debout et le prend."
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Tu restes là comme une momie."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s essaye de décrisser, mais échoue."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "Fuck! Tu peux pas te sauver!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s s'est enfuit %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "%s se sont échappés!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "Tu t'es échappé!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Guns rechargés..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s tire sur %s... et manque son coup!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s te tire dessus.. et rate!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "Tu as manqué %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s tue %s par balle"
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s tire sur %s et tue une %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s est %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s te tire dessus... et tue une %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "%s t'a pogné, man!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "T'as achevé %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Tu pognes %s, et tue une %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "Tu pognes %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr " Tu trouves %P sur le corps!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr " Tu fouilles le corps!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "Impossible d'initialiser WinSock (%s)!"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr "Échec général du serveur SOCKS"
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Connexion refusée par les règles SOCKS"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Connexion réseau impossible"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Connexion à l'hôte impossible"
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr "SOCKS: Connexion refusée"
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: Le TTL a expiré"
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Commande non-supportée"
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Type d'adresse non-supporté"
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr "Le serveur SOCKS a réjeté toutes les méthodes offertes"
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr "Le type de l'adresse SOCKS retournée est inconnu"
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr "Échec d'authentification SOCKS"
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "Authentification SOCKS annulée par l'utilisateur"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Requête rejetée ou échouée"
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Rejeté - impossible de contacter identd"
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Rejeté - identd rapporte un nom d'utilisateur différent"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr "Code de réponse SOCKS inconnu"
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr "Code de version de réponse SOCKS inconnu"
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr "Version de serveur SOCKS inconnue"
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "Code d'error SOCKS: %d"
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3800,22 +3821,31 @@ msgstr ""
 "Connexion établie.  Utilisez Ctrl-D pour terminer votre session.\n"
 "\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Impossible d'ouvrir le fichier %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Impossible d'ouvrir le fichier %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Impossible d'ouvrir le fichier %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr "Impossible de déterminer le fichier de configuration local."
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Impossible d'ouvrir le fichier %s: %s"
@@ -3856,116 +3886,121 @@ msgstr ""
 "Utilisation de Socks.Auth.User et Socks.Auth.Password pour \n"
 "l'authentification SOCKS5\n"
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "Le joueur IA a débuté et tente de contacter le serveur sur %s:%d..."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "Impossible de se connecter au méta-serveur à %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Le joueur IA a terminé correctement.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Connexion au serveur perdue!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Utiliser le nom %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Joueurs dans ce jeu:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s joint la partie.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s a quitté la partie.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Déplacement de %tde avec %P en cash et %P en dettes\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Le joueur IA a été tué. Fin normale.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Temps de jeu écoulé. La partie est terminée.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "Joueur IA éjecté du serveur.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "Le serveur a terminé.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendre %d %tde à %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Acheter %d %tde à %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Acheter un %tde pour %P au marchand d'armes\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dettes de %P payées au prêteur à gages\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Le prêteur à gages est situé à %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Le marchand d'armes est situé à %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Le bar est situé à %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "La banque est située à %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Tu oses te prendre pour un pusher?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Un singe apprivoisé pourrait faire mieux..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Tu penses que t'es assez toff pour dealer avec du monde comme moi?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzzz... tu vends des bonbons ou quoi?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Je crois que je vais devoir te tuer pour ton propre bien."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3975,19 +4010,24 @@ msgstr ""
 "se comporter comme un joueur IA.\n"
 "Recompile en passant --enable-networking au script de configuration."
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "Impossible d'ouvrir le fichier %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "Impossible d'obtenir les détails du méta-serveur"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Ne peux pas démarrer Church Wars en mode multi-joueurs"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Le plugin sélectionné (\"%s\") est invalide.\n"
-"(%s est disponible, utilisation de \"%s\".)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "Impossible d'ouvrir le fichier %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Le plugin sélectionné (\"%s\") est invalide.\n"
+#~ "(%s est disponible, utilisation de \"%s\".)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "La commande utilisée pour lancer votre fureteur"

--- a/po/nn.po
+++ b/po/nn.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nn_new\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2003-08-31 22:58+0200\n"
 "Last-Translator: Åsmund Skjæveland <aasmunds@fys.uio.no>\n"
 "Language-Team: Norsk nynorsk <i18n-nn@lister.ping.uio.no>\n"
@@ -34,28 +34,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -63,582 +63,582 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "Lånehaien"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "Banken"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Nettverksport å kopla til"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Namn på poengfila"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Namn på tenaren du vil kopla deg til"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Tenaren si velkomsthelsing for dagen"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Netverkadressa tenaren skal lytta på"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE viss ein SOCKS-tenar skal brukast i nettverket"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE viss numerisk brukar-ID skal brukast for SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Viss ikkje blank, brukarnamnet som skal brukast til SOCKS4"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "Vertsnamnet på SOCKS-tenaren"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "Portnummeret på SOCKS-tenaren"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "Versjonen av SOCKS-protokollen du vil bruka (4 eller 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Brukarnamn for SOCKS5-autentisering"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Passord for SOCKS5-autentisering"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "TRUE viss tenaren skal rapportera til ein metatenar"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Metatenar å rapportera til/få tenar-detaljar frå"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Føretrukke vertsnamn på tenarmaskinen din"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentisering for LocalName med metatenaren"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Tenarskildring, rapportert til metatenaren"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Viss TRUE, vil tenaren minimera til systemtrauet"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Viss TRUE, så vil tenaren køyra i bakgrunnen"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Tal på rundar i spelet (viss 0 vil spelet aldri slutta)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Dagen i månaden som spelet startar på"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Månaden spelet startar i"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Året spelet startar i"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr "Valutasymbolet (t.d. $)"
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr "Viss TRUE, går valutasymbolet framfor prisane"
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Fil som loggmeldingar skal skrivast til"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Kontrollerer talet på loggmeldingar som blir laga"
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "strftime()-format-streng for logg-tidsmerker"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Tilfeldige hendingar er rensa"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "TRUE viss verdien av det kjøpte dopet skal hugsast"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Vér ordrik når oppsettfila blir lest"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Tal på stader i spelet"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Tal på typar politimenn i spelet"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Tal på våpen i spelet"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Tal på sortar dop i spelet"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Staden Lånehaien held til"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Staden banken held til"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Staden våpenbutikken held til"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Staden puben held til"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Dagleg rente på gjelda til lånehaien"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Dagleg rente på innskotet i banken"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Namnet på lånehaien"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Namnet på banken"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Namnet på våpenforretningen"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Namnet på puben"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "SANN for å slå på lyd"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Lyd som blir spelt når eit skot treff"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Lyd som blir spelt når eit skot bommar"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Lyd som blir spelt når våpna blir lada"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 "Lyd som blir spelt når ein fiendtleg klerikar eller betjent blir drepen"
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr "Lyd som blir spelt når ein av klerikarane dine blir drepen"
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 "Lyd som blir spelt når ein annan spelar eller ei politimann blir drepen"
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Lyd som blir spelt når du blir drepen"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr "Lyd som blir spelt når ein spelar ikkje klarer å koma seg unna"
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr "Lyd som blir spelt når du ikkje klarer å koma deg unna"
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr "Lyd som blir spelt når ein spelar klarer å koma seg unna"
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr "Lyd som blir spelt når du klarer å koma deg unna"
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Lyd som blir spelt når du kjem til ein ny stad"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr "Lyd som blir spelt når ein annan blir med i spelet"
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr "Lyd som blir spelt når ein spelar går ut av spelet"
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr "Lyd som blir spelt i byrjinga av spelet"
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr "Lyd som blir spelt i slutten av spelet"
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Sorteringsnøkkel for lista over det tilgjengelege dopet"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Tal på sekund du har på deg til å skyta tilbake"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Spelarar blir kopla frå etter så mange sekund"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tida i sekund for å kopla til eller bryta samband"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maksimalt tal på TCP/IP-sambandar"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Sekund mellom rundane for AI-spelarar"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Kor mykje pengar kvar spelar startar med"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Kor mykje gjeld kvar spelar startar med"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Namn på kvar stad"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Politinærleik på kvar stad (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Minste tal på dopsortar på kvar plass"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Største tal på dopsortar på kvar plass"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr "% motstand mot skot for kvar spelar"
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr "% motstand mot skot for kvar klerikar"
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Namn på kvar politimann"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Namn på kvar politimann sin betjent"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Namn på kvar politimann sine betjentar"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr "% motstand mot skot for kvar purk"
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr "% motstand mot skot for kvar politibetjent"
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Åtaks-handikap relativt til ein spelar"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Forsvars-handikap relativt til ein spelar"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Minste tal på politibetjentar"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Største tal på politibetjentar"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Null-basert indeks på våpenet politiet er væpna med"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Tal på våpen kvar politimann har"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr "Tal på våpen kvar politibetjent har"
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Namn på kvart dop"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Minste vanlege pris på kvart dop"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Største vanlege pris på kvart dop"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "TRUE viss dette dopet kan vera ekstra billeg"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "TRUE viss dette dopet kan vera ekstra dyrt"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Melding som skal visast når dette dopet er ekstra billeg"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Formatstreng brukt for dyrt dop 50% av tida"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Tal som prisen på dopet skal delast på når det er ekstra billeg"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Tal som prisen på dopet skal gangast med når det er ekstra dyrt"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Namn på kvar stad"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Prisen på kvart våpen"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Plassen kvart våpen tek"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Skaden kvart våpen gjer"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Ord for ein einskild «klerikar»"
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Ord for to eller fleire «klerikarar»"
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Ord for eit einskild våpen eller tilsvarande"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Ord for to eller fleire våpen"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Ord for eit einskild narkotikum eller tilsvarande"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Ord for to eller fleire slag dop"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr "strftime() formatstreng for å visa tida i spelet"
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Kostnad for at ein klerikar spionerer på fienden"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Kostnad for at ein klerikar tystar til politiet på ein fiende"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Minstepris for å tilsetja ein klerikar"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Høgaste pris for å tilsetja ein klerikar"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Liste over ting du høyrer på T-banen"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Tal på ting som blir sagt på T-banen"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Liste over songar du kan høyra bli spelt"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Tal på sogar som spelar"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Liste over ting du kan stoppa for å gjera"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Tal på ting du kan stoppa for å gjera"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -646,183 +646,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Marknaden er oversvømt med billeg heimelaga syre!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "Colombiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Melding"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr "Politiet gjorde eit kjempebeslag av %tde! Prisane er skyhøge!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Politiet gjennomførte ein stor razzia mot %tde! Prisane er skyhøge!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Narkomane kjøper %tde til avsindige prisar!"
@@ -831,143 +831,143 @@ msgstr "Narkomane kjøper %tde til avsindige prisar!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Ville det ikkje vore festleg viss alle plutseleg kvekkte samtidig?"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "Paven var jøde ein gong, veit du."
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Eg er sikker på at du har nokon ordentleg interessante draumar."
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Eg trur eg skal reisa til Amsterdam i år"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Guten min, du treng ein gul hårklipp."
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Eg synest det er fantastisk kva dei får til med røykjelse no til dags."
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "Eg har ikkje vore kvinne heile livet, veit du"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Veit mora di at du sel dop?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "Er du høg på noko?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Å, du må vera frå California"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Eg var hippie sjølv ein gong i tida"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Det er ingenting som å ha mykje pengar"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "Du ser ut som eit beltedyr!"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Eg trur ikkje på Ronald Reagan"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Ha mot! Bush er ein nuddel!"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Har eg ikkje sett deg på fjernsynet?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Me vinn krigen mot narkotika!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Ein dag utan dop er som ei natt"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Me bruker berre 20% av hjernane våre, så kvifor ikkje øydeleggja resten"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Eg samlar inn pengar til Zomibiar for Kristus"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Eg vil gjerne selja deg ein etande puddel"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Vinnarar dopar seg ikkje... viss ikkje dei gjer det"
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus elskar deg meir enn du veit"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "Vil du ha ein seigmann?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Kan ikkje tolka oppsettfila %s, linje %d"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Klarte ikkje å opna fila %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -977,40 +977,40 @@ msgstr ""
 " er logga på. Vent til alle spelarane har logga av, eller\n"
 "fjern dei med dytt- eller-drep-kommandoane, og prøv igjen."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks til %s array burde vore mellom 1 og %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s er %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s er %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s er %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s er «%s»\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] er %s\n"
@@ -1018,42 +1018,42 @@ msgstr "%s[%d] er %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s er { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s kan ikkje vera mindre enn %d - ignorerer!"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s kan ikkje vera større enn %d - ignorerer!"
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Forandra storleiken på strukturlista til %d element\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Venta ein boolsk verdi (ein av 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr "Currency.Prefix=TRUE"
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1061,7 +1061,7 @@ msgstr ""
 "  -u, --plugin=FIL        bruk lydmodul «FIL»\n"
 "                            "
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1069,19 +1069,17 @@ msgstr ""
 "  -u fil   bruk lydmodul «fil»\n"
 "\t          "
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s tilgjengeleg)\n"
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars versjon %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1096,7 +1094,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1161,7 +1159,7 @@ msgstr ""
 "  -C, --convert=FIL       konverter ei poengfil i gamalt format til det\n"
 "                            nye formatet\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1177,9 +1175,7 @@ msgstr ""
 "GNU GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1192,7 +1188,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1240,7 +1236,7 @@ msgstr ""
 "  -C fil   konverter ei poengfil i gamalt format til det nye formatet\n"
 "  -A       kopla til ein lokalt køyrande tenar for administrasjon\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1256,7 +1252,7 @@ msgstr ""
 "GNU GPL\n"
 "Rapportér feil til forfattaren på benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1266,7 +1262,7 @@ msgstr ""
 "på nytt, med valet --enable-curses-client til configure,\n"
 "eller bruk ein grafisk klient (viss tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1277,7 +1273,7 @@ msgstr ""
 "configure, eller bruk tekstmodus-klienten (viss\n"
 "tilgjengeleg) i staden.\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1285,7 +1281,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1296,91 +1292,91 @@ msgstr ""
 "og kan ikkje køyra som tenar. Kompilér på nytt, og gi valet\n"
 "--enable-networking til configure-skriptet.\n"
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Norsk omsetjing               Åsmund Skjæveland"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr "Church Wars er tufta på Drug Wars av John E. Dell, og er ei simulering"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr "av ein oppdikta narkotikamarknad. Skap rikdomen din ved å kjøpa"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "og selja narkotika. Ikkje lat politiet ta deg!"
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
 "Collector. After"
 msgstr "Det fyrste du må gjera er å betala gjelda di til lånehaien."
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 "Etter det, er målet ditt å tena så mykje pengar som råd (og halda deg i "
 "live)!"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Du har ein månad i speletid på å skapa formuen din."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Versjon %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars er tilgjengeleg under GNU General Public License"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Ikon og grafikk               Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Lydar                         Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Speltesting                   Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Grundig speltesting           Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Ukonstruktiv kritikk          James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Ukonstruktiv kritikk          James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr "For informasjon om kommandolinevala, skriv Church Wars -h på"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1388,60 +1384,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Skriv vertsnamnet og porten på ein Church Wars-tenar:"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Vertsnamn:"
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Port:"
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Vent litt... prøver å kontakta metatenar..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Tenar  : %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Port   : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Versjon    : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Spelarar: -ukjent- (maksimum %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Spelarar: %d (maksimum %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "Oppe sidan   : %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Kommentar: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>este tenar: F>ørre tenar: V>el denne tenaren"
 
@@ -1449,210 +1450,199 @@ msgstr "N>este tenar: F>ørre tenar: V>el denne tenaren"
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "NFV"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Kopla til SOCKS-tenar %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Autentiserer mot SOCKS-tenar"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Ber SOCKS om samband til %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr "Treng SOCKS-autentisering (skriv eit blankt brukarnamn for å avbryta)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Brukarnamn:"
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Passord:"
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Vent litt... prøver å kopla til Church Wars-tenar..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "Kan ikkje henta metatenar-detaljar"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Kunne ikkje starta fleirspelar Church Wars"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Vil du K>opla til ein bestemt Church Wars-tenar"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "       L>ista tenarane på metatenaren, og velga ein"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "       A>vslutta (du kan starta ein tenar med «Church Wars -s»)"
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "       eller S>pela åleine? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "KLAS"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr "%d. %tde"
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Kor til, kompis? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr "%/Liste over stader/%tde"
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Du kan ikkje få nokon pengar for desse %tde:"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "Kva vil du kasta? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Kor mange vil du kasta? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "Kva vil du kjøpa? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "Kva vil du selja? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Du har råd til %d, og kan béra %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Kor mange vil du kjøpa? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Du har %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Kor mange vil du selja? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Er du viss på at du vil avslutta? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "JN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nytt namn:"
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Du har blitt dytta av tenaren. Byter til einspelar-modus."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Tenaren har stengt. Byter til einspelar-modus."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s blir med i spelet!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s har forlatt spelet."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s er no kjend som %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Staden du er no/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Diverre er det alt nokon som brukar «ditt» namn. Vér snill og byt det."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "P O E N G L I S T E"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Du har ikkje noko %tde å selja!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Du har ikkje noko å selja!"
 
@@ -1660,27 +1650,27 @@ msgstr "Du har ikkje noko å selja!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Du treng fleire %tde for å bera meir %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Du har ikkje nok plass til å bera det %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Du har ikkje nok pengar til å kjøpa det %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Vil du K>jøpa, S>elja eller G>å?"
 
@@ -1688,41 +1678,41 @@ msgstr "Vil du K>jøpa, S>elja eller G>å?"
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "KSG"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Kor mykje pengar vil du betala tilbake?"
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "Du har ikkje så mykje pengar!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Vil du S>etja inn pengar, T>a ut pengar, eller G>å?"
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "STG"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Kor mykje pengar?"
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "Du har ikkje så mykje i banken."
 
@@ -1730,47 +1720,47 @@ msgstr "Du har ikkje så mykje i banken."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "J:Ja"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Nei"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "S:Spring"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "K:Kjemp"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Angrip"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "U:Unngå"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Trykk ein tast..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr "Meldingar (-/+ rullar opp/ned)"
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Status"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Kontantar"
 
@@ -1778,41 +1768,41 @@ msgstr "Kontantar"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tuf"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Helse"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Bank"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Gjeld"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Plass %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d plass %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Frakk"
 
@@ -1820,158 +1810,164 @@ msgstr "Frakk"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr "%-7tde  %3d @ %P"
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr "%-7tde  %3d"
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr "%-22tde %3d"
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tuf"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Ingen andre spelarar er logga på no."
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Spelarar som er logga på:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hei du. Her kostar %tde:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Kan ikkje installera SIGWINCH-avbrotshandsamar!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Namnet ditt:"
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "Vil du K>jøpa"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", S>elja"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", H>iva"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", sN>akka med alle, snakka med E>in"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", sjå L>ister"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", kJ>empa"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", R>eisa"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", eller A>vslutta? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Vil du "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "K>jempa, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "V>enta, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "R>ømma, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "S>elja %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "eller A>vslutta?"
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Mista sambandet til tenaren! Går tilbake til einspelar-modus."
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "KSHNELGJRA"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "SRKVA"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Lista opp kva? S>pelarar eller P>oeng? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "SP"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Kan ikkje starta opp WinSock (%s)!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Spela igjen? "
 
@@ -2061,8 +2057,8 @@ msgid "Inventory"
 msgstr "Eignelutar"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Steng"
 
@@ -2242,13 +2238,13 @@ msgstr "Selja kor mange?"
 msgid "Drop how many?"
 msgstr "Hiva kor mange?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2306,54 +2302,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Norsk omsetjing"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Ikon og grafikk"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Lydar"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Dopsal og research"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Speltesting"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Grundig speltesting"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Konstruktiv kritikk"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Ukonstruktiv kritikk"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2381,7 +2377,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2390,134 +2386,135 @@ msgstr ""
 "Version %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars er tilgjengeleg under GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Lånehai vindagustittel/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Banknamn vindaugstittel/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "Du må skriva inn ei positiv mengde pengar!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Du har ikkje så mykje pengar i banken."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Kontantar: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Gjeld: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Bank: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Betal tilbake:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Sett inn"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Ta ut"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Betal alt"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Spelarliste"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Snakk med spelar(ar)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Snakk med alle spelarane"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Melding:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Send"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Namn"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Pris"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Mengde"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Kjøp ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Sel"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Hiv <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tuf her"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tuf du har"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Byt namn"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2525,12 +2522,12 @@ msgstr "Diverre, nokon andre bruker «ditt» namn. Ver snill og byt det:-"
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/GTK Våpenforretning-tittel/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2797,7 +2794,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 #, fuzzy
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
@@ -2811,39 +2808,39 @@ msgstr ""
 "\n"
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "Church Wars-tenaren avsluttar."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr "AD"
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2885,27 +2882,27 @@ msgstr ""
 "Lovlege variablar er lista under:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Kunne ikkje kopla til metatenaren på %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metatenar  : %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr "Prøver for ofte å kopla til metatenaren - venter på neste tidsavbrot"
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Ventar på tilkopling til metatenaren på %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 #, fuzzy
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
@@ -2918,7 +2915,7 @@ msgstr ""
 "ikkje vera støtta. Hent den nyaste versjonen frå^Church Wars-vevsida, http://"
 "Church Wars.sourceforge.net/."
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 #, fuzzy
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
@@ -2929,14 +2926,14 @@ msgstr ""
 "denne tenaren. For den fulle^ «opplevinga» bør du henta den siste versjonen "
 "av ^ Church Wars frå vevsida: https://Church Wars.sourceforge.io/"
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "Gjekk over MaxClients (%d) - bryt sambandet"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2946,7 +2943,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2958,138 +2955,144 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s kallar seg no for %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: NEKTA reise til %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Pushetida di er ute."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: NEKTA reise til %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Ukjend melding: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Bruker pid-fil %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Kan ikkje laga pid-fil %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
 msgstr "Kan ikkje laga (lytte-)sokkel (%s) til tenaren. Avbryt."
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr "Kan ikkje kopla til port %u (%s). Bryt av."
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
-msgstr "Kan ikkje lytta til nettverkssokkel. Avbryt."
+msgid "Cannot set socket reuse option (%s)"
+msgstr ""
 
 #: src/serverside.c:769
+#, fuzzy, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr "Kan ikkje kopla til port %u (%s). Bryt av."
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "Kan ikkje lytta til nettverkssokkel. Avbryt."
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "Church Wars-tenar versjon %s er klar og ventar på samband på port %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Kan ikkje installera SIGUSR1-avbrotshandsamar!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Kan ikkje installera SIGHUP-avbrotshandsamar!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Kan ikkje installera SIGINT-avbrotshandsamar!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Kan ikkje installera SIGTERM-avbrotshandsamar!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Kan ikkje installera røyr-handsamar!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Oppsettfil lagra OK som %s\n"
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Brukarar logga på:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Ingen brukarar er logga på no.\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Dyttar %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Ingen slik brukar!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s drepen\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Ukjend kommando - prøv «help» for hjelp\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "Vart kopla til frå %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "Church Wars-tenaren avsluttar."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s forlét tenaren!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
@@ -3097,7 +3100,7 @@ msgstr ""
 "Kunne ikkje laga unix domenesokkel til admin-samband - sjekk skriveløyva på /"
 "tmp!"
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3105,41 +3108,51 @@ msgstr ""
 "Church Wars-tenar versjon %s er klar til å ta imot admin-kommandoar, prøv "
 "«help» for å få hjelp"
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Nytt admin-samband"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Admin-kommando: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Admin-samband stengt"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr "Klarte ikkje å setja NT teneste-status"
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr "Kunne ikkje posta tenestevarselsmelding"
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr "Kunne ikkje registrera tenestehandsamar"
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr "Klarte ikkje å starta NT-teneste"
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Kommando:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Kan ikkje opna poengtavlefila %s: %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3148,17 +3161,17 @@ msgstr ""
 "Kan ikkje laga kopi (%s) av\n"
 "poengtavlefila %s."
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Feil ved lesing av poeng frå %s."
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Kan ikkje opna poengtavlefila %s: %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
@@ -3167,7 +3180,7 @@ msgstr ""
 "Den gamle poengfila %s har blitt konvertert til det nye\n"
 "formatet. Ein kopi av den gamle fila har fått namnet %s.\n"
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3176,12 +3189,12 @@ msgstr ""
 "Kan ikkje laga kopi (%s) av\n"
 "poengtavlefila %s."
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Kan ikkje opna poengtavlefila %s: %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3194,7 +3207,7 @@ msgstr ""
 "til å bruka denne fila, eller spesifisera ei\n"
 "anna poengtavlefil med kommandolineopsjonen -f."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, fuzzy, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3209,7 +3222,7 @@ msgstr ""
 "fyrst konvertera henne til det nye formatet ved å køyra\n"
 "«Church Wars -C %s» frå kommandolina."
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 #, fuzzy
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
@@ -3220,7 +3233,7 @@ msgstr ""
 "av innstillingane ikkje vil virka som venta. Sjå på loggfila\n"
 "«Church Wars-log.txt» for fleire detaljar."
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
@@ -3230,132 +3243,132 @@ msgstr ""
 "av innstillingane ikkje vil virka som venta. Sjå på meldingane på\n"
 "standard-ut for fleire detaljar."
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Kan ikkje opna poengtavlefila %s: %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Kan ikkje lesa poengtavlefila %s"
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Gratulerar! Du kom på poengtavla!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Du kom ikkje ein gong på poengtavla..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Kan ikkje skriva til poengtavlefila %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(Kvil i fred.)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Dama attmed deg på t-banen sa^ «%s»%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (i det minste er det det du -trur- ho sa)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Du høyrer nokon som speler %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Vil du vitja %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Vil du hyra ei %tue for %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s er alt her!^Vil du gå til Angrep, eller Stikka av?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "Ingen politi eller våpen!"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "Politi kan ikkje gå til åtak på andre politi!"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "Spelarane er allereie i ein kamp!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "Spelarane er alt i kvar sine kampar!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Kan ikkje starta kamp - har ingen våpen!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Du er daud! Spelet er slutt."
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^vil du betala %P til ein doktor for å lappa deg saman?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Du vart rana på t-banen!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Du møter ein venn! Han gjev deg %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Du møter ein venn, og gjev han %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Luka vekk eit RandomOffer"
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
 msgstr ""
 "Politihundar jagar deg %d kvartal! Du mista litt %tde. Det er hardt, mann."
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Du finn %d %tde på ein daud kar på t-banen!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mora di laga sjokoladekjeks med litt av %tde. Dei var kjempegode!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3363,24 +3376,24 @@ msgstr ""
 "YN^Det er litt jazztobakk som luktar ugraskverk her.^Det ser bra ut! Vil du "
 "røyka det?"
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Du stoppa for å %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Vil du kjøpa ein større frakk for %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hei du! Eg kan hjelpa deg å bera %tde for berre %P. Ja eller nei?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Vil du kjøpa ein %tue for %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3388,29 +3401,29 @@ msgstr ""
 "Du hallusinerte i tre dagar på den villaste trippen du kunne^ forestilla "
 "deg! Så døydde du fordi hjernen din smuldra opp!"
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "For seint. %s har nett gått."
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr "Politiet ser at du kastar %tde!"
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Sender oppdateringar til metatenaren"
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr "Sender påminningsmelding til metatenaren..."
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Spelaren fjerna: Han/ho var ikkje aktiv"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Spelaren fjerna pga. tidsavbrot i sambandet"
 
@@ -3530,243 +3543,251 @@ msgstr "Intern metatenar-feil «%s»"
 msgid "Bad metaserver reply \"%s\""
 msgstr "Feil metatenar-svar «%s»"
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Kan ikkje starta opp WinSock (%s)!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Stikk du av?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Stikk du av, eller slåst du?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "Latterleg dårleg væpna"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "lett væpna"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "godt væpna"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "tungt væpna"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "væpna til tennene"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - spring etter deg!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s og %d %tde - %s - spring etter deg!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s kjem hit med %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s står og tek imot"
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Du står der som ein annan tulling."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s prøver å rømma, men får det ikkje til."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "Panikk! Du kjem deg ikkje vekk!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s har rømt til %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "%s kom seg unna!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "Du kom deg unna!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Våpna lada..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s skyt på %s... og bommar!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s skyt på deg...  og bommar!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "Du bomma på %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s drep %s."
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s skyt på %s og drep ei %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s er %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s skyt på deg... og drep ei %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "%s treff deg, mann!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "Du drap %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Du traff %s, og drap ei %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "Du traff %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr " Du finn %P på liket!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr "Du plyndrar liket!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr "Kan ikkje starta opp WinSock (%s)!"
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr "SOCKS server generell feil"
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr "Samband nekta av SOCKS-regelsett"
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr "SOCKS: Kan ikkje nå nettverket"
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr "SOCKS: Kan ikkje nå verten"
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr "Samband nekta"
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr "SOCKS: TTL gjekk ut"
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr "SOCKS: Kommandoen er ikkje støtta"
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr "SOCKS: Adressetypen er ikkje støtta"
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr "SOCKS-tenar avviste alle tilbudte metodar"
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr "Ukjend SOCKS-adressetype returnert"
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr "SOCKS-autentiserer feila"
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr "SOCKS-autentisering avbroten av brukar"
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr "SOCKS: Førespurnad vart avvist eller feila"
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr "SOCKS: Avslått - kan ikkje kontakta identd"
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr "SOCKS: Avslått - identd rapporterer ein annan brukaridentitet"
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr "Ukjend SOCKS svarkode"
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr "Ukjend SOCKS svar-versjon-kode"
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr "Ukjend SOCKS tenarversjon"
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr "SOCKS feilkode %d"
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3787,22 +3808,31 @@ msgstr ""
 "Samband oppretta. Bruk Ctrl-D for å stenga tilkoplinga.\n"
 "\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Kunne ikkje opna file %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Kunne ikkje opna file %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Kunne ikkje opna file %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr "Kunne ikkje finna ei lokal oppsettfil å skriva til"
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Kunne ikkje opna file %s: %s"
@@ -3842,116 +3872,121 @@ msgid ""
 msgstr ""
 "Bruker Socks.Auth.User og Socks.Auth.Password til SOCKS5-autentisering\n"
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "Datastyrt spelar starta. Prøver å kopla til tenaren på %s:%d."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "Kunne ikkje kopla til metatenaren på %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Datastyrt spelar avslutta OK.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Sambandet vart brote!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Bruker namnet %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Spelarar i denne runden:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s blir med i runden.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s har gått ut av spelet.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Reiser til %tde med %P i kontantar og %P i gjeld\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Datastyrt spelar vart drepen. Avsluttar normalt.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Speletida er ute. Avsluttar spelet.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "Datastyrt spelar vart dytta av tenaren.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "Tenaren har avslutta.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Sel %d %tde for %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Kjøper %d %tde for %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kjøper ein %tde for %P på våpenbutikken\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Gjeld på %P vart betalt til lånehaien\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Lånehaien er på %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Våpenforretninga er på %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Puben er på %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Banken er på %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Og de kallar drykk dopseljarar?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Ein trent apekatt kunne gjort det betre."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Trur du du er tøff nok til å takla slike som meg?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Sel du snop, eller kva?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Eg blir vel nøydd til å skyta deg til ditt eige beste."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3961,19 +3996,24 @@ msgstr ""
 "ikkje fungera som ein nettverksspelar.\n"
 "Kompiler på nytt med opsjonen --enable-networking til configure."
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "Klarte ikkje å opna fila %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "Kan ikkje henta metatenar-detaljar"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Kunne ikkje starta fleirspelar Church Wars"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Ugyldig modul «%s» vald.\n"
-"(%s tilgjengeleg, brukar «%s» no.)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "Klarte ikkje å opna fila %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Ugyldig modul «%s» vald.\n"
+#~ "(%s tilgjengeleg, brukar «%s» no.)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "Kommandoen som startar nettlesaren din"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2001-04-08 16:16+01000\n"
 "Last-Translator: Slawomir Molenda <jeszua@panda.bg.univ.gda.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -20,28 +20,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -49,580 +49,580 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "siedziba Złotych Pasów"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "bank"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Port do połączenia"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nazwa pliku z najlepszymi wynikami"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nazwa serwera do połączenia się"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr ""
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr ""
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr ""
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr ""
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr ""
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr ""
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr ""
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "Niezerowa wartość jeżeli serwer ma się kontaktować z metaserwerem"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nazwa metaserwera do wysyłania szczegółów o serwerze"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Preferowana nazwa hosta twojego serwera"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentyfikacja dla LocalName z metaserwerem"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Opis serwera, zgłaszany do metaserwera"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr ""
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr ""
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "Ilość tur (jeżeli 0, brak ograniczeń)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr ""
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr ""
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr ""
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr ""
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr ""
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Losowe zdarzenia umiarkowane"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr ""
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Tryb śledzenia dla pliku konfiguracji"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Ilość miejsc w grze"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr ""
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Ilość broni w grze"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Ilość narkotyków w grze"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Położenie Złotych Pasów"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Położenie banku"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Położenie ruskiego bazaru z bronią"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Położenie dyskoteki"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr ""
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr ""
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nazwa Złotych Pasów"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nazwa banku"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nazwa sklepu z bronią"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nazwa dyskoteki"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr ""
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr ""
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr ""
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr ""
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr ""
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr ""
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Rodzaj klucza sortującego dostępne narkotyki"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Ilość sekund na oddanie strzału"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Gracze są rozłączani po tej liczbie sekund"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Liczba sekund na nawiązanie połącznia albo zerwanie"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Maksymalna ilość połączeń TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Liczba sekund pomiędzy turami komputerowych graczy"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Ilość gotówki, z jaką gracz zaczyna"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Z jakim długiem zaczyna każdy gracz"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nazwa każdej lokacji"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Policja obecna w każdym miejscu (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Minimalna ilość dragów dla każdego miejsca"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Maksymalna ilość dragów dla każdego miejsca"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr ""
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr ""
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr ""
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr ""
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr ""
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr ""
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr ""
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nazwa poszczególnych narkotyków"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Minimalna cena każdego draga"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Maksymalna cena każdego draga"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Niezerowa wartość jeżeli ten drag ma być szczególnie tani"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Niezerowa wartość jeżeli ten drag ma być szczególnie drogi"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Wiadomość wyświetlana, gdy drag jest szczególnie tani"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Format używany dla drogich dragów przez 50% czasu"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Separator dla ceny szczególnie taniego draga"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Mnożnik dla szczególnie drogich dragów"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nazwa każdej lokacji"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Cena każdej broni"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Miejsce zajmowane przez poszczególną broń"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Obrażenia zadawane prze poszczególne bronie"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Słowo określające jednego \"kleryka\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Słowo określające dwóch lub więcej \"kleryków\""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Słowo określające jedną broń"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Słowo określające więcej broni"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Słowo określające jednego draga"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Słowo określające więcej dragów"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Koszt szpiegowania wroga przez kleryka"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Koszt donosu kleryka na wroga do glin"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Minimalna cena wynajęcia kleryka"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Maksymalna cena wynajęcia kleryka"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Lista rzeczy jakie słyszysz na dworcu"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Liczba komentarzy na dworcu"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Liczba piosenek, które możesz usłyszeć"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Liczba granych piosenek"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Lista rzeczy, które możesz przestać robić"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Liczba rzeczy, które możesz przestać robić"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -630,183 +630,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "Rynek jest pełen taniego, domowej roboty kwasu!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "Świeża dostawa marihuany z Holandii! Ceny trawy lecą w dół"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Wiadomość"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
 msgstr "Gliny zrobiły obławę na %tde ! Ceny towaru są kosmiczne!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
@@ -815,142 +815,142 @@ msgstr "Ćpuny kupują %tde po absurdalnych cenach!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Byłoby fajnie gdyby wszyscy wyszli na ulicę i się pieprzyli"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "Zażywasz-przegrywasz!"
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Hej cieciu, zwolnij trochę"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Po co ci mózg, jak masz dresy"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Wiesz, nie zawsze byłam kobietą"
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Masz niezły tyłek...chcesz się zabawić?"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "Wiesz, nie zawsze byłam kobietą"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Czy twoja stara wie, że jesteś dilerem?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "Co dziś wciągnąłeś?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Pan z Wołomina?"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Kiedyś też byłem śmieciem, tak ja ty."
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Nic się nie liczy oprócz pieniędzy"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "Niezły dres, widzę, że zarabiasz na tym gównie kupę szmalu"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Przypominasz mi zafajdanego ćpuna"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Odwagi! Zajaraj sobie i się wyluzujesz!"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Czy ja cie czasem nie widziałem w TV?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Wygramy tę wojnę o narkotyki!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Dzień bez prochów jest jak noc"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr "Używamy tylko 10% naszego mózgu, czemu nie zjarać reszty?"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Zbieram datki na Kościół Zombich Chrystusa"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Sprzedać ci trochę pyłku kosmicznego?"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Zwycięzcy nie używają dragów...dopóki są zwycięzcami"
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Jezus kocha cię bardziej ode mnie"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "Chcesz landrynkę kotku?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr ""
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr ""
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -960,40 +960,40 @@ msgstr ""
 "żaden z graczy nie jest zalogowany. Zaczekaj, aż wszyscy się wylogują\n"
 "lub usuń ich komendami \"push\" albo \"kill\" i spróbuj jeszcze raz."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Indeks w tablicy %s powinien być pomiędzy 1 i %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s jest %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s jest %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s jest %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s jest \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] jest %s\n"
@@ -1001,66 +1001,64 @@ msgstr "%s[%d] jest %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s jest { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr ""
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Zmieniono strukturę listy do %d elementów\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr ""
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
 msgstr ""
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
 msgstr ""
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr ""
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Serwer zakończył pracę."
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1075,7 +1073,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1135,7 +1133,7 @@ msgstr ""
 "Church Wars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1145,9 +1143,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1160,7 +1156,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1211,7 +1207,7 @@ msgstr ""
 "Church Wars (C) Ben Webb 1998-2000, publikowane zgodnie z GNU GPL\n"
 "Wszelkie błędy wysyłaj na adres autora benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1221,7 +1217,7 @@ msgid ""
 "Report bugs to the author at benwebb@users.sf.net\n"
 msgstr ""
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1231,7 +1227,7 @@ msgstr ""
 "opcję --enable-curses-client to pliku konfigurancyjnego, albo użyj\n"
 "zamiast tego okienkowej wersji klienta (jeżeli jest dostępny).\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1241,7 +1237,7 @@ msgstr ""
 "--enable-gui-client do skryptu konfiguracyjnego, albo użyj\n"
 "zamiast tego (jeżeli jest dostępny) klienta opartego na curses.\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1249,7 +1245,7 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1257,150 +1253,155 @@ msgid ""
 "script.\n"
 msgstr ""
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Tłumaczenie na polski         Slawomir Molenda"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D R E S S   W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
 msgstr ""
 "Oparte są na starej grze `Drug Wars` Johna E. Dell'a. Jest to symulacja "
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr "rynku narkotykowego z takimi elementami jak kupowanie, sprzedawanie "
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "i próby ucieczki od gliniarzy."
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
 "Collector. After"
 msgstr "Najpierw musisz spłacić dług Złotym Pasom. Potem twoim celem jest"
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr "zarobienie tak dużo forsy, jak się da i pozostanie przy życiu!"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "Masz jeden miesiąc na zdobycie fortuny."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Wersja %-8s Copyright (C) 1998-2022 Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "  Church Wars są publikowane zgodnie z GNU General Public License"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr ""
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Testowanie gry                Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Ekstensywne testowanie gry    Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Niekonstruktywna krytyka      James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Niekonstruktywna krytyka      James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr "Informacje o komendach linni poleceń uzyskasz pisząc Church Wars -h po"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr "  twoim znaku zachęty. To wyświetli ekran pomocy z dostępnym opcjami."
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Wprowadź nazwę hosta i port serwera Church Wars:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Nazwa hosta: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Port: "
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Proszę czekać... próba kontaktu z metaserwerem..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Serwer : %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Port:  : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Wersja     : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Gracze: -nieznani- (maksymalnie %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Gracze: %d (maksymalnie %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "Od        : %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Komentarz: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "N>astępny serwer; P>oprzedni serwer; W>ybierz ten serwer... "
 
@@ -1408,210 +1409,199 @@ msgstr "N>astępny serwer; P>oprzedni serwer; W>ybierz ten serwer... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "NPW"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr ""
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr ""
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Proszę czekać... próba kontaktu z serwerem Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr ""
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Nie mogę wystartować trybu multiplayer"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr ""
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Chcesz... P>ołączyć się z innym hostem i/lub portem"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "          Z>obaczyć listę serwerów na metaserwerze i wybrać jeden"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "          W>yjść (możesz uruchomić serwer pisząc "
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "          G>rać w trybie single-player"
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "PZWG"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Dokąd jedziesz ? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Nie dostaniesz forsy za to ci niesiesz %tde :"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "Co chcesz zostawić? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Ile chcesz zostawić? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "Co chcesz kupić? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "Co chcesz sprzedać? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Stać cię na %d, a możesz unieść %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Ile kupujesz? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Posiadasz %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Ile sprzedajesz? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Na pewno chcesz wyjść? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "YN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Nowe imię: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Zostałeś wyrzucony z serwera. Włączenie trybu dla jednego gracza."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "Serwer został zatrzymany. Włączenie trybu dla jednego gracza."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s dołączył do gry!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s opuścił grę."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s będzie teraz znany jako %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "N A J L E P S Z E   W Y N I K I"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Nie masz żadnej %tde do sprzedania!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Nie masz nic do opchnięcia!"
 
@@ -1619,27 +1609,27 @@ msgstr "Nie masz nic do opchnięcia!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Będziesz potrzebował więcej %tde aby jeszcze unieść %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Nie masz wystarczająco dużo miejsca, aby unieść tę %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Nie masz tyle kasy na %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "K>upić, S>przedać, czy W>yjść? "
 
@@ -1647,41 +1637,41 @@ msgstr "K>upić, S>przedać, czy W>yjść? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "KSW"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Ile forsy oddajesz Złotym Pasom? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "Nie masz tak dużo kasy!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Zamierzasz Z>deponować, W>ycofać gotówkę czy O>puścić bank? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "ZWO"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Ile kasy? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "Nie ma tyle gotówki w banku..."
 
@@ -1689,47 +1679,47 @@ msgstr "Nie ma tyle gotówki w banku..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "T:Tak"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Nie"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "U:Uciekasz"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "A:Atak"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Atakuj"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "E:Ewakuuj się"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Naciśnij dowolny klawisz..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Statystyka"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Kasa"
 
@@ -1737,41 +1727,41 @@ msgstr "Kasa"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr ""
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Zdrowie"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Bank"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Debet"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Miejsce %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Miejsce %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Twój płaszcz"
 
@@ -1779,158 +1769,164 @@ msgstr "Twój płaszcz"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr ""
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr ""
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Nie ma aktualnie innych zalogowanych graczy!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Gracze aktualnie zalogowani:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Hej cieciu, oto %tde jakie są w obiegu:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Jak się nazywasz cieciu? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "K>up"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr " S>przedaj"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr " U>puść"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr " G>adaj P>owiedz "
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr " Z>obacz"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr " A>takuj"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr " J>edź"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr " W>yjście"
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Czy "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "A>takujesz"
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "S>toisz, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "U>ciekasz, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "D>ilujesz %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "czy W>yjście "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Połączenie z serwerem zerwane! Włączenie trybu dla jednego gracza"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "KSUGPZDAJW"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "DUASW"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Co chcesz zobaczyć? G>raczy W>yniki"
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "GW"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Nie można obłużyć potoku!"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Grasz jeszcze raz? "
 
@@ -2020,8 +2016,8 @@ msgid "Inventory"
 msgstr "Plecak"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Zamknij"
 
@@ -2197,13 +2193,13 @@ msgstr ""
 msgid "Drop how many?"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2261,54 +2257,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Tłumaczenie na polski"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Dilowanie dragami i rozwój"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Testowanie gry"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Ekstensywne testowanie gry"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Konstruktywna krytyka"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Niekonstruktywna krytyka"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2336,7 +2332,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2345,134 +2341,135 @@ msgstr ""
 "Wersja %s    Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars są publikowane zgodnie z GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr ""
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Nie ma tyle gotówki w banku..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Kasa: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Debet: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Bank %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Zwróć:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Depozyt"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Wycofaj się"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Spłać wszystko"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Lista graczy"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Mów do gracza(y)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Mów do wszystkich graczy"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Wiadomość:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Wyślij"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nazwa"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Cena"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Ilość"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Kup ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Sprzedaj"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Zostaw <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde na rynku"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde w plecaku"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Zmień nicka"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2480,12 +2477,12 @@ msgstr "Niestety jakiś cieć używa już twojego nicka. Zmień go."
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr ""
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2752,7 +2749,7 @@ msgstr ""
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
@@ -2761,39 +2758,39 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "Serwer zakończył pracę."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2833,27 +2830,27 @@ msgstr ""
 "Prawidłowe zmienne są poniżej:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr ""
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Metaserwer : %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr ""
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2861,21 +2858,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClients (%d) przekoroczona wartość - zrywam połączenie"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2885,7 +2882,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2897,220 +2894,235 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s będzie znany jako %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: ZABRONIONY przejazd do %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Twój czas dilerki dobiegł końca..."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: ZABRONIONY przejazd do %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr ""
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Używam pliku %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Nie można utworzyć pliku pid %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
-msgstr ""
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
+msgstr "Nie można utworzyć pliku pid %s: %s"
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr ""
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
+msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
 #: src/serverside.c:769
+#, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr ""
+
+#: src/serverside.c:778
+msgid "Cannot listen to network socket."
+msgstr ""
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
 msgstr "serwer Church Wars w wersji %s gotowy i oczekuje połączeńna porcie %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGUSR1!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGHUP!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGINT!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Nie można obsłużyć przerwania SIGTERM!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Nie można obłużyć potoku!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr ""
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Użytkownicy aktualnie zalogowani:=\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Nie ma żadnych zalogowanych użytkowników\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Wywalam %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Nie ma takiego użytkownika!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s zabity\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Nieznana komenda - spróbuj \"help\",aby uzyskać pomoc...\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "połączenie z %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "Serwer zakończył pracę."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s opuszcza serwer!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr ""
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
 msgstr "serwer Church Wars w wersji %s gotowy i oczekuje połączeńna porcie %d."
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr ""
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr ""
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr ""
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr ""
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Nie można odczytać pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Nie można utworzyć pliku pid %s: %s"
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
 "high score file: %s."
 msgstr ""
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr ""
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3122,7 +3134,7 @@ msgstr ""
 "Upewnij się, że masz dostęp do pliku i katalogu, albo podaj nazwę\n"
 "alternatywnego pliku poprzez opcję -f z linni poleceń."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3132,129 +3144,129 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Nie można odczytać pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Gratulacje! Wpiszesz się na karty historii!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Nawet się nie wpiszesz, cieniasie..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr ""
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "Jakaś kobieta stojąca obok na dworcu powiedziała^\"%s\"%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (tak ci się przynajmniej wydaje, że TO powiedziała)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Słyszysz jak ktoś puszcza %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Chciałbyś odwiedzić %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Chciałbyś wynająć %tde za %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s już tu jest!^A>takujesz czy E>wakuujesz się?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr ""
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr ""
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr ""
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr ""
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr ""
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr ""
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr "YN^Płacisz doktorowi %P, żeby cię pozszywał?"
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Zostałeś obrzygany w pociągu!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Spotykasz starego dilera! Daje ci %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Spotkałeś przyjaciela! Dajesz mu %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Wyłączono RandomOffer"
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3262,17 +3274,17 @@ msgstr ""
 "Policyjne psy skoczyły ci do gardła %d! Upuściłeś jakieś %tde! Ale "
 "rozpierdol!dresie!"
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Znalazłeś %d %tde przy zwłokach jakiegoś ćpuna w WC!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Mamuśka zrobiła ci kanapki z odrobiną %tde! Były super!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
@@ -3280,24 +3292,24 @@ msgstr ""
 "YN^Znalazłeś trochę ziela, które pachnie tak świeżo!^Dobrze wygląda! "
 "Zapalisz? "
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Zatrzymujesz się i %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Chciałbyć kupić większy płaszcz za %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr "YN^Hej koleś! Pomogę ci ponieść %tde za jedyne %P. Zgadzasz się?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Chciałbyś kupić %tde za %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3305,29 +3317,29 @@ msgstr ""
 "Miałeś haluny przez trzy dni i najlepszego tripa w swoim życiu!^Potem "
 "umarłeś, bo dla twojego mózga ta wycieczka była za mocna!"
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Za późno - %s właśnie zwiał!"
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Gracz usunięty przez przekroczenie czasu na ruch"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Gracz usunięty przez przekroczenia czasu przy połączeniu"
 
@@ -3447,243 +3459,251 @@ msgstr ""
 msgid "Bad metaserver reply \"%s\""
 msgstr ""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr ""
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Nie można obłużyć potoku!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Uciekasz?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Uciekasz czy Atakujesz?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "beznadziejnie uzbrojony"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "lekko uzbrojony"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "całkiem nieźle uzbrojony"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "dobrze uzbrojony"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "kurewsko uzbrojony po zęby"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr ""
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr ""
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s przybył, z %d %tde, %s"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s stoi i dostaje."
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Stoisz tam jak idiota."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr ""
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
-msgstr ""
-
-#: src/message.c:1362
-#, c-format
-msgid "%s has got away to %tde!"
-msgstr "%s zwiał do %tde!"
-
-#: src/message.c:1365
-#, c-format
-msgid "%s has got away!"
-msgstr "%s zwiał!"
-
-#: src/message.c:1368
-msgid "You got away!"
-msgstr ""
-
-#: src/message.c:1374
-msgid "Weapons readied..."
-msgstr ""
-
-#: src/message.c:1379
-#, c-format
-msgid "%s attacks %s... and fails!"
-msgstr ""
-
-#: src/message.c:1382
-#, c-format
-msgid "%s swings at you... and misses!"
-msgstr ""
-
-#: src/message.c:1385
-#, c-format
-msgid "You missed %s!"
-msgstr ""
-
-#: src/message.c:1391
-#, c-format
-msgid "%s charges %s to death."
-msgstr ""
-
-#: src/message.c:1394
-#, c-format
-msgid "%s attacks at %s and kills a %tde!"
-msgstr ""
-
-#: src/message.c:1397
-#, c-format
-msgid "%s attacks %s."
-msgstr "%s jest %s"
-
-#: src/message.c:1402
-#, c-format
-msgid "%s killed you! The Angels carry you home."
-msgstr ""
-
-#: src/message.c:1406
-#, c-format
-msgid "%s charges at you... and kills a %tde!"
 msgstr ""
 
 #: src/message.c:1409
 #, c-format
+msgid "%s has got away to %tde!"
+msgstr "%s zwiał do %tde!"
+
+#: src/message.c:1412
+#, c-format
+msgid "%s has got away!"
+msgstr "%s zwiał!"
+
+#: src/message.c:1415
+msgid "You got away!"
+msgstr ""
+
+#: src/message.c:1421
+msgid "Weapons readied..."
+msgstr ""
+
+#: src/message.c:1426
+#, c-format
+msgid "%s attacks %s... and fails!"
+msgstr ""
+
+#: src/message.c:1429
+#, c-format
+msgid "%s swings at you... and misses!"
+msgstr ""
+
+#: src/message.c:1432
+#, c-format
+msgid "You missed %s!"
+msgstr ""
+
+#: src/message.c:1438
+#, c-format
+msgid "%s charges %s to death."
+msgstr ""
+
+#: src/message.c:1441
+#, c-format
+msgid "%s attacks at %s and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1444
+#, c-format
+msgid "%s attacks %s."
+msgstr "%s jest %s"
+
+#: src/message.c:1449
+#, c-format
+msgid "%s killed you! The Angels carry you home."
+msgstr ""
+
+#: src/message.c:1453
+#, c-format
+msgid "%s charges at you... and kills a %tde!"
+msgstr ""
+
+#: src/message.c:1456
+#, c-format
 msgid "%s hits you!"
 msgstr ""
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "Trafisz i zabijasz %s"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr ""
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr ""
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr ""
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr ""
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr ""
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3700,22 +3720,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Nie można zapisać do pliku z najlepszymi wynikami %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Nie można utworzyć pliku pid %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Nie można utworzyć pliku pid %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr ""
@@ -3754,116 +3783,120 @@ msgid ""
 "Using Socks.Auth.User and Socks.Auth.Password for SOCKS5 authentication\n"
 msgstr ""
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "Gracz AI rozpoczął grę; próba kontaktu z serwerem %s:%d..."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+msgid "Failed to connect to server; cleaning up."
+msgstr ""
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Gracz AI zakończył rozgrywkę.\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Połączenie z serwerem przerwane!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Używa imienia %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Gracze w grze:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s dołączył do gry.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s opuścił grę.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Jedziesz do %tde z %P kasą i %P debetem\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Gracz AI zabity. Normalne wyjście.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Czas gry się skończył. Opuszczam grę.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "Gracz AI wyrzucony z serwera.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "Serwer zakończył pracę.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Sprzedaję %d %tde w %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Kupuję %d %tde w %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Kupuję %tde za %P na ruskim bazarze z bronią\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Dług %P został spłacony Złotym Pasom\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Siedziba Złotych Pasów jest w mieście %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Sklep z bronią jest w mieście %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Dyskoteka jest w mieście %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Bank jest w mieście %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Nazywacie się dilerami?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Wytrenowana małpa zrobiłaby to lepiej..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Myślisz, że jesteś taki twardy, aby ze mną dilować?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... dilujesz cukiereczku czy co?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Uważam, że powiniennem cię zastrzelić dla twojego własnego dobra."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3873,17 +3906,9 @@ msgstr ""
 "jakby był komputerowym graczem.\n"
 "Skonfiguruj z opcją --enable-networking i przekompiluj"
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr ""
-
-#: src/sound.c:229
-#, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Nie mogę wystartować trybu multiplayer"
 
 #~ msgid "Whom do you want to page (talk privately to) ? "
 #~ msgstr "Do kogo prywatnie zagadujesz ? "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Church Wars-1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 15:14+0000\n"
+"POT-Creation-Date: 2025-08-15 06:28+0000\n"
 "PO-Revision-Date: 2022-06-10 23:06-0300\n"
 "Last-Translator: Bruno Lopes <brunoml@bol.com.br>\n"
 "Language-Team: Portuguese/Brazil <pt_BR@li.org>\n"
@@ -21,28 +21,28 @@ msgstr ""
 #. object) then read doc/i18n.html about the %tde (etc.) notation. N.B.
 #. This notation can be used for most of the translatable strings in
 #. dopewars.
-#: src/dopewars.c:181
+#: src/dopewars.c:199
 msgid "cleric"
 msgstr ""
 
 #. Word used for two or more clerics
-#: src/dopewars.c:183
+#: src/dopewars.c:201
 msgid "clerics"
 msgstr ""
 
 #. Word used for a single gun
-#: src/dopewars.c:185
+#: src/dopewars.c:203
 msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
-#: src/dopewars.c:187
+#: src/dopewars.c:205
 msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
 #. Word used for two or more drugs
-#: src/dopewars.c:189 src/dopewars.c:191
+#: src/dopewars.c:207 src/dopewars.c:209
 msgid "goods"
 msgstr ""
 
@@ -50,580 +50,580 @@ msgstr ""
 #. to the strftime() function, with the exception that %T is used to
 #. mean the turn number rather than the calendar date.
 #. N_("%m-%d-%Y"),
-#: src/dopewars.c:196
+#: src/dopewars.c:214
 msgid "Turn %T"
 msgstr ""
 
 #. Names of the loan shark, the bank, the gun shop, and the pub,
 #. respectively
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Loan Collector"
 msgstr "o agiota"
 
-#: src/dopewars.c:199
+#: src/dopewars.c:217
 msgid "the Merchant Bank"
 msgstr "o Banco"
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "the Hall of Arms"
 msgstr ""
 
-#: src/dopewars.c:200
+#: src/dopewars.c:218
 msgid "Holy Mass"
 msgstr ""
 
 #. The following strings are the helptexts for all the options that can
 #. be set in a dopewars configuration file, or in the server. See
 #. doc/configfile.html for more detailed explanations.
-#: src/dopewars.c:241
+#: src/dopewars.c:259
 msgid "Network port to connect to"
 msgstr "Porta de rede para conectar"
 
-#: src/dopewars.c:244
+#: src/dopewars.c:262
 msgid "Name of the high score file"
 msgstr "Nome do arquivo de pontuação"
 
-#: src/dopewars.c:247
+#: src/dopewars.c:265
 msgid "Name of the server to connect to"
 msgstr "Nome do servidor para conectar"
 
-#: src/dopewars.c:250
+#: src/dopewars.c:268
 msgid "Server's welcome message of the day"
 msgstr "Mensagem de boas vindas do dia no servidor"
 
-#: src/dopewars.c:253
+#: src/dopewars.c:271
 msgid "Network address for the server to listen on"
 msgstr "Endereço de rede para em que o servidor aguardará conexões"
 
-#: src/dopewars.c:257
+#: src/dopewars.c:275
 msgid "TRUE if a SOCKS server should be used for networking"
 msgstr "TRUE se um servidor SOCKS deve ser usado para conectar à rede"
 
-#: src/dopewars.c:261
+#: src/dopewars.c:279
 msgid "TRUE if numeric user IDs should be used for SOCKS4"
 msgstr "TRUE se IDs numéricos de usuário devem ser usados para SOCKS4"
 
-#: src/dopewars.c:265
+#: src/dopewars.c:283
 msgid "If not blank, the username to use for SOCKS4"
 msgstr "Se não em branco, será o nome de usuário a usar para SOCKS4"
 
-#: src/dopewars.c:268
+#: src/dopewars.c:286
 msgid "The hostname of a SOCKS server to use"
 msgstr "O hostname do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:271
+#: src/dopewars.c:289
 msgid "The port number of a SOCKS server to use"
 msgstr "O número da porta do servidor SOCKS a ser usado"
 
-#: src/dopewars.c:274
+#: src/dopewars.c:292
 msgid "The version of the SOCKS protocol to use (4 or 5)"
 msgstr "A versão do protocolo SOCKS a usar (4 ou 5)"
 
-#: src/dopewars.c:277
+#: src/dopewars.c:295
 msgid "Username for SOCKS5 authentication"
 msgstr "Nome de usuário para autenticação SOCKS5"
 
-#: src/dopewars.c:280
+#: src/dopewars.c:298
 msgid "Password for SOCKS5 authentication"
 msgstr "Senha para autenticação SOCKS5"
 
-#: src/dopewars.c:283
+#: src/dopewars.c:301
 msgid "TRUE if server should report to a metaserver"
 msgstr "Não-zero se o servidor deve reportar ao servidor meta"
 
-#: src/dopewars.c:286
+#: src/dopewars.c:304
 msgid "Metaserver URL to report/get server details to/from"
 msgstr "Nome do meta-servidor para reportar/obter os detalhes do servidor"
 
-#: src/dopewars.c:289
+#: src/dopewars.c:307
 msgid "Preferred hostname of your server machine"
 msgstr "Nome do host preferido para a sua máquina servidor"
 
-#: src/dopewars.c:292
+#: src/dopewars.c:310
 msgid "Authentication for LocalName with the metaserver"
 msgstr "Autentificação para o NomeLocal com o servidor meta"
 
-#: src/dopewars.c:295
+#: src/dopewars.c:313
 msgid "Server description, reported to the metaserver"
 msgstr "Descrição do servidor, reportado para o servidor meta"
 
-#: src/dopewars.c:300
+#: src/dopewars.c:318
 msgid "If TRUE, the server minimizes to the System Tray"
 msgstr "Se TRUE, o servidor minimiza a Barra do Sistema"
 
-#: src/dopewars.c:304
+#: src/dopewars.c:322
 msgid "If TRUE, the server runs in the background"
 msgstr "Se TRUE, o servidor executa em background"
 
-#: src/dopewars.c:308
+#: src/dopewars.c:326
 msgid "No. of game turns (if 0, game never ends)"
 msgstr "No. de turnos do jogo (se 0, o jogo nunca acaba)"
 
-#: src/dopewars.c:311
+#: src/dopewars.c:329
 msgid "Day of the month on which the game starts"
 msgstr "Dia do mês em que o jogo inicia"
 
-#: src/dopewars.c:314
+#: src/dopewars.c:332
 msgid "Month in which the game starts"
 msgstr "Mês em que o jogo inicia"
 
-#: src/dopewars.c:317
+#: src/dopewars.c:335
 msgid "Year in which the game starts"
 msgstr "Ano em que o jogo inicia"
 
-#: src/dopewars.c:320
+#: src/dopewars.c:338
 msgid "The currency symbol (e.g. $)"
 msgstr ""
 
-#: src/dopewars.c:323
+#: src/dopewars.c:341
 msgid "If TRUE, the currency symbol precedes prices"
 msgstr ""
 
-#: src/dopewars.c:326
+#: src/dopewars.c:344
 msgid "File to write log messages to"
 msgstr "Arquivo onde escrever mensagens de log"
 
-#: src/dopewars.c:329
+#: src/dopewars.c:347
 msgid "Controls the number of log messages produced"
 msgstr "Controla o número de mensagens de log produzidas"
 
-#: src/dopewars.c:332
+#: src/dopewars.c:350
 msgid "strftime() format string for log timestamps"
 msgstr "String de formato strftime() para timestamps de log"
 
-#: src/dopewars.c:335
+#: src/dopewars.c:353
 msgid "Random events are sanitized"
 msgstr "Eventos aleatórios são censurados"
 
-#: src/dopewars.c:338
+#: src/dopewars.c:356
 msgid "TRUE if the value of bought drugs should be saved"
 msgstr "Não-zero se o valor das drogas compradas devem ser salvos"
 
-#: src/dopewars.c:341
+#: src/dopewars.c:359
 msgid "Be verbose in processing config file"
 msgstr "Mostrar mensagens processando o arquivo de configuração"
 
-#: src/dopewars.c:344
+#: src/dopewars.c:362
 msgid "Number of locations in the game"
 msgstr "Quantidade de locais no jogo"
 
-#: src/dopewars.c:348
+#: src/dopewars.c:366
 msgid "Number of types of cop in the game"
 msgstr "Número de tipos de policiais no jogo"
 
-#: src/dopewars.c:352
+#: src/dopewars.c:370
 msgid "Number of guns in the game"
 msgstr "Número de armas no jogo"
 
-#: src/dopewars.c:356
+#: src/dopewars.c:374
 msgid "Number of drugs in the game"
 msgstr "Número de drogas no jogo"
 
-#: src/dopewars.c:360
+#: src/dopewars.c:378
 msgid "Location of the Loan Shark"
 msgstr "Localização do agiota"
 
-#: src/dopewars.c:362
+#: src/dopewars.c:380
 msgid "Location of the bank"
 msgstr "Localização do banco"
 
-#: src/dopewars.c:365
+#: src/dopewars.c:383
 msgid "Location of the gun shop"
 msgstr "Localização da loja de armas"
 
-#: src/dopewars.c:368
+#: src/dopewars.c:386
 msgid "Location of the pub"
 msgstr "Localização do bordel"
 
-#: src/dopewars.c:371
+#: src/dopewars.c:389
 msgid "Daily interest rate on the loan shark debt"
 msgstr "Juros diários na dívida do agiota"
 
-#: src/dopewars.c:374
+#: src/dopewars.c:392
 msgid "Daily interest rate on your bank balance"
 msgstr "Juros diários em sua poupança"
 
-#: src/dopewars.c:377
+#: src/dopewars.c:395
 msgid "Name of the loan shark"
 msgstr "Nome do agiota"
 
-#: src/dopewars.c:379
+#: src/dopewars.c:397
 msgid "Name of the bank"
 msgstr "Nome do banco"
 
-#: src/dopewars.c:381
+#: src/dopewars.c:399
 msgid "Name of the gun shop"
 msgstr "Nome da loja de armas"
 
-#: src/dopewars.c:383
+#: src/dopewars.c:401
 msgid "Name of the pub"
 msgstr "Nome do bordel"
 
-#: src/dopewars.c:385
+#: src/dopewars.c:403
 msgid "TRUE if sounds should be enabled"
 msgstr "TRUE se sons devem ser habilitados"
 
-#: src/dopewars.c:388
+#: src/dopewars.c:406
 msgid "Sound file played for a gun \"hit\""
 msgstr "Arquivo de som tocado para um tiro que acerta o alvo"
 
-#: src/dopewars.c:391
+#: src/dopewars.c:409
 msgid "Sound file played for a gun \"miss\""
 msgstr "Arquivo de som tocado quando um tiro erra o alvo"
 
-#: src/dopewars.c:394
+#: src/dopewars.c:412
 msgid "Sound file played when guns are reloaded"
 msgstr "Arquivo de som tocado quando armas são recarregadas"
 
-#: src/dopewars.c:397
+#: src/dopewars.c:415
 msgid "Sound file played when an enemy cleric/deputy is killed"
 msgstr ""
 
-#: src/dopewars.c:400
+#: src/dopewars.c:418
 msgid "Sound file played when one of your clerics is killed"
 msgstr ""
 
-#: src/dopewars.c:403
+#: src/dopewars.c:421
 msgid "Sound file played when another player or cop is killed"
 msgstr ""
 
-#: src/dopewars.c:406
+#: src/dopewars.c:424
 msgid "Sound file played when you are killed"
 msgstr "Arquivo de som tocado quando você é morto"
 
-#: src/dopewars.c:409
+#: src/dopewars.c:427
 msgid "Sound file played when a player tries to escape, but fails"
 msgstr ""
 
-#: src/dopewars.c:412
+#: src/dopewars.c:430
 msgid "Sound file played when you try to escape, but fail"
 msgstr ""
 
-#: src/dopewars.c:415
+#: src/dopewars.c:433
 msgid "Sound file played when a player successfully escapes"
 msgstr ""
 
-#: src/dopewars.c:418
+#: src/dopewars.c:436
 msgid "Sound file played when you successfully escape"
 msgstr ""
 
-#: src/dopewars.c:421
+#: src/dopewars.c:439
 msgid "Sound file played on arriving at a new location"
 msgstr "Arquivo de som tocado ao chegar em um novo local"
 
-#: src/dopewars.c:424
+#: src/dopewars.c:442
 msgid "Sound file played when a player joins the game"
 msgstr ""
 
-#: src/dopewars.c:427
+#: src/dopewars.c:445
 msgid "Sound file played when a player leaves the game"
 msgstr ""
 
-#: src/dopewars.c:430
+#: src/dopewars.c:448
 msgid "Sound file played at the start of the game"
 msgstr ""
 
-#: src/dopewars.c:433
+#: src/dopewars.c:451
 msgid "Sound file played at the end of the game"
 msgstr ""
 
-#: src/dopewars.c:436
+#: src/dopewars.c:454
 msgid "Sort key for listing available drugs"
 msgstr "Teclas de ordenação para a listagem de drogas disponíveis"
 
-#: src/dopewars.c:439
+#: src/dopewars.c:457
 msgid "No. of seconds in which to return fire"
 msgstr "Número de segundos em para revidar tiro"
 
-#: src/dopewars.c:442
+#: src/dopewars.c:460
 msgid "Players are disconnected after this many seconds"
 msgstr "Jogadores são desconectados depois destes segundos"
 
-#: src/dopewars.c:445
+#: src/dopewars.c:463
 msgid "Time in seconds for connections to be made or broken"
 msgstr "Tempo em segundos para conexões a serem feitas ou quebradas"
 
-#: src/dopewars.c:448
+#: src/dopewars.c:466
 msgid "Maximum number of TCP/IP connections"
 msgstr "Número máximo de conexões TCP/IP"
 
-#: src/dopewars.c:451
+#: src/dopewars.c:469
 msgid "Seconds between turns of AI players"
 msgstr "Segundos entre turnos dos jogadores IA"
 
-#: src/dopewars.c:454
+#: src/dopewars.c:472
 msgid "Amount of cash that each player starts with"
 msgstr "Quantidade de dinheiro que cada jogador começa"
 
-#: src/dopewars.c:457
+#: src/dopewars.c:475
 msgid "Amount of debt that each player starts with"
 msgstr "Quantidade de débito que cada jogador começa"
 
-#: src/dopewars.c:460
+#: src/dopewars.c:478
 msgid "Name of each location"
 msgstr "Nome de cada local"
 
-#: src/dopewars.c:464
+#: src/dopewars.c:482
 msgid "Police presence at each location (%)"
 msgstr "Polícia presente em cada local (%)"
 
-#: src/dopewars.c:468
+#: src/dopewars.c:486
 msgid "Minimum number of drugs at each location"
 msgstr "Número mínimo de drogas em cada local"
 
-#: src/dopewars.c:472
+#: src/dopewars.c:490
 msgid "Maximum number of drugs at each location"
 msgstr "Número máximo de drogas em cada local"
 
-#: src/dopewars.c:476 src/dopewars.c:479
+#: src/dopewars.c:494 src/dopewars.c:497
 msgid "% resistance to gunshots of each player"
 msgstr ""
 
-#: src/dopewars.c:482 src/dopewars.c:485
+#: src/dopewars.c:500 src/dopewars.c:503
 msgid "% resistance to gunshots of each cleric"
 msgstr ""
 
-#: src/dopewars.c:488
+#: src/dopewars.c:506
 msgid "Name of each cop"
 msgstr "Nome de cada policial"
 
-#: src/dopewars.c:492
+#: src/dopewars.c:510
 msgid "Name of each cop's deputy"
 msgstr "Nome de cada ajudante do policial"
 
-#: src/dopewars.c:496
+#: src/dopewars.c:514
 msgid "Name of each cop's deputies"
 msgstr "Nome dos ajudantes do policial"
 
-#: src/dopewars.c:500 src/dopewars.c:504
+#: src/dopewars.c:518 src/dopewars.c:522
 msgid "% resistance to gunshots of each cop"
 msgstr ""
 
-#: src/dopewars.c:508 src/dopewars.c:512
+#: src/dopewars.c:526 src/dopewars.c:530
 msgid "% resistance to gunshots of each deputy"
 msgstr ""
 
-#: src/dopewars.c:516
+#: src/dopewars.c:534
 msgid "Attack penalty relative to a player"
 msgstr "Valor relativo de ataque para o jogador"
 
-#: src/dopewars.c:520
+#: src/dopewars.c:538
 msgid "Defend penalty relative to a player"
 msgstr "Valor relativo de defesa para o jogador"
 
-#: src/dopewars.c:524
+#: src/dopewars.c:542
 msgid "Minimum number of accompanying deputies"
 msgstr "Número mínimo de ajudantes acompanhantes"
 
-#: src/dopewars.c:528
+#: src/dopewars.c:546
 msgid "Maximum number of accompanying deputies"
 msgstr "Número máximo de ajudantes acompanhantes"
 
-#: src/dopewars.c:532
+#: src/dopewars.c:550
 msgid "Zero-based index of the gun that cops are armed with"
 msgstr "Índice baseado-em-zero da arma que os policiais estão armados"
 
-#: src/dopewars.c:536
+#: src/dopewars.c:554
 msgid "Number of guns that each cop carries"
 msgstr "Número de armas que cada policial carrega"
 
-#: src/dopewars.c:540
+#: src/dopewars.c:558
 msgid "Number of guns that each deputy carries"
 msgstr ""
 
-#: src/dopewars.c:544
+#: src/dopewars.c:562
 msgid "Name of each drug"
 msgstr "Nome de cada droga"
 
-#: src/dopewars.c:548
+#: src/dopewars.c:566
 msgid "Minimum normal price of each drug"
 msgstr "Preço mínimo normal de cada droga"
 
-#: src/dopewars.c:552
+#: src/dopewars.c:570
 msgid "Maximum normal price of each drug"
 msgstr "Preço máximo normal de cada droga"
 
-#: src/dopewars.c:556
+#: src/dopewars.c:574
 msgid "TRUE if this drug can be specially cheap"
 msgstr "Não-zero se esta droga pode ser especialmente barata"
 
-#: src/dopewars.c:560
+#: src/dopewars.c:578
 msgid "TRUE if this drug can be specially expensive"
 msgstr "Não-zero se esta droga pode ser especialmente cara"
 
-#: src/dopewars.c:564
+#: src/dopewars.c:582
 msgid "Message displayed when this drug is specially cheap"
 msgstr "Mensagem mostrada quando esta droga é especialmente barata"
 
-#: src/dopewars.c:568 src/dopewars.c:572
+#: src/dopewars.c:586 src/dopewars.c:590
 #, no-c-format
 msgid "Format string used for expensive drugs 50% of time"
 msgstr "Formato da string usada para drogas caras em 50% do tempo"
 
-#: src/dopewars.c:575
+#: src/dopewars.c:593
 msgid "Divider for drug price when it's specially cheap"
 msgstr "Divisor para os preços da droga especialmente barata"
 
-#: src/dopewars.c:579
+#: src/dopewars.c:597
 msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para para os preços da droga especialmente cara"
 
-#: src/dopewars.c:582
+#: src/dopewars.c:600
 msgid "Name of each weapon"
 msgstr "Nome de cada local"
 
-#: src/dopewars.c:586
+#: src/dopewars.c:604
 msgid "Price of each weapon"
 msgstr "Preço de cada arma"
 
-#: src/dopewars.c:590
+#: src/dopewars.c:608
 msgid "Space taken by each weapon"
 msgstr "Espaço tomado por cada arma"
 
-#: src/dopewars.c:594
+#: src/dopewars.c:612
 msgid "Damage done by each weapon"
 msgstr "Dano de cada arma"
 
-#: src/dopewars.c:598
+#: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
 msgstr "Palavra usada para denominar um simples \"clérigo\""
 
-#: src/dopewars.c:601
+#: src/dopewars.c:619
 msgid "Word used to denote two or more \"clerics\""
 msgstr "Palavra usada para denominar dois ou mais \"clérigos\""
 
-#: src/dopewars.c:604
+#: src/dopewars.c:622
 msgid "Word used to denote a single gun or equivalent"
 msgstr "Palavra usada para detominar uma simples arma ou equivalente"
 
-#: src/dopewars.c:607
+#: src/dopewars.c:625
 msgid "Word used to denote two or more guns"
 msgstr "Palavra usada para denominar duas ou mais armas"
 
-#: src/dopewars.c:610
+#: src/dopewars.c:628
 msgid "Word used to denote a single drug or equivalent"
 msgstr "Palavra usada para denominar uma simples droga ou equivalente"
 
-#: src/dopewars.c:613
+#: src/dopewars.c:631
 msgid "Word used to denote two or more drugs"
 msgstr "Palavra usada para denominar duas ou mais drogas"
 
-#: src/dopewars.c:616
+#: src/dopewars.c:634
 msgid "strftime() format string for displaying the game turn"
 msgstr ""
 
-#: src/dopewars.c:619
+#: src/dopewars.c:637
 msgid "Cost for a cleric to spy on the enemy"
 msgstr "Custo para que um clérigo espione o inimigo"
 
-#: src/dopewars.c:622
+#: src/dopewars.c:640
 msgid "Cost for a cleric to tipoff the cops to an enemy"
 msgstr "Custo para que um clérigo denuncie um inimigo à polícia"
 
-#: src/dopewars.c:625
+#: src/dopewars.c:643
 msgid "Minimum price to hire a cleric"
 msgstr "Preço mínimo para contratar um clérigo"
 
-#: src/dopewars.c:628
+#: src/dopewars.c:646
 msgid "Maximum price to hire a cleric"
 msgstr "Preço máximo para contratar um clérigo"
 
-#: src/dopewars.c:631
+#: src/dopewars.c:649
 msgid "List of things which you overhear on the subway"
 msgstr "Lista de coisas ao qual você ouve no metrô"
 
-#: src/dopewars.c:634
+#: src/dopewars.c:652
 msgid "Number of subway sayings"
 msgstr "Número de falas no metrô"
 
-#: src/dopewars.c:637
+#: src/dopewars.c:655
 msgid "List of songs which you can hear playing"
 msgstr "Lista de sons ao qual você ouve tocando"
 
-#: src/dopewars.c:640
+#: src/dopewars.c:658
 msgid "Number of playing songs"
 msgstr "Número de sons tocando"
 
-#: src/dopewars.c:643
+#: src/dopewars.c:661
 msgid "List of things which you can stop to do"
 msgstr "Lista de coisas que você pode parar de fazer"
 
-#: src/dopewars.c:646
+#: src/dopewars.c:664
 msgid "Number of things which you can stop to do"
 msgstr "Número de coisas que você pode parar de fazer"
 
 #. Default list of songs that you can hear playing (N.B. this can be
 #. overridden in the configuration file with the "Playing" variable) -
 #. look for "You hear someone playing %s" to see how these are used.
-#: src/dopewars.c:656
+#: src/dopewars.c:674
 msgid "The Song of Moses"
 msgstr ""
 
-#: src/dopewars.c:657
+#: src/dopewars.c:675
 msgid "The Song of Deborah"
 msgstr ""
 
-#: src/dopewars.c:658
+#: src/dopewars.c:676
 msgid "The Canticle of Hannah"
 msgstr ""
 
-#: src/dopewars.c:659
+#: src/dopewars.c:677
 msgid "Magnificat"
 msgstr ""
 
-#: src/dopewars.c:660
+#: src/dopewars.c:678
 msgid "The Benedictus"
 msgstr ""
 
-#: src/dopewars.c:661
+#: src/dopewars.c:679
 msgid "The Nunc Dimittis"
 msgstr ""
 
-#: src/dopewars.c:662
+#: src/dopewars.c:680
 msgid "Veni Creator Spiritus"
 msgstr ""
 
-#: src/dopewars.c:663
+#: src/dopewars.c:681
 msgid "Pange Lingua Gloriosi"
 msgstr ""
 
-#: src/dopewars.c:664
+#: src/dopewars.c:682
 msgid "Salve Regina"
 msgstr ""
 
-#: src/dopewars.c:665
+#: src/dopewars.c:683
 msgid "Gloria in Excelsis Deo"
 msgstr ""
 
-#: src/dopewars.c:666
+#: src/dopewars.c:684
 msgid "Dies Irae"
 msgstr ""
 
-#: src/dopewars.c:667
+#: src/dopewars.c:685
 msgid "Ubi Caritas"
 msgstr ""
 
-#: src/dopewars.c:668
+#: src/dopewars.c:686
 msgid "Te Deum Laudamus"
 msgstr ""
 
-#: src/dopewars.c:669
+#: src/dopewars.c:687
 msgid "O Fortuna"
 msgstr ""
 
-#: src/dopewars.c:670
+#: src/dopewars.c:688
 msgid "Phos Hilaron"
 msgstr ""
 
-#: src/dopewars.c:671
+#: src/dopewars.c:689
 msgid "The Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:672
+#: src/dopewars.c:690
 msgid "Sub Tuum Praesidium"
 msgstr ""
 
-#: src/dopewars.c:673
+#: src/dopewars.c:691
 msgid "Kyrie Eleison"
 msgstr ""
 
@@ -631,183 +631,183 @@ msgstr ""
 #. cost you a little money). These can be overridden with the "StoppedTo"
 #. variable in the configuration file. See the later string "You stopped
 #. to %s." to see how these strings are used.
-#: src/dopewars.c:682
+#: src/dopewars.c:700
 msgid "practice your needlework"
 msgstr ""
 
-#: src/dopewars.c:683
+#: src/dopewars.c:701
 msgid "translate the Church Fathers"
 msgstr ""
 
-#: src/dopewars.c:684
+#: src/dopewars.c:702
 msgid "recite the Lord's Prayer"
 msgstr ""
 
-#: src/dopewars.c:685
+#: src/dopewars.c:703
 msgid "memorise the Pentateuch"
 msgstr ""
 
-#: src/dopewars.c:686
+#: src/dopewars.c:704
 msgid "celebrate the Eucharist"
 msgstr ""
 
 #. Name of the first police officer to attack you
-#: src/dopewars.c:691
+#: src/dopewars.c:709
 msgid "Seljuk Malik-shah"
 msgstr ""
 
 #. Name of a single deputy of the first police officer
-#: src/dopewars.c:693 src/dopewars.c:697
+#: src/dopewars.c:711 src/dopewars.c:715
 msgid "Janissary"
 msgstr ""
 
 #. Word used for more than one deputy of the first police officer
-#: src/dopewars.c:695 src/dopewars.c:697
+#: src/dopewars.c:713 src/dopewars.c:715
 msgid "Janissaries"
 msgstr ""
 
 #. Ditto, for the other police officers
-#: src/dopewars.c:697
+#: src/dopewars.c:715
 msgid "Ahmad Sanjar"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Mahmud II"
 msgstr ""
 
-#: src/dopewars.c:699
+#: src/dopewars.c:717
 msgid "Amir"
 msgstr ""
 
-#: src/dopewars.c:699 src/gui_client/optdialog.c:952
+#: src/dopewars.c:717 src/gui_client/optdialog.c:952
 msgid "Amirs"
 msgstr ""
 
 #. The names of the default guns
-#: src/dopewars.c:704
+#: src/dopewars.c:722
 msgid "Mace"
 msgstr ""
 
-#: src/dopewars.c:705
+#: src/dopewars.c:723
 msgid "Crossbow"
 msgstr ""
 
-#: src/dopewars.c:706
+#: src/dopewars.c:724
 msgid "Spear"
 msgstr ""
 
-#: src/dopewars.c:707
+#: src/dopewars.c:725
 msgid "Battle Axe"
 msgstr ""
 
 #. The names of the default drugs, and the messages displayed when they
 #. are specially cheap or expensive
-#: src/dopewars.c:713
+#: src/dopewars.c:731
 msgid "Byzantine Icons"
 msgstr ""
 
-#: src/dopewars.c:714
+#: src/dopewars.c:732
 msgid "The market is flooded with cheap home-made icons!"
 msgstr "O mercado está cheio de ácido caseiro barato!"
 
-#: src/dopewars.c:715
+#: src/dopewars.c:733
 msgid "Spices"
 msgstr ""
 
-#: src/dopewars.c:716
+#: src/dopewars.c:734
 msgid "Holy Relics"
 msgstr ""
 
-#: src/dopewars.c:717
+#: src/dopewars.c:735
 msgid "Traders from Constantinople have arrived!"
 msgstr ""
 
-#: src/dopewars.c:718
+#: src/dopewars.c:736
 msgid "Elephants"
 msgstr ""
 
-#: src/dopewars.c:719
+#: src/dopewars.c:737
 msgid "Medicines"
 msgstr ""
 
-#: src/dopewars.c:720
+#: src/dopewars.c:738
 msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
-#: src/dopewars.c:721 src/gui_client/optdialog.c:947
+#: src/dopewars.c:739 src/gui_client/optdialog.c:947
 msgid "Weapons"
 msgstr ""
 
-#: src/dopewars.c:722
+#: src/dopewars.c:740
 msgid "Horses"
 msgstr ""
 
-#: src/dopewars.c:723
+#: src/dopewars.c:741
 msgid "True Cross splinters"
 msgstr ""
 
-#: src/dopewars.c:724
+#: src/dopewars.c:742
 msgid "Food"
 msgstr ""
 
-#: src/dopewars.c:725
+#: src/dopewars.c:743
 msgid "Silk"
 msgstr ""
 
-#: src/dopewars.c:726
+#: src/dopewars.c:744
 msgid "Gold"
 msgstr ""
 
-#: src/dopewars.c:727
+#: src/dopewars.c:745
 msgid "Holy Scriptures"
 msgstr ""
 
-#: src/dopewars.c:728
+#: src/dopewars.c:746
 msgid ""
 "Alexandrian scholars have sent parchments! Scripture prices have bottomed "
 "out!"
 msgstr "Colombianos enganaram a Guarda Costeira! Preços de maconha abaixaram!"
 
 #. The names of the default locations
-#: src/dopewars.c:736
+#: src/dopewars.c:754
 msgid "Jerusalem"
 msgstr ""
 
-#: src/dopewars.c:737
+#: src/dopewars.c:755
 msgid "Hagia Sophia"
 msgstr ""
 
-#: src/dopewars.c:738
+#: src/dopewars.c:756
 msgid "Acre"
 msgstr ""
 
-#: src/dopewars.c:739
+#: src/dopewars.c:757
 msgid "Antioch"
 msgstr ""
 
-#: src/dopewars.c:740
+#: src/dopewars.c:758
 msgid "Damascus"
 msgstr ""
 
-#: src/dopewars.c:741
+#: src/dopewars.c:759
 msgid "Iconium"
 msgstr ""
 
-#: src/dopewars.c:742
+#: src/dopewars.c:760
 msgid "Edessa"
 msgstr "Mensagem"
 
-#: src/dopewars.c:743
+#: src/dopewars.c:761
 msgid "Nicaea"
 msgstr ""
 
-#. Messages displayed for drug busts, etc.
-#: src/dopewars.c:749
+#. Messages displayed for drug raids, etc.
+#: src/dopewars.c:767
 #, c-format
-msgid "Seljuk Amirs made a big %tde bust! Prices are outrageous!"
-msgstr "Policiais apreenderam %tde! Preços estão super altos!"
+msgid "Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"
+msgstr "Policiais fizeram uma grande batida e apreenderam %tde! Preços estão super altos!"
 
-#: src/dopewars.c:750
+#: src/dopewars.c:768
 #, c-format
 msgid "Traders are buying %tde at ridiculous prices!"
 msgstr "Viciados estão comprando %tde a preços ridículos!"
@@ -816,144 +816,144 @@ msgstr "Viciados estão comprando %tde a preços ridículos!"
 #. (N.B. can be overridden with the "SubwaySaying" config. file
 #. variable). Look for "the lady next to you" to see how these strings
 #. are used.
-#: src/dopewars.c:760
+#: src/dopewars.c:778
 msgid "Wouldn't it be funny if everyone suddenly converted at once?"
 msgstr "Não seria engraçado se todos tivessem de uma vez só?"
 
-#: src/dopewars.c:761
+#: src/dopewars.c:779
 msgid "The Pope was once Jewish, you know"
 msgstr "O Papa já foi judeu uma vez, você sabe"
 
-#: src/dopewars.c:762
+#: src/dopewars.c:780
 msgid "I'll bet you have some really interesting dreams"
 msgstr "Eu aposto que você tem sonhos realmente interessantes"
 
-#: src/dopewars.c:763
+#: src/dopewars.c:781
 msgid "So I think I'm going to Alexandria this year"
 msgstr "Então eu acho que vou para Amsterdã este ano"
 
-#: src/dopewars.c:764
+#: src/dopewars.c:782
 msgid "Son, you need a yellow horse"
 msgstr "Filho, você precisa de um corte de cabelo amarelo"
 
-#: src/dopewars.c:765
+#: src/dopewars.c:783
 msgid "I think it's wonderful what they're doing with incense these days"
 msgstr "Eu acho maravilhoso o que estão fazendo com incenso estes dias"
 
-#: src/dopewars.c:766
+#: src/dopewars.c:784
 msgid "I wasn't always a woman, you know"
 msgstr "I eu não fui sempre uma mulher, você sabe"
 
-#: src/dopewars.c:767
+#: src/dopewars.c:785
 msgid "Does your mother know you're a war monger?"
 msgstr "Sua mãe sabe que você é um traficante de drogas?"
 
-#: src/dopewars.c:768
+#: src/dopewars.c:786
 msgid "Are you praying something?"
 msgstr "Você está doidão ou coisa parecida?"
 
-#: src/dopewars.c:769
+#: src/dopewars.c:787
 msgid "Oh, you must be from Constantinople"
 msgstr "Ah, você deve ser da Califórnia"
 
-#: src/dopewars.c:770
+#: src/dopewars.c:788
 msgid "I used to be a Manichaean, myself"
 msgstr "Eu mesmo costumava ser hippe"
 
-#: src/dopewars.c:771
+#: src/dopewars.c:789
 msgid "There's nothing like having lots of money"
 msgstr "Não há nada como ter muito dinheiro"
 
-#: src/dopewars.c:772
+#: src/dopewars.c:790
 msgid "You look like an aardvark!"
 msgstr "Você tá parecendo um aardvark!"
 
-#: src/dopewars.c:773
+#: src/dopewars.c:791
 msgid "I don't believe in Pope Urban II"
 msgstr "Eu não acredito no Ronal Reagan"
 
-#: src/dopewars.c:774
+#: src/dopewars.c:792
 msgid "Courage!  Justinian and Theodora!"
 msgstr "Coragem! Bush é um zé!"
 
-#: src/dopewars.c:775
+#: src/dopewars.c:793
 msgid "Haven't I seen you at the Tavern?"
 msgstr "Eu já não te vi na TV?"
 
-#: src/dopewars.c:776
+#: src/dopewars.c:794
 msgid "I have seen the nails of Christ!"
 msgstr ""
 
-#: src/dopewars.c:777
+#: src/dopewars.c:795
 msgid "We're winning the war for Empire!"
 msgstr "Nós estamos ganhando a guerra das drogas!"
 
-#: src/dopewars.c:778
+#: src/dopewars.c:796
 msgid "A day without grace is like night"
 msgstr "Um dia sem droga é como a noite"
 
-#: src/dopewars.c:780
+#: src/dopewars.c:798
 #, no-c-format
 msgid "We only use 20% of our brains, so why not burn out the other 80%"
 msgstr ""
 "Nós usamos apenas 20% de nossos cérebros, então porque não estragar os "
 "outros 80%"
 
-#: src/dopewars.c:781
+#: src/dopewars.c:799
 msgid "I'm soliciting contributions for a protestant movement"
 msgstr "Eu estou solicitando contribuições para os Zumbis de Cristo"
 
-#: src/dopewars.c:782
+#: src/dopewars.c:800
 msgid "I'd like to sell you the Holy Grail"
 msgstr "Eu queria te mandar um poodle"
 
-#: src/dopewars.c:783
+#: src/dopewars.c:801
 msgid "Saints don't do Confession... unless they do"
 msgstr "Vencedores não usam drogas... ao menos que usem"
 
-#: src/dopewars.c:784
+#: src/dopewars.c:802
 msgid "Christos Anesti! Alithos Anesti!"
 msgstr ""
 
-#: src/dopewars.c:785
+#: src/dopewars.c:803
 msgid "On you rests this duty!"
 msgstr ""
 
-#: src/dopewars.c:786
+#: src/dopewars.c:804
 msgid "Jesus loves you more than you will know"
 msgstr "Jesus ama você mais do que você sabe"
 
-#: src/dopewars.c:787
+#: src/dopewars.c:805
 msgid "Deus Vult!"
 msgstr ""
 
-#: src/dopewars.c:788
+#: src/dopewars.c:806
 msgid "I can resist anything except temptation"
 msgstr ""
 
-#: src/dopewars.c:789
+#: src/dopewars.c:807
 msgid "Moses speaks of Christ!"
 msgstr ""
 
-#: src/dopewars.c:790
+#: src/dopewars.c:808
 msgid "Would you like a cabbage?"
 msgstr "Você gostaria de um doce, bebê?"
 
-#: src/dopewars.c:791
+#: src/dopewars.c:809
 msgid "Homoousios!"
 msgstr ""
 
-#: src/dopewars.c:1757
+#: src/dopewars.c:1867
 #, c-format
 msgid "Unable to process configuration file %s, line %d"
 msgstr "Não foi possível processar o arquivo de configuração %s, linha %d"
 
-#: src/dopewars.c:1793
+#: src/dopewars.c:1903
 #, c-format
 msgid "Unable to open file %s"
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: src/dopewars.c:1857
+#: src/dopewars.c:1967
 msgid ""
 "Configuration can only be changed interactively when no\n"
 "players are logged on. Wait for all players to log off, or remove\n"
@@ -963,40 +963,40 @@ msgstr ""
 "nenhum jogador está logado. Espere por todos os jogadores saírem,\n"
 "ou remove eles com os comandos push ou kill, e tente de novo."
 
-#: src/dopewars.c:1970
+#: src/dopewars.c:2080
 #, c-format
 msgid "Index into %s array should be between 1 and %d"
 msgstr "Índice da array %s deve ser entre 1 e %d"
 
 #. Display of a numeric config. file variable - e.g. "NumDrug is 6"
-#: src/dopewars.c:1995
+#: src/dopewars.c:2105
 #, c-format
 msgid "%s is %d\n"
 msgstr "%s é %d\n"
 
 #. Display of a boolean config. file variable - e.g. "DrugValue is
 #. TRUE"
-#: src/dopewars.c:2000
+#: src/dopewars.c:2110
 #, c-format
 msgid "%s is %s\n"
 msgstr "%s é %s\n"
 
 #. Display of a price config. file variable - e.g. "Cleric.MinPrice is
 #. $200"
-#: src/dopewars.c:2006
+#: src/dopewars.c:2116
 msgid "%s is %P\n"
 msgstr "%s é %P\n"
 
 #. Display of a string config. file variable - e.g. "LoanSharkName is
 #. \"the loan shark\""
-#: src/dopewars.c:2011
+#: src/dopewars.c:2121
 #, c-format
 msgid "%s is \"%s\"\n"
 msgstr "%s é \"%s\"\n"
 
 #. Display of an indexed string list config. file variable - e.g.
 #. "StoppedTo[1] is have a beer"
-#: src/dopewars.c:2017
+#: src/dopewars.c:2127
 #, c-format
 msgid "%s[%d] is %s\n"
 msgstr "%s[%d] é %s\n"
@@ -1004,42 +1004,42 @@ msgstr "%s[%d] é %s\n"
 #. Display of the first part of an entire string list config. file
 #. variable - e.g. "StoppedTo is { " (followed by "have a beer",
 #. "smoke a joint" etc.)
-#: src/dopewars.c:2026
+#: src/dopewars.c:2136
 #, c-format
 msgid "%s is { "
 msgstr "%s é { "
 
-#: src/dopewars.c:2081
+#: src/dopewars.c:2191
 #, c-format
 msgid "%s can be no smaller than %d - ignoring!"
 msgstr "%s não pode ser menor que %d - ignorando!"
 
-#: src/dopewars.c:2087
+#: src/dopewars.c:2197
 #, c-format
 msgid "%s can be no larger than %d - ignoring!"
 msgstr "%s não pode ser maior que %d - ignorando!"
 
-#: src/dopewars.c:2096
+#: src/dopewars.c:2206
 #, c-format
 msgid "Resized structure list to %d elements\n"
 msgstr "Estrutura de lista redimensionada para %d elementos\n"
 
-#: src/dopewars.c:2134
+#: src/dopewars.c:2244
 msgid "expected a boolean value (one of 0, FALSE, 1, TRUE)"
 msgstr "Valor booleano esperado (om dentre 0, FALSE, 1, TRUE)"
 
 #. The currency symbol
-#: src/dopewars.c:2318
+#: src/dopewars.c:2428
 msgid "£"
 msgstr ""
 
 #. Translate this to "Currency.Prefix=FALSE" if you want your currency
 #. symbol to follow all prices.
-#: src/dopewars.c:2322
+#: src/dopewars.c:2432
 msgid "Currency.Prefix=TRUE"
 msgstr ""
 
-#: src/dopewars.c:2447
+#: src/dopewars.c:2563
 msgid ""
 "  -u, --plugin=FILE       use sound plugin \"FILE\"\n"
 "                            "
@@ -1047,7 +1047,7 @@ msgstr ""
 "  -u, --plugin=ARQUIVO    use plugin de som \"ARQUIVO\"\n"
 "                            "
 
-#: src/dopewars.c:2450
+#: src/dopewars.c:2566
 msgid ""
 "  -u file  use sound plugin \"file\"\n"
 "\t          "
@@ -1055,19 +1055,17 @@ msgstr ""
 "  -u arquivo  use plugin de som \"arquivo\"\n"
 "\t          "
 
-#: src/dopewars.c:2454
+#: src/dopewars.c:2570
 #, c-format
 msgid "(%s available)\n"
 msgstr "(%s dispnível)\n"
 
-#: src/dopewars.c:2460
+#: src/dopewars.c:2595
 #, fuzzy, c-format
 msgid "Church Wars version %s\n"
 msgstr "Church Wars versão %s\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (version with support for GNU long options)
-#: src/dopewars.c:2469
+#: src/dopewars.c:2606
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1082,7 +1080,7 @@ msgid ""
 "original\n"
 "                            version as possible (no networking)\n"
 "  -f, --scorefile=FILE    specify a file to use as the high score table (by\n"
-"                            default %s/churchwars.sco is used)\n"
+"                            default %s is used)\n"
 "  -o, --hostname=ADDR     specify a hostname where the server for "
 "multiplayer\n"
 "                            Church Wars can be found\n"
@@ -1141,7 +1139,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2499
+#: src/dopewars.c:2636
 msgid ""
 "  -h, --help              display this help information\n"
 "  -v, --version           output version information and exit\n"
@@ -1156,9 +1154,7 @@ msgstr ""
 "Church Wars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#. Usage information, printed when the user runs "dopewars -h"
-#. (short options only version)
-#: src/dopewars.c:2506
+#: src/dopewars.c:2642
 #, fuzzy, c-format
 msgid ""
 "Usage: Church Wars [OPTION]...\n"
@@ -1171,7 +1167,7 @@ msgid ""
 "as\n"
 "              possible (no networking)\n"
 "  -f file  specify a file to use as the high score table\n"
-"              (by default %s/churchwars.sco is used)\n"
+"              (by default %s is used)\n"
 "  -o addr  specify a hostname where the server for multiplayer Church Wars\n"
 "              can be found\n"
 "  -s       run in server mode (note: see the -A option for configuring a\n"
@@ -1221,7 +1217,7 @@ msgstr ""
 "  -h         mostra estas informações de ajuda\n"
 "  -v         mostra informações de versão e sai\n"
 
-#: src/dopewars.c:2535
+#: src/dopewars.c:2671
 msgid ""
 "  -h       display this help information\n"
 "  -v       output version information and exit\n"
@@ -1236,7 +1232,7 @@ msgstr ""
 "Church Wars Copyright (C) Ben Webb 1998-2022, e licenciado sob a GNU GPL\n"
 "Reporte bugs ao autor em benwebb@users.sf.net\n"
 
-#: src/dopewars.c:2803
+#: src/dopewars.c:2943
 msgid ""
 "No curses client available - rebuild the binary passing the\n"
 "--enable-curses-client option to configure, or use a windowed\n"
@@ -1246,7 +1242,7 @@ msgstr ""
 "--enable-curses-client para configurar, ou use o cliente gráfico\n"
 "(se disponível) no lugar!\n"
 
-#: src/dopewars.c:2823
+#: src/dopewars.c:2963
 msgid ""
 "No graphical client available - rebuild the binary\n"
 "passing the --enable-gui-client option to configure, or\n"
@@ -1256,7 +1252,7 @@ msgstr ""
 "a opção --enable-gui-client para configurar, ou use o cliente\n"
 "curses (se disponível) no lugar!\n"
 
-#: src/dopewars.c:2871
+#: src/dopewars.c:3012
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1267,7 +1263,7 @@ msgstr ""
 "em modo admin. Recompile passando --enable-networking para o script de "
 "configuração.\n"
 
-#: src/dopewars.c:2892 src/winmain.c:381
+#: src/dopewars.c:3033 src/winmain.c:382
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "run\n"
@@ -1278,16 +1274,16 @@ msgstr ""
 "em modo admin. Recompile passando --enable-networking para o script de "
 "configuração.\n"
 
-#: src/curses_client/curses_client.c:326
+#: src/curses_client/curses_client.c:327
 msgid "English Translation           Ben Webb"
 msgstr "Tradução de Portugal            Bruno Lopes"
 
 #. Curses client introduction screen
-#: src/curses_client/curses_client.c:334
+#: src/curses_client/curses_client.c:335
 msgid "C H U R C H W A R S"
 msgstr "D O P E W A R S"
 
-#: src/curses_client/curses_client.c:339
+#: src/curses_client/curses_client.c:340
 #, fuzzy
 msgid ""
 "Based on John E. Dell's old Drug Wars game, Church Wars is a simulation of an"
@@ -1295,17 +1291,17 @@ msgstr ""
 "Baseado no velho jogo Drug Wars de John E. Dell, Church Wars é uma simulação "
 "de"
 
-#: src/curses_client/curses_client.c:341
+#: src/curses_client/curses_client.c:342
 msgid ""
 "imaginary Crusader market.  Church Wars is a Crusades game which features"
 msgstr ""
 "um mercado de drogas imaginário. Church Wars é um jogo americano onde se pode"
 
-#: src/curses_client/curses_client.c:343
+#: src/curses_client/curses_client.c:344
 msgid "buying, selling, and funding the Holy Christian Empire!"
 msgstr "comprar, vender, e tentar se safar dos policiais!"
 
-#: src/curses_client/curses_client.c:345
+#: src/curses_client/curses_client.c:346
 #, fuzzy
 msgid ""
 "The first thing you need to do is pay off your debt to the Pope's Loan "
@@ -1313,60 +1309,60 @@ msgid ""
 msgstr ""
 "A primeira coisa que você irá precisar fazer é pagar seu débito com o agiota."
 
-#: src/curses_client/curses_client.c:347
+#: src/curses_client/curses_client.c:348
 msgid "that, your goal is to make as much money as possible (and stay alive)!"
 msgstr ""
 "Depois disso, seu objetivo é ganhar o máximo de dinheiro possível (e ficar"
 
-#: src/curses_client/curses_client.c:349
+#: src/curses_client/curses_client.c:350
 msgid "You have 31 travels of game time to make your fortune."
 msgstr "vivo)! Você tem um mês de tempo de jogo para fazer sua fortuna."
 
-#: src/curses_client/curses_client.c:351
+#: src/curses_client/curses_client.c:352
 #, c-format
 msgid "Version %-8s Copyright (C) 2024  O Batstone theprawn26@gmail.com"
 msgstr "Versão %-8s Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net"
 
-#: src/curses_client/curses_client.c:354
+#: src/curses_client/curses_client.c:355
 msgid "Church Wars is released under the GNU General Public License"
 msgstr "Church Wars está lançado sob a GNU General Public License"
 
-#: src/curses_client/curses_client.c:362
+#: src/curses_client/curses_client.c:363
 msgid "Icons and Graphics            O Batstone"
 msgstr "Icons and Graphics              Ocelot Mantis"
 
-#: src/curses_client/curses_client.c:363
+#: src/curses_client/curses_client.c:364
 msgid "Sounds                        freesound.org, 19.5degs.com"
 msgstr "Sounds                          Robin Kohli, 19.5degs.com"
 
-#: src/curses_client/curses_client.c:364
+#: src/curses_client/curses_client.c:365
 msgid "History and Research    O Batstone"
 msgstr ""
 
-#: src/curses_client/curses_client.c:365
+#: src/curses_client/curses_client.c:366
 msgid "Play Testing                  L Evans           O Batstone"
 msgstr "Teste de Jogo                   Phil Davis           Owen Walsh"
 
-#: src/curses_client/curses_client.c:367
+#: src/curses_client/curses_client.c:368
 msgid "Extensive Play Testing        L Evans       O Batstone"
 msgstr "Testes Extensivos de Jogo       Katherine Holt       Caroline Moore"
 
-#: src/curses_client/curses_client.c:369
+#: src/curses_client/curses_client.c:370
 msgid "Constructive Criticism        L Evans  O Batstone"
 msgstr "Crítica não construtiva         James Matthews"
 
-#: src/curses_client/curses_client.c:371
+#: src/curses_client/curses_client.c:372
 msgid "Unconstructive Criticism      R Batstone"
 msgstr "Crítica não construtiva         James Matthews"
 
-#: src/curses_client/curses_client.c:373
+#: src/curses_client/curses_client.c:374
 #, fuzzy
 msgid ""
 "For information on the command line options, type Church Wars -h at your"
 msgstr ""
 "Para informações de opções da linha de comando, digite Church Wars -h no seu"
 
-#: src/curses_client/curses_client.c:375
+#: src/curses_client/curses_client.c:376
 msgid ""
 "Unix prompt. This will display a help screen, listing the available options."
 msgstr ""
@@ -1375,60 +1371,65 @@ msgstr ""
 
 #. Prompts for hostname and port when selecting a server
 #. manually
-#: src/curses_client/curses_client.c:401
+#: src/curses_client/curses_client.c:404
 #, fuzzy
 msgid "Please enter the hostname and port of a Church Wars server:-"
 msgstr "Por favor entre com o nome do host e porta do servidor Church Wars:-"
 
-#: src/curses_client/curses_client.c:402
+#: src/curses_client/curses_client.c:405
 msgid "Hostname: "
 msgstr "Nome do Host: "
 
-#: src/curses_client/curses_client.c:406
+#: src/curses_client/curses_client.c:409
 msgid "Port: "
 msgstr "Porta"
 
-#: src/curses_client/curses_client.c:432
+#: src/curses_client/curses_client.c:412
+#, c-format
+msgid "Invalid port '%s'; keeping previous port %d"
+msgstr ""
+
+#: src/curses_client/curses_client.c:440
 msgid "Please wait... attempting to contact metaserver..."
 msgstr "Aguarde... tentando contactar o servidor meta..."
 
 #. Printout of metaserver information in curses client
-#: src/curses_client/curses_client.c:495
+#: src/curses_client/curses_client.c:507
 #, c-format
 msgid "Server : %s"
 msgstr "Servidor : %s"
 
-#: src/curses_client/curses_client.c:497
+#: src/curses_client/curses_client.c:509
 #, c-format
 msgid "Port   : %d"
 msgstr "Porta    : %d"
 
-#: src/curses_client/curses_client.c:499
+#: src/curses_client/curses_client.c:511
 #, c-format
 msgid "Version    : %s"
 msgstr "Versão   : %s"
 
-#: src/curses_client/curses_client.c:502
+#: src/curses_client/curses_client.c:514
 #, c-format
 msgid "Players: -unknown- (maximum %d)"
 msgstr "Jogadores: -unknown- (máximo de %d)"
 
-#: src/curses_client/curses_client.c:505
+#: src/curses_client/curses_client.c:517
 #, c-format
 msgid "Players: %d (maximum %d)"
 msgstr "Jogadores: %d (máximo de %d)"
 
-#: src/curses_client/curses_client.c:509
+#: src/curses_client/curses_client.c:521
 #, c-format
 msgid "Up since   : %s"
 msgstr "Rodando desde : %s"
 
-#: src/curses_client/curses_client.c:511
+#: src/curses_client/curses_client.c:523
 #, c-format
 msgid "Comment: %s"
 msgstr "Comentário: %s"
 
-#: src/curses_client/curses_client.c:515
+#: src/curses_client/curses_client.c:527
 msgid "N>ext server; P>revious server; S>elect this server... "
 msgstr "P>róximo servidor; A>nterior; S>elecionar este servidor... "
 
@@ -1436,211 +1437,200 @@ msgstr "P>róximo servidor; A>nterior; S>elecionar este servidor... "
 #. if you translate them, keep the keys in the same order (N>ext,
 #. P>revious, S>elect) as they are here, otherwise they'll do the
 #. wrong things.
-#: src/curses_client/curses_client.c:521
+#: src/curses_client/curses_client.c:533
 msgid "NPS"
 msgstr "PAS"
 
-#: src/curses_client/curses_client.c:570
+#: src/curses_client/curses_client.c:582
 #, c-format
 msgid "Connected to SOCKS server %s..."
 msgstr "Conectado ao servidor SOCKS %s..."
 
-#: src/curses_client/curses_client.c:574
+#: src/curses_client/curses_client.c:586
 msgid "Authenticating with SOCKS server"
 msgstr "Autenticando com o servidor SOCKS"
 
-#: src/curses_client/curses_client.c:577
+#: src/curses_client/curses_client.c:589
 #, c-format
 msgid "Asking SOCKS for connect to %s..."
 msgstr "Pedindo ao SOCKS para conectar em %s..."
 
-#: src/curses_client/curses_client.c:598
+#: src/curses_client/curses_client.c:611
 msgid "SOCKS authentication required (enter a blank username to cancel)"
 msgstr ""
 "Autenticação SOCKS necessária (entre nome de usuário em branco para cancelar)"
 
-#: src/curses_client/curses_client.c:601
+#: src/curses_client/curses_client.c:614
 msgid "User name: "
 msgstr "Nome de usuário: "
 
-#: src/curses_client/curses_client.c:603
+#: src/curses_client/curses_client.c:616
 msgid "Password: "
 msgstr "Senha: "
 
-#: src/curses_client/curses_client.c:698
+#: src/curses_client/curses_client.c:718
 #, fuzzy
 msgid "Please wait... attempting to contact Church Wars server..."
 msgstr "Aguarde... tentando contactar o servidor Church Wars..."
 
-#. Display of an error while contacting the metaserver
-#: src/curses_client/curses_client.c:709
-msgid "Cannot get metaserver details"
-msgstr "Não foi possível obter detalhes do metaservidor"
-
-#. Display of an error message while trying to contact a dopewars
-#. server (the error message itself is displayed on the next
-#. screen line)
-#: src/curses_client/curses_client.c:717
-#, fuzzy
-msgid "Could not start multiplayer Church Wars"
-msgstr "Não foi possível iniciar o Church Wars em multiplayer"
-
-#: src/curses_client/curses_client.c:720
-msgid "connection to server failed"
-msgstr "a conexão com o servidor falhou"
-
-#: src/curses_client/curses_client.c:727
+#: src/curses_client/curses_client.c:733
 #, fuzzy
 msgid "Will you... C>onnect to a named Church Wars server"
 msgstr "Você irá... C>onectar em um diferente host e porta"
 
-#: src/curses_client/curses_client.c:729
+#: src/curses_client/curses_client.c:735
 msgid "            L>ist the servers on the metaserver, and select one"
 msgstr "            L>istar os servidor no servidor meta, e selecionar um"
 
-#: src/curses_client/curses_client.c:732
+#: src/curses_client/curses_client.c:738
 #, fuzzy
 msgid ""
 "            Q>uit (where you can start a server by typing \"Church Wars -s\")"
 msgstr "            S>air (onde você pode iniciar um servidor digitando "
 
-#: src/curses_client/curses_client.c:734
+#: src/curses_client/curses_client.c:740
 msgid "         or P>lay single-player ? "
 msgstr "         ou J>ogar com apenas um jogador ? "
 
 #. Translate these 4 keys in line with the above options, keeping
 #. the order the same (C>onnect, L>ist, Q>uit, P>lay single-player)
-#: src/curses_client/curses_client.c:739
+#: src/curses_client/curses_client.c:745
 msgid "CLQP"
 msgstr "CLSJ"
 
 #. Display of shortcut keys and locations to jet to
-#: src/curses_client/curses_client.c:832
+#: src/curses_client/curses_client.c:842
 #, c-format
 msgid "%d. %tde"
 msgstr ""
 
 #. Prompt when the player chooses to "jet" to a new location
 #. Prompt in 'Jet' dialog
-#: src/curses_client/curses_client.c:839 src/gui_client/gtk_client.c:1422
+#: src/curses_client/curses_client.c:849 src/gui_client/gtk_client.c:1422
 msgid "Where to, trader ? "
 msgstr "Para onde, cara ? "
 
-#: src/curses_client/curses_client.c:845
+#: src/curses_client/curses_client.c:855
 msgid "%/Location display/%tde"
 msgstr ""
 
 #. List of drugs that you can drop (%tde = "drugs" by
 #. default)
-#: src/curses_client/curses_client.c:881
+#: src/curses_client/curses_client.c:893
 #, c-format
 msgid "You can't get any cash for the following carried %tde :"
 msgstr "Você não pode ganhar nenhum dinheiro pelo seguinte %tde :"
 
-#: src/curses_client/curses_client.c:894
+#: src/curses_client/curses_client.c:906
 msgid "What do you want to drop? "
 msgstr "O que você quer largar? "
 
-#: src/curses_client/curses_client.c:904
+#: src/curses_client/curses_client.c:916
 msgid "How many do you drop? "
 msgstr "Que quantidade você quer largar? "
 
+#: src/curses_client/curses_client.c:920 src/curses_client/curses_client.c:984
+#: src/curses_client/curses_client.c:1006
+#, c-format
+msgid "Invalid quantity '%s'"
+msgstr ""
+
 #. Buy and sell prompts for dealing drugs or guns
-#: src/curses_client/curses_client.c:940 src/curses_client/curses_client.c:1343
+#: src/curses_client/curses_client.c:957 src/curses_client/curses_client.c:1372
 msgid "What do you wish to buy? "
 msgstr "O que você quer comprar? "
 
-#: src/curses_client/curses_client.c:942 src/curses_client/curses_client.c:1295
+#: src/curses_client/curses_client.c:959 src/curses_client/curses_client.c:1324
 msgid "What do you wish to sell? "
 msgstr "O que você quer vender? "
 
 #. Display of number of drugs you could buy and/or carry, when
 #. buying drugs
-#: src/curses_client/curses_client.c:960
+#: src/curses_client/curses_client.c:977
 #, c-format
 msgid "You can afford %d, and can carry %d. "
 msgstr "Você pode comprar %d, e pode carregar %d. "
 
-#: src/curses_client/curses_client.c:963
+#: src/curses_client/curses_client.c:980
 msgid "How many do you buy? "
 msgstr "Quantos você vai comprar? "
 
-#: src/curses_client/curses_client.c:976
+#: src/curses_client/curses_client.c:999
 #, c-format
 msgid "You have %d. "
 msgstr "Você tem %d. "
 
-#: src/curses_client/curses_client.c:979
+#: src/curses_client/curses_client.c:1002
 msgid "How many do you sell? "
 msgstr "Quantos você vai vender? "
 
-#: src/curses_client/curses_client.c:1002
+#: src/curses_client/curses_client.c:1031
 msgid "Are you sure you want to quit? "
 msgstr "Você tem certeza que quer sair? "
 
-#: src/curses_client/curses_client.c:1004
-#: src/curses_client/curses_client.c:2713
+#: src/curses_client/curses_client.c:1033
+#: src/curses_client/curses_client.c:2759
 msgid "YN"
 msgstr "SN"
 
 #. Prompt for player to change his/her name
-#: src/curses_client/curses_client.c:1015
+#: src/curses_client/curses_client.c:1044
 msgid "New name: "
 msgstr "Novo nome: "
 
-#: src/curses_client/curses_client.c:1082
+#: src/curses_client/curses_client.c:1111
 msgid "You have been pushed from the server. Reverting to single player mode."
 msgstr "Você foi tirado do servidor. Revertendo para modo de jogador único."
 
-#: src/curses_client/curses_client.c:1092
+#: src/curses_client/curses_client.c:1121
 msgid "The server has terminated. Reverting to single player mode."
 msgstr "O servidor foi terminado. Revertendo para modo de jogador único."
 
-#: src/curses_client/curses_client.c:1110 src/gui_client/gtk_client.c:504
-#: src/serverside.c:371
+#: src/curses_client/curses_client.c:1139 src/gui_client/gtk_client.c:504
+#: src/serverside.c:373
 #, c-format
 msgid "%s joins the game!"
 msgstr "%s entrou no jogo!"
 
-#: src/curses_client/curses_client.c:1117 src/gui_client/gtk_client.c:513
+#: src/curses_client/curses_client.c:1146 src/gui_client/gtk_client.c:513
 #, c-format
 msgid "%s has left the game."
 msgstr "%s saiu do jogo."
 
 #. Displayed when a player changes his/her name
-#: src/curses_client/curses_client.c:1125
+#: src/curses_client/curses_client.c:1154
 #, c-format
 msgid "%s will now be known as %s."
 msgstr "%s agora vai ser conhecido como %s."
 
-#: src/curses_client/curses_client.c:1147
+#: src/curses_client/curses_client.c:1176
 msgid "H O L Y M A S S"
 msgstr ""
 
-#: src/curses_client/curses_client.c:1154
-#: src/curses_client/curses_client.c:2012 src/gui_client/gtk_client.c:1163
+#: src/curses_client/curses_client.c:1183
+#: src/curses_client/curses_client.c:2041 src/gui_client/gtk_client.c:1163
 msgid "%/Current location/%tde"
 msgstr "%/Local atual/%tde"
 
-#: src/curses_client/curses_client.c:1196
+#: src/curses_client/curses_client.c:1225
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it."
 msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o."
 
-#: src/curses_client/curses_client.c:1223
+#: src/curses_client/curses_client.c:1252
 msgid "H I G H   S C O R E S"
 msgstr "M E L H O R E S   P O N T U A Ç Õ E S"
 
 #. Error - player tried to sell guns that he/she doesn't have
 #. (%tde="guns" by default)
-#: src/curses_client/curses_client.c:1287 src/gui_client/gtk_client.c:1786
+#: src/curses_client/curses_client.c:1316 src/gui_client/gtk_client.c:1786
 #, c-format
 msgid "You don't have any %tde to sell!"
 msgstr "Você não tem nenhum %tde para vender!"
 
 #. Error - player tried to sell some guns that he/she doesn't have
-#: src/curses_client/curses_client.c:1306 src/gui_client/gtk_client.c:1807
+#: src/curses_client/curses_client.c:1335 src/gui_client/gtk_client.c:1807
 msgid "You don't have any to sell!"
 msgstr "Você não tem nenhum para vender!"
 
@@ -1648,27 +1638,27 @@ msgstr "Você não tem nenhum para vender!"
 #. than his/her bitches can carry (1st
 #. %tde="bitches", 2nd %tde="guns" by
 #. default)
-#: src/curses_client/curses_client.c:1334 src/gui_client/gtk_client.c:1792
+#: src/curses_client/curses_client.c:1363 src/gui_client/gtk_client.c:1792
 #, c-format
 msgid "You'll need more %tde to carry any more %tde!"
 msgstr "Você irá precisar de mais %tde para carregar ainda mais %tde!"
 
 #. Error - player tried to buy a gun that he/she doesn't have
 #. space for (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1355 src/gui_client/gtk_client.c:1798
+#: src/curses_client/curses_client.c:1384 src/gui_client/gtk_client.c:1798
 #, c-format
 msgid "You don't have enough space to carry that %tde!"
 msgstr "Você não tem espaço suficiente para carregar aquele %tde!"
 
 #. Error - player tried to buy a gun that he/she can't afford
 #. (%tde="gun" by default)
-#: src/curses_client/curses_client.c:1365 src/gui_client/gtk_client.c:1803
+#: src/curses_client/curses_client.c:1394 src/gui_client/gtk_client.c:1803
 #, c-format
 msgid "You don't have enough cash to buy that %tde!"
 msgstr "Você não tem dinheiro suficiente para comprar aquele %tde!"
 
 #. Prompt for actions in the gun shop
-#: src/curses_client/curses_client.c:1405
+#: src/curses_client/curses_client.c:1434
 msgid "Will you B>uy, S>ell, or L>eave? "
 msgstr "Você irá C>omprar, V>ender, ou S>air? "
 
@@ -1676,41 +1666,41 @@ msgstr "Você irá C>omprar, V>ender, ou S>air? "
 #. the order (B>uy, S>ell, L>eave) the same - you can change the
 #. wording of the prompt, but if you change the order in this key
 #. list, the keys will do the wrong things!
-#: src/curses_client/curses_client.c:1415
+#: src/curses_client/curses_client.c:1444
 msgid "BSL"
 msgstr "CVS"
 
-#: src/curses_client/curses_client.c:1438
+#: src/curses_client/curses_client.c:1467
 msgid "How much money do you pay back? "
 msgstr "Quanto dinheiro você quer pagar de volta? "
 
 #. Error - player doesn't have enough money to pay back the loan
 #. Error - player has tried to put more money into the bank than
 #. he/she has
-#: src/curses_client/curses_client.c:1449
-#: src/curses_client/curses_client.c:1495 src/gui_client/gtk_client.c:2471
+#: src/curses_client/curses_client.c:1478
+#: src/curses_client/curses_client.c:1524 src/gui_client/gtk_client.c:2479
 msgid "You don't have that much money!"
 msgstr "Você não tem todo esse dinheiro!"
 
 #. Prompt for dealing with the bank in the curses client
-#: src/curses_client/curses_client.c:1474
+#: src/curses_client/curses_client.c:1503
 msgid "Do you want to D>eposit money, W>ithdraw money, or L>eave ? "
 msgstr "Você quer D>epositar dinheiro, R>etirar dinheiro, ou S>air ? "
 
 #. Make sure you keep the order the same if you translate these keys!
 #. (D>eposit, W>ithdraw, L>eave)
-#: src/curses_client/curses_client.c:1480
+#: src/curses_client/curses_client.c:1509
 msgid "DWL"
 msgstr "DRS"
 
 #. Prompt for putting money in or taking money out of the bank
-#: src/curses_client/curses_client.c:1484
+#: src/curses_client/curses_client.c:1513
 msgid "How much money? "
 msgstr "Quanto dinheiro? "
 
 #. Error - player has tried to withdraw more money from the bank
 #. than there is in the account
-#: src/curses_client/curses_client.c:1500
+#: src/curses_client/curses_client.c:1529
 msgid "There isn't that much money in the bank..."
 msgstr "Não há todo este dinheiro no banco..."
 
@@ -1718,47 +1708,47 @@ msgstr "Não há todo este dinheiro no banco..."
 #. user. i.e. "Yes" is printed for the key "Y" etc. You should indicate
 #. to the user which letter in the word corresponds to the keypress, by
 #. capitalising it or similar.
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "Y:Yes"
 msgstr "S:Sim"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "N:No"
 msgstr "N:Não"
 
-#: src/curses_client/curses_client.c:1550
+#: src/curses_client/curses_client.c:1579
 msgid "R:Run"
 msgstr "C:Correr"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "F:Fight"
 msgstr "L:Lutar"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "A:Attack"
 msgstr "A:Atacar"
 
-#: src/curses_client/curses_client.c:1551
+#: src/curses_client/curses_client.c:1580
 msgid "E:Evade"
 msgstr "E:Evacuar"
 
-#: src/curses_client/curses_client.c:1688
+#: src/curses_client/curses_client.c:1717
 msgid "Press any key..."
 msgstr "Pressione qualquer tecla..."
 
 #. Title of the "Messages" window in the curses client
-#: src/curses_client/curses_client.c:1952
+#: src/curses_client/curses_client.c:1981
 msgid "Messages (-/+ scrolls up/down)"
 msgstr ""
 
 #. Title of the "Stats" window in the curses client
-#: src/curses_client/curses_client.c:1962 src/gui_client/gtk_client.c:2208
+#: src/curses_client/curses_client.c:1991 src/gui_client/gtk_client.c:2209
 msgid "Stats"
 msgstr "Estatísticas"
 
 #. Display of the player's cash in the stats window
 #. Player's cash label in GTK+ client status display
-#: src/curses_client/curses_client.c:1967 src/gui_client/gtk_client.c:2029
+#: src/curses_client/curses_client.c:1996 src/gui_client/gtk_client.c:2029
 msgid "Cash"
 msgstr "Dinheiro"
 
@@ -1766,41 +1756,41 @@ msgstr "Dinheiro"
 #. Title of the "guns" window (the only important bit in this string
 #. is the "%Tde" which is "Guns" by default)
 #. Display of the total number of guns carried (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:1973
-#: src/curses_client/curses_client.c:2052 src/gui_client/gtk_client.c:1186
+#: src/curses_client/curses_client.c:2002
+#: src/curses_client/curses_client.c:2081 src/gui_client/gtk_client.c:1186
 msgid "%/Stats: Guns/%Tde"
 msgstr "%Tde"
 
 #. Display of the player's health
 #. Player's health label in GTK+ client status display
-#: src/curses_client/curses_client.c:1979 src/gui_client/gtk_client.c:2060
+#: src/curses_client/curses_client.c:2008 src/gui_client/gtk_client.c:2060
 msgid "Health"
 msgstr "Pontos de vida"
 
 #. Display of the player's bank balance
 #. Player's bank balance label in GTK+ client status display
-#: src/curses_client/curses_client.c:1984 src/gui_client/gtk_client.c:2043
+#: src/curses_client/curses_client.c:2013 src/gui_client/gtk_client.c:2043
 msgid "Bank"
 msgstr "Banco"
 
 #. Display of the player's debt
 #. Player's debt label in GTK+ client status display
-#: src/curses_client/curses_client.c:1992 src/gui_client/gtk_client.c:2036
+#: src/curses_client/curses_client.c:2021 src/gui_client/gtk_client.c:2036
 msgid "Debt"
 msgstr "Débito"
 
-#: src/curses_client/curses_client.c:2004
+#: src/curses_client/curses_client.c:2033
 #, c-format
 msgid "Space %6d"
 msgstr "Espaço %6d"
 
 #. Display of the player's number of bitches, and available space
 #. (%Tde="Bitches" by default)
-#: src/curses_client/curses_client.c:2008
+#: src/curses_client/curses_client.c:2037
 msgid "%Tde %3d  Space %6d"
 msgstr "%Tde %3d  Espaço %6d"
 
-#: src/curses_client/curses_client.c:2021
+#: src/curses_client/curses_client.c:2050
 msgid "Trenchcoat"
 msgstr "Casaco"
 
@@ -1808,158 +1798,164 @@ msgstr "Casaco"
 #. string is the "%Tde" which is "Drugs" by default; the %/.../ part
 #. is ignored, so you don't need to translate it; see doc/i18n.html)
 #.
-#: src/curses_client/curses_client.c:2027
+#: src/curses_client/curses_client.c:2056
 msgid "%/Stats: Drugs/%Tde"
 msgstr "%/Estatísticas: Drogas/%Tde"
 
-#: src/curses_client/curses_client.c:2035
+#: src/curses_client/curses_client.c:2064
 msgid "%-7tde  %3d @ %P"
 msgstr ""
 
 #. Display of carried drugs (%tde="Opium", etc. by default)
-#: src/curses_client/curses_client.c:2042
+#: src/curses_client/curses_client.c:2071
 #, c-format
 msgid "%-7tde  %3d"
 msgstr ""
 
 #. Display of carried guns (%tde="Baretta", etc. by default)
-#: src/curses_client/curses_client.c:2057
+#: src/curses_client/curses_client.c:2086
 #, c-format
 msgid "%-22tde %3d"
 msgstr ""
 
-#: src/curses_client/curses_client.c:2082
+#: src/curses_client/curses_client.c:2111
 #, c-format
 msgid "Spy reports for %s"
 msgstr ""
 
 #. Message displayed with a spy's list of drugs (%Tde="Drugs" by
 #. default)
-#: src/curses_client/curses_client.c:2088
+#: src/curses_client/curses_client.c:2117
 msgid "%/Spy: Drugs/%Tde..."
 msgstr "%/Estatísticas: Drogas/%Tde"
 
 #. Message displayed with a spy's list of guns (%Tde="Guns" by default)
-#: src/curses_client/curses_client.c:2096
+#: src/curses_client/curses_client.c:2125
 msgid "%/Spy: Guns/%Tde..."
 msgstr "%Tde"
 
-#: src/curses_client/curses_client.c:2124
+#: src/curses_client/curses_client.c:2153
 msgid "No other players are currently logged on!"
 msgstr "Nenhum outro jogador está atualmente logado!"
 
-#: src/curses_client/curses_client.c:2129
+#: src/curses_client/curses_client.c:2158
 msgid "Players currently logged on:-"
 msgstr "Jogadores atualmente logados:-"
 
 #. Display of drug prices (%tde="drugs" by default)
-#: src/curses_client/curses_client.c:2304
+#: src/curses_client/curses_client.c:2333
 #, c-format
 msgid "Hey dude, the prices of %tde here are:"
 msgstr "Ei carinha, os preços de %tde aqui estão:"
 
 #. List of individual drug names for selection (%tde="Opium" etc.
 #. by default)
-#: src/curses_client/curses_client.c:2315
+#: src/curses_client/curses_client.c:2344
 msgid "%/Drug Select/%c. %tde"
 msgstr "%c. %tde"
 
-#: src/curses_client/curses_client.c:2360
+#: src/curses_client/curses_client.c:2389
 msgid "Cannot install SIGWINCH interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGWINCH!"
 
-#: src/curses_client/curses_client.c:2377
+#: src/curses_client/curses_client.c:2406
 msgid "Hey there! What's your name? "
 msgstr "Ei carinha, qual seu nome? "
 
 #. Prompts for "normal" actions in curses client
-#: src/curses_client/curses_client.c:2421
+#: src/curses_client/curses_client.c:2451
 msgid "Will you B>uy"
 msgstr "Você irá C>omprar"
 
-#: src/curses_client/curses_client.c:2423
+#: src/curses_client/curses_client.c:2453
 msgid ", S>ell"
 msgstr ", V>ender"
 
-#: src/curses_client/curses_client.c:2425
+#: src/curses_client/curses_client.c:2455
 msgid ", D>rop"
 msgstr ", L>argar"
 
-#: src/curses_client/curses_client.c:2427
+#: src/curses_client/curses_client.c:2457
 msgid ", T>alk, P>age"
 msgstr ", F>alar, P>agear"
 
-#: src/curses_client/curses_client.c:2428
+#: src/curses_client/curses_client.c:2458
 msgid ", L>ist"
 msgstr ", J>ogadores"
 
-#: src/curses_client/curses_client.c:2430
+#: src/curses_client/curses_client.c:2460
 msgid ", F>ight"
 msgstr ", L>utar"
 
-#: src/curses_client/curses_client.c:2432
+#: src/curses_client/curses_client.c:2462
 msgid ", J>et"
 msgstr ", I>r"
 
-#: src/curses_client/curses_client.c:2434
+#: src/curses_client/curses_client.c:2464
 msgid ", or Q>uit? "
 msgstr ", ou S>air? "
 
 #. Prompts for actions during fights in curses client
-#: src/curses_client/curses_client.c:2443
+#: src/curses_client/curses_client.c:2473
 msgid "Do you "
 msgstr "Você quer "
 
-#: src/curses_client/curses_client.c:2446
+#: src/curses_client/curses_client.c:2476
 msgid "F>ight, "
 msgstr "L>utar, "
 
-#: src/curses_client/curses_client.c:2448
+#: src/curses_client/curses_client.c:2478
 msgid "S>tand, "
 msgstr "F>icar paradão, "
 
-#: src/curses_client/curses_client.c:2452
+#: src/curses_client/curses_client.c:2482
 msgid "R>un, "
 msgstr "C>orrer, "
 
 #. (%tde = "drugs" by default here)
-#: src/curses_client/curses_client.c:2455
+#: src/curses_client/curses_client.c:2485
 #, c-format
 msgid "D>eal %tde, "
 msgstr "T>raficar %tde, "
 
-#: src/curses_client/curses_client.c:2456
+#: src/curses_client/curses_client.c:2486
 msgid "or Q>uit? "
 msgstr "ou S>air? "
 
-#: src/curses_client/curses_client.c:2521
+#: src/curses_client/curses_client.c:2554
 msgid "Connection to server lost! Reverting to single player mode"
 msgstr "Conexão com o servidor perdida! Revertendo para o modo de um jogador"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (B>uy, S>ell, D>rop, T>alk, P>age,
 #. L>ist, F>ight, J>et, Q>uit)
-#: src/curses_client/curses_client.c:2546
+#: src/curses_client/curses_client.c:2581
 msgid "BSDTPLFJQ"
 msgstr "CVLFPJDLIS"
 
 #. N.B. You must keep the order of these keys the same as the
 #. original when you translate (D>eal drugs, R>un, F>ight, S>tand,
 #. Q>uit)
-#: src/curses_client/curses_client.c:2552
+#: src/curses_client/curses_client.c:2587
 msgid "DRFSQ"
 msgstr "TCLFS"
 
-#: src/curses_client/curses_client.c:2582
+#: src/curses_client/curses_client.c:2617
 msgid "List what? P>layers or S>cores? "
 msgstr "Listar o que? J>ogadores ou P>ontuações? "
 
 #. P>layers, S>cores
-#: src/curses_client/curses_client.c:2584
+#: src/curses_client/curses_client.c:2619
 msgid "PS"
 msgstr "JP"
 
-#: src/curses_client/curses_client.c:2712
+#: src/curses_client/curses_client.c:2724 src/gui_client/gtk_client.c:2275
+#: src/serverside.c:828
+#, fuzzy, c-format
+msgid "Cannot initialize networking: %s"
+msgstr "Não é possível alcançar a rede"
+
+#: src/curses_client/curses_client.c:2758
 msgid "Play again? "
 msgstr "Jogar novamente? "
 
@@ -2049,8 +2045,8 @@ msgid "Inventory"
 msgstr "Inventário"
 
 #: src/gui_client/gtk_client.c:342 src/gui_client/gtk_client.c:726
-#: src/gui_client/gtk_client.c:2631 src/gui_client/gtk_client.c:2767
-#: src/gui_client/gtk_client.c:3062 src/gui_client/gtk_client.c:3114
+#: src/gui_client/gtk_client.c:2639 src/gui_client/gtk_client.c:2775
+#: src/gui_client/gtk_client.c:3070 src/gui_client/gtk_client.c:3122
 msgid "_Close"
 msgstr "_Fechar"
 
@@ -2226,13 +2222,13 @@ msgstr "Vender que quantidade?"
 msgid "Drop how many?"
 msgstr "Largar que quantidade?"
 
-#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2403
-#: src/gui_client/gtk_client.c:2572 src/gui_client/gtk_client.c:3008
+#: src/gui_client/gtk_client.c:1726 src/gui_client/gtk_client.c:2411
+#: src/gui_client/gtk_client.c:2580 src/gui_client/gtk_client.c:3016
 #: src/gui_client/optdialog.c:1050 src/gtkport/gtkport.c:5370
 msgid "_OK"
 msgstr "_OK"
 
-#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2584
+#: src/gui_client/gtk_client.c:1733 src/gui_client/gtk_client.c:2592
 #: src/gui_client/optdialog.c:1060 src/gtkport/gtkport.c:5370
 #: src/gtkport/gtkport.c:5481
 msgid "_Cancel"
@@ -2290,54 +2286,54 @@ msgstr ""
 
 #. Title of main window in GTK+ client
 #: src/gui_client/gtk_client.c:2137 src/gui_client/gtk_client.c:2174
-#: src/winmain.c:403 src/winmain.c:412
+#: src/winmain.c:405 src/winmain.c:414
 msgid "Church Wars"
 msgstr ""
 
 #. Credits labels in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "English Translation"
 msgstr "Tradução de Portugal"
 
-#: src/gui_client/gtk_client.c:2313
+#: src/gui_client/gtk_client.c:2321
 msgid "O Batstone"
 msgstr ""
 
-#: src/gui_client/gtk_client.c:2314
+#: src/gui_client/gtk_client.c:2322
 msgid "Icons and graphics"
 msgstr "Ícones e gráficos"
 
-#: src/gui_client/gtk_client.c:2315 src/gui_client/optdialog.c:1038
+#: src/gui_client/gtk_client.c:2323 src/gui_client/optdialog.c:1038
 msgid "Sounds"
 msgstr "Sons"
 
-#: src/gui_client/gtk_client.c:2316
+#: src/gui_client/gtk_client.c:2324
 msgid "History and Research"
 msgstr "Tráfico de Drogas e Pesquisas"
 
-#: src/gui_client/gtk_client.c:2317
+#: src/gui_client/gtk_client.c:2325
 msgid "Play Testing"
 msgstr "Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2318
+#: src/gui_client/gtk_client.c:2326
 msgid "Extensive Play Testing"
 msgstr "Extensivo Teste de Jogo"
 
-#: src/gui_client/gtk_client.c:2320
+#: src/gui_client/gtk_client.c:2328
 msgid "Constructive Criticism"
 msgstr "Crítica Construtiva"
 
-#: src/gui_client/gtk_client.c:2322
+#: src/gui_client/gtk_client.c:2330
 msgid "Unconstructive Criticism"
 msgstr "Crítica não construtiva"
 
 #. Title of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2330
+#: src/gui_client/gtk_client.c:2338
 msgid "About Church Wars"
 msgstr ""
 
 #. Main content of GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2341
+#: src/gui_client/gtk_client.c:2349
 msgid ""
 "It’s AD 1095, and the Crusades are about to begin.\n"
 "As a famed Trader-Saint, Pope Urban II has\n"
@@ -2365,7 +2361,7 @@ msgid ""
 msgstr ""
 
 #. Version and copyright notice in GTK+ 'about' dialog
-#: src/gui_client/gtk_client.c:2368
+#: src/gui_client/gtk_client.c:2376
 #, c-format
 msgid ""
 "Version %s     Copyright (C) 2024  O Batstone theprawn26@gmail.com\n"
@@ -2374,134 +2370,135 @@ msgstr ""
 "Versão %s     Copyright (C) 1998-2022  Ben Webb benwebb@users.sf.net\n"
 "Church Wars está lançado sob a GNU General Public License\n"
 
-#: src/gui_client/gtk_client.c:2396
-msgid "Original Church Wars information here:"
+#: src/gui_client/gtk_client.c:2404
+#, fuzzy
+msgid "Original Church Wars information here"
 msgstr "Original Church Wars information here:"
 
 #. Title of loan shark dialog - (%Tde="The Loan Shark" by default)
-#: src/gui_client/gtk_client.c:2449 src/gui_client/gtk_client.c:2501
+#: src/gui_client/gtk_client.c:2457 src/gui_client/gtk_client.c:2509
 msgid "%/LoanShark window title/%Tde"
 msgstr "%/Título da janela do agiota/%Tde"
 
 #. Title of bank dialog - (%Tde="The Bank" by default)
-#: src/gui_client/gtk_client.c:2456 src/gui_client/gtk_client.c:2505
+#: src/gui_client/gtk_client.c:2464 src/gui_client/gtk_client.c:2513
 msgid "%/BankName window title/%Tde"
 msgstr "%/Título da janela do NomeDoBanco/%Tde"
 
-#: src/gui_client/gtk_client.c:2465
+#: src/gui_client/gtk_client.c:2473
 msgid "You must enter a positive amount of money!"
 msgstr "Você precisa entrar uma quantidade positiva de dinheiro!"
 
-#: src/gui_client/gtk_client.c:2468
+#: src/gui_client/gtk_client.c:2476
 msgid "There isn't that much money available..."
 msgstr "Não há todo este dinheiro no banco..."
 
 #. Display of player's cash in bank or loan shark dialog
-#: src/gui_client/gtk_client.c:2521
+#: src/gui_client/gtk_client.c:2529
 msgid "Cash: %P"
 msgstr "Dinheiro: %P"
 
 #. Display of player's debt in loan shark dialog
-#: src/gui_client/gtk_client.c:2527
+#: src/gui_client/gtk_client.c:2535
 msgid "Debt: %P"
 msgstr "Débito: %P"
 
 #. Display of player's bank balance in bank dialog
-#: src/gui_client/gtk_client.c:2530
+#: src/gui_client/gtk_client.c:2538
 msgid "Bank: %P"
 msgstr "Banco: %P"
 
 #. Prompt for paying back a loan
-#: src/gui_client/gtk_client.c:2538
+#: src/gui_client/gtk_client.c:2546
 msgid "Pay back:"
 msgstr "Pagar de volta:"
 
 #. Radio button selected if you want to pay money into the bank
-#: src/gui_client/gtk_client.c:2542
+#: src/gui_client/gtk_client.c:2550
 msgid "Deposit"
 msgstr "Depositar"
 
 #. Radio button selected if you want to withdraw money from the bank
-#: src/gui_client/gtk_client.c:2548
+#: src/gui_client/gtk_client.c:2556
 msgid "Withdraw"
 msgstr "Retirar"
 
 #. Button to pay back the entire loan/debt
-#: src/gui_client/gtk_client.c:2579
+#: src/gui_client/gtk_client.c:2587
 msgid "Pay all"
 msgstr "Pagar tudo"
 
 #. Title of player list dialog
-#: src/gui_client/gtk_client.c:2610
+#: src/gui_client/gtk_client.c:2618
 msgid "Player List"
 msgstr "Lista de jogadores"
 
 #. Title of talk dialog
-#: src/gui_client/gtk_client.c:2718
+#: src/gui_client/gtk_client.c:2726
 msgid "Talk to player(s)"
 msgstr "Falar com jogador(es)"
 
 #. Checkbutton set if you want to talk to all players
-#: src/gui_client/gtk_client.c:2740
+#: src/gui_client/gtk_client.c:2748
 msgid "Talk to all players"
 msgstr "Falar com todos os jogadores"
 
 #. Prompt for you to enter the message to be sent to other players
-#: src/gui_client/gtk_client.c:2746
+#: src/gui_client/gtk_client.c:2754
 msgid "Message:-"
 msgstr "Mensagem:-"
 
 #. Button to send a message to other players
-#: src/gui_client/gtk_client.c:2761
+#: src/gui_client/gtk_client.c:2769
 msgid "Send"
 msgstr "Mandar"
 
 #. Column titles for display of drugs/guns carried or available for
 #. purchase
-#: src/gui_client/gtk_client.c:2842 src/gui_client/optdialog.c:677
+#: src/gui_client/gtk_client.c:2850 src/gui_client/optdialog.c:677
 msgid "Name"
 msgstr "Nome"
 
-#: src/gui_client/gtk_client.c:2843 src/gui_client/optdialog.c:827
+#: src/gui_client/gtk_client.c:2851 src/gui_client/optdialog.c:827
 msgid "Price"
 msgstr "Preço"
 
-#: src/gui_client/gtk_client.c:2844
+#: src/gui_client/gtk_client.c:2852
 msgid "Number"
 msgstr "Número"
 
 #. Button titles for buying/selling/dropping guns or drugs
-#: src/gui_client/gtk_client.c:2847
+#: src/gui_client/gtk_client.c:2855
 msgid "_Buy ->"
 msgstr "_Comprar ->"
 
-#: src/gui_client/gtk_client.c:2848
+#: src/gui_client/gtk_client.c:2856
 msgid "<- _Sell"
 msgstr "<- _Vender"
 
-#: src/gui_client/gtk_client.c:2849
+#: src/gui_client/gtk_client.c:2857
 msgid "_Drop <-"
 msgstr "_Largar <-"
 
 #. Title of the display of available drugs/guns (%Tde = "Guns" or
 #. "Drugs" by default)
-#: src/gui_client/gtk_client.c:2856
+#: src/gui_client/gtk_client.c:2864
 msgid "%Tde here"
 msgstr "%Tde aqui"
 
 #. Title of the display of carried drugs/guns (%Tde = "Guns" or "Drugs"
 #. by default)
-#: src/gui_client/gtk_client.c:2862
+#: src/gui_client/gtk_client.c:2870
 msgid "%Tde carried"
 msgstr "%Tde carregados"
 
 #. Title of dialog for changing a player's name
-#: src/gui_client/gtk_client.c:2981
+#: src/gui_client/gtk_client.c:2989
 msgid "Change Name"
 msgstr "Mudar Nome"
 
 #. Informational text to prompt the player to change his/her name
-#: src/gui_client/gtk_client.c:2994
+#: src/gui_client/gtk_client.c:3002
 msgid ""
 "Unfortunately, somebody else is already using \"your\" name. Please change "
 "it:-"
@@ -2509,12 +2506,12 @@ msgstr "Infelizmente, alguém já está usando o \"seu\" nome. Por favor mude-o:
 
 #. Title of 'gun shop' dialog in GTK+ client (%Tde="Dan's House of Guns"
 #. by default)
-#: src/gui_client/gtk_client.c:3039
+#: src/gui_client/gtk_client.c:3047
 msgid "%/GTK GunShop window title/%Tde"
 msgstr "%/Título da janela da LojaDeArmas/%Tde"
 
 #. Title of window to display reports from spies with other players
-#: src/gui_client/gtk_client.c:3098
+#: src/gui_client/gtk_client.c:3106
 msgid "Spy reports"
 msgstr ""
 
@@ -2781,7 +2778,7 @@ msgstr "_Selecionar"
 #. Informational comment placed at the start of the Windows log file
 #. (this is used for messages printed during processing of the config
 #. files - under Unix these are just printed to stdout)
-#: src/winmain.c:329
+#: src/winmain.c:330
 msgid ""
 "# This is the Church Wars startup log, containing any\n"
 "# informative messages resulting from configuration\n"
@@ -2790,39 +2787,39 @@ msgid ""
 msgstr ""
 
 #. Title of Church Wars server window (if used)
-#: src/winmain.c:370 src/serverside.c:1614 src/serverside.c:1621
+#: src/winmain.c:371 src/serverside.c:1646 src/serverside.c:1653
 #, fuzzy
 msgid "Church Wars server"
 msgstr "servidor Church Wars encerrando."
 
 #. Title of the Windows window used for AI player output
-#: src/winmain.c:391
+#: src/winmain.c:392
 msgid "Church Wars AI"
 msgstr ""
 
 #. Things that can "happen" to your spies - look for strings containing
 #. "The spy %s!" to see how these strings are used.
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "escaped"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "defected"
 msgstr ""
 
-#: src/serverside.c:74
+#: src/serverside.c:76
 msgid "was attacked"
 msgstr ""
 
 #. The two keys that are valid answers to the Attack/Evade question. If
 #. you wish to translate them, do so in the same order as they given here.
 #. You will also need to translate the answers given by the clients.
-#: src/serverside.c:80
+#: src/serverside.c:82
 msgid "AE"
 msgstr ""
 
 #. Help on various general server commands
-#: src/serverside.c:130
+#: src/serverside.c:132
 #, c-format
 msgid ""
 "Church Wars server version %s commands and settings\n"
@@ -2861,29 +2858,29 @@ msgstr ""
 "Variáveis válidas são mostradas abaixo:-\n"
 "\n"
 
-#: src/serverside.c:161
+#: src/serverside.c:163
 #, c-format
 msgid "Failed to connect to metaserver at %s (%s)"
 msgstr "Falha ao conectar com metaservidor em %s (%s)"
 
-#: src/serverside.c:169 src/serverside.c:1051
+#: src/serverside.c:171 src/serverside.c:1081
 #, c-format
 msgid "MetaServer: %s"
 msgstr "Meta servidor: %s"
 
-#: src/serverside.c:199
+#: src/serverside.c:201
 msgid ""
 "Attempt to connect to metaserver too frequently - waiting for next timeout"
 msgstr ""
 "Tentativa de conectar ao metaservidor muito frequentemente - aguardando o "
 "próximo timeout"
 
-#: src/serverside.c:241
+#: src/serverside.c:243
 #, c-format
 msgid "Waiting for connect to metaserver at %s..."
 msgstr "Aguardando para conectar ao metaservidor em %s..."
 
-#: src/serverside.c:299
+#: src/serverside.c:301
 msgid ""
 "You appear to be using an extremely old (version 1.4.x) client.^While this "
 "will probably work, many of the newer features^will be unsupported. Get the "
@@ -2891,21 +2888,21 @@ msgid ""
 "io/."
 msgstr ""
 
-#: src/serverside.c:308
+#: src/serverside.c:310
 msgid ""
 "Warning: your client is too old to support all of this^server's features. "
 "For the full \"experience\", get^the latest version of Church Wars from "
 "the^website, https://dopewars.sourceforge.io/."
 msgstr ""
 
-#: src/serverside.c:386
+#: src/serverside.c:388
 #, c-format
 msgid "MaxClients (%d) exceeded - dropping connection"
 msgstr "MaxClientes (%d) excedido - cancelando conexão"
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:392
+#: src/serverside.c:394
 msgid ""
 "Sorry, but this server has a limit of 1 player, which has been reached."
 "^Please try connecting again later."
@@ -2915,7 +2912,7 @@ msgstr ""
 
 #. Message sent to a player if the
 #. server is full
-#: src/serverside.c:399
+#: src/serverside.c:401
 #, c-format
 msgid ""
 "Sorry, but this server has a limit of %d players, which has been reached."
@@ -2927,60 +2924,66 @@ msgstr ""
 #. A player changed their name during the game (unusual, and not
 #. really properly supported anyway) - notify all players of the
 #. change
-#: src/serverside.c:415
+#: src/serverside.c:417
 #, c-format
 msgid "%s will now be known as %s"
 msgstr "%s será conhecido como %s"
 
-#: src/serverside.c:439
+#: src/serverside.c:442
 #, c-format
 msgid "%s: DENIED travel to invalid location %s"
 msgstr "%s: RECUSADO ir para local inválido %s"
 
 #. Message displayed when a player reaches their maximum number of
 #. turns
-#: src/serverside.c:458
+#: src/serverside.c:462
 msgid "Your trading time is up..."
 msgstr "Seu tempo de tráfico acabou..."
 
 #. A player has tried to jet to a new location, but we don't allow
 #. them to. (e.g. they're still fighting someone, or they're
 #. supposed to be dead)
-#: src/serverside.c:477
+#: src/serverside.c:481
 #, c-format
 msgid "%s: DENIED travel to %s"
 msgstr "%s: RECUSADO ir para %s"
 
-#: src/serverside.c:531
+#: src/serverside.c:536
 #, c-format
 msgid "Unknown message: %s:%c:%s:%s"
 msgstr "Mensagem desconhecida: %s:%c:%s:%s"
 
-#: src/serverside.c:683
+#: src/serverside.c:688
 #, c-format
 msgid "Maintaining pid file %s"
 msgstr "Mantendo o arquivo pid %s"
 
-#: src/serverside.c:689
+#: src/serverside.c:694
 #, c-format
 msgid "Cannot create pid file %s: %s"
 msgstr "Não foi possível criar o arquivo pid %s: %s"
 
-#: src/serverside.c:737
-#, c-format
-msgid "Cannot create server (listening) socket (%s) Aborting."
-msgstr ""
+#: src/serverside.c:742
+#, fuzzy, c-format
+msgid "Cannot create server (listening) socket (%s)"
+msgstr "Não foi possível criar o arquivo pid %s: %s"
 
 #: src/serverside.c:755
 #, c-format
-msgid "Cannot bind to port %u (%s) Aborting."
-msgstr ""
-
-#: src/serverside.c:763
-msgid "Cannot listen to network socket. Aborting."
+msgid "Cannot set socket reuse option (%s)"
 msgstr ""
 
 #: src/serverside.c:769
+#, c-format
+msgid "Cannot bind to port %u (%s)"
+msgstr ""
+
+#: src/serverside.c:778
+#, fuzzy
+msgid "Cannot listen to network socket."
+msgstr "Não é possível alcançar a rede"
+
+#: src/serverside.c:785
 #, c-format
 msgid ""
 "Church Wars server version %s ready and waiting for connections on port %d."
@@ -2989,84 +2992,84 @@ msgstr ""
 "na porta %d."
 
 #. Warning messages displayed if we fail to trap various signals
-#: src/serverside.c:782
+#: src/serverside.c:798
 msgid "Cannot install SIGUSR1 interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGUSR1!"
 
-#: src/serverside.c:788
+#: src/serverside.c:804
 msgid "Cannot install SIGHUP interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGHUP!"
 
-#: src/serverside.c:794
+#: src/serverside.c:810
 msgid "Cannot install SIGINT interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGINT!"
 
-#: src/serverside.c:797
+#: src/serverside.c:813
 msgid "Cannot install SIGTERM interrupt handler!"
 msgstr "Não foi possível instalar o sinal de interrupção SIGTERM!"
 
-#: src/serverside.c:802
+#: src/serverside.c:818
 msgid "Cannot install pipe handler!"
 msgstr "Não foi possível instalar o sinal de pipe!"
 
-#: src/serverside.c:866
+#: src/serverside.c:887
 #, c-format
 msgid "Configuration file saved OK as %s\n"
 msgstr "Arquivo de configuração gravado OK como %s\n"
 
-#: src/serverside.c:898
+#: src/serverside.c:919
 msgid "Users currently logged on:-\n"
 msgstr "Usuários atualmente logados:-\n"
 
-#: src/serverside.c:906
+#: src/serverside.c:927
 msgid "No users currently logged on!\n"
 msgstr "Nenhum usuário atualmente logado!\n"
 
-#: src/serverside.c:910
+#: src/serverside.c:931
 #, c-format
 msgid "Pushing %s\n"
 msgstr "Retirando %s\n"
 
-#: src/serverside.c:913 src/serverside.c:924
+#: src/serverside.c:934 src/serverside.c:945
 msgid "No such user!\n"
 msgstr "Este usuário não existe!\n"
 
 #. The named user has been removed from the server following
 #. a "kill" command
-#: src/serverside.c:919
+#: src/serverside.c:940
 #, c-format
 msgid "%s killed\n"
 msgstr "%s morto\n"
 
-#: src/serverside.c:926
+#: src/serverside.c:947
 msgid "Unknown command - try \"help\" for help...\n"
 msgstr "Comando desconhecido - tente \"help\" para ajuda...\n"
 
-#: src/serverside.c:945
+#: src/serverside.c:966
 #, c-format
 msgid "got connection from %s"
 msgstr "conexão de %s"
 
-#: src/serverside.c:958
+#: src/serverside.c:979
 msgid "Church Wars server terminating."
 msgstr "servidor Church Wars encerrando."
 
-#: src/serverside.c:967
+#: src/serverside.c:988
 #, c-format
 msgid "%s leaves the server!"
 msgstr "%s saiu do servidor!"
 
-#: src/serverside.c:1054
+#: src/serverside.c:1084
 msgid "MetaServer: (closed)"
 msgstr "MetaServidor: (fechado)"
 
-#: src/serverside.c:1153
+#: src/serverside.c:1183
 msgid ""
 "Could not set up Unix domain socket for admin connections - check "
 "permissions on /tmp!"
 msgstr ""
 
-#: src/serverside.c:1233
+#: src/serverside.c:1263
 #, fuzzy, c-format
 msgid ""
 "Church Wars server version %s ready for admin commands; try \"help\" for help"
@@ -3074,41 +3077,51 @@ msgstr ""
 "servidor Church Wars versão %s pronto para comandos de administração; tente "
 "\\\"help\\\" para ajuda"
 
-#: src/serverside.c:1236
+#: src/serverside.c:1266
 msgid "New admin connection"
 msgstr "Nova conexão de administrador"
 
-#: src/serverside.c:1247
+#: src/serverside.c:1277
 #, c-format
 msgid "Admin command: %s"
 msgstr "Comando de administração: %s"
 
-#: src/serverside.c:1253
+#: src/serverside.c:1283
 msgid "Admin connection closed"
 msgstr "Conexão de administrador encerrada"
 
-#: src/serverside.c:1502 src/serverside.c:1521 src/serverside.c:1528
-#: src/serverside.c:1668
+#: src/serverside.c:1534 src/serverside.c:1553 src/serverside.c:1560
+#: src/serverside.c:1700
 msgid "Failed to set NT Service status"
 msgstr ""
 
-#: src/serverside.c:1508
+#: src/serverside.c:1540
 msgid "Failed to post service notification message"
 msgstr ""
 
-#: src/serverside.c:1517
+#: src/serverside.c:1549
 msgid "Failed to register service handler"
 msgstr ""
 
-#: src/serverside.c:1543
+#: src/serverside.c:1575
 msgid "Failed to start NT Service"
 msgstr ""
 
-#: src/serverside.c:1632
+#: src/serverside.c:1664
 msgid "Command:"
 msgstr "Comando:"
 
-#: src/serverside.c:1833
+#: src/serverside.c:1819
+#, fuzzy, c-format
+msgid "Cannot write to high score file: %s."
+msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
+
+#: src/serverside.c:1881
+#, c-format
+msgid "Invalid score file version '%s'"
+msgstr ""
+
+#: src/serverside.c:1925
 #, fuzzy, c-format
 msgid ""
 "Cannot truncate backup (%s) of the\n"
@@ -3117,24 +3130,24 @@ msgstr ""
 "Não foi possível criar backup (%s) do\n"
 "arquivo de recordes: %s."
 
-#: src/serverside.c:1857
+#: src/serverside.c:1949
 #, c-format
 msgid "Error reading scores from %s."
 msgstr "Não foi possível ler o arquivo de pontuação %s"
 
-#: src/serverside.c:1862
+#: src/serverside.c:1954
 #, fuzzy, c-format
 msgid "Cannot truncate high score file %s: %s."
 msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
 
-#: src/serverside.c:1868
+#: src/serverside.c:1960
 #, c-format
 msgid ""
 "The high score file %s has been converted to the new format.\n"
 "A backup of the old file has been created as %s.\n"
 msgstr ""
 
-#: src/serverside.c:1877
+#: src/serverside.c:1969
 #, c-format
 msgid ""
 "Cannot create backup (%s) of the\n"
@@ -3143,12 +3156,12 @@ msgstr ""
 "Não foi possível criar backup (%s) do\n"
 "arquivo de recordes: %s."
 
-#: src/serverside.c:1886
+#: src/serverside.c:1978
 #, c-format
 msgid "Cannot open high score file %s: %s."
 msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
 
-#: src/serverside.c:1991
+#: src/serverside.c:2083
 #, c-format
 msgid ""
 "Cannot open high score file %s.\n"
@@ -3160,7 +3173,7 @@ msgstr ""
 "Veja se você tem permissões para acessar este arquivo e diretório, ou\n"
 "especifique um arquivo de pontuação alternativo com a opção -f."
 
-#: src/serverside.c:2005
+#: src/serverside.c:2097
 #, c-format
 msgid ""
 "%s does not appear to be a valid\n"
@@ -3170,129 +3183,129 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/serverside.c:2015
+#: src/serverside.c:2107
 msgid ""
 "Errors were encountered during the reading of the configuration file.\n"
 "As as result, some settings may not work as expected. Please consult the\n"
 "file \"churchwars-log.txt\" for further details."
 msgstr ""
 
-#: src/serverside.c:2020
+#: src/serverside.c:2112
 msgid ""
 "Errors were encountered during the reading of the configuration\n"
 "file. As a result, some settings may not work as expected. Please see the\n"
 "messages on standard output for further details."
 msgstr ""
 
-#: src/serverside.c:2066
+#: src/serverside.c:2170
 #, fuzzy, c-format
 msgid "Cannot truncate high score file: %s."
 msgstr "Não foi possível abrir o arquivo de recordes %s: %s."
 
-#: src/serverside.c:2104
+#: src/serverside.c:2211
 #, c-format
 msgid "Unable to read high score file %s"
 msgstr "Não foi possível ler o arquivo de pontuação %s"
 
-#: src/serverside.c:2134
+#: src/serverside.c:2241
 msgid "Congratulations! You made the high scores!"
 msgstr "Parabéns! Você entrou nas melhores pontuações!"
 
-#: src/serverside.c:2147
+#: src/serverside.c:2254
 msgid "You didn't even make the high score table..."
 msgstr "Você nem conseguiu entrar na tabela de melhores pontuações..."
 
-#: src/serverside.c:2168
+#: src/serverside.c:2275
 #, c-format
 msgid "Unable to write high score file %s"
 msgstr "Não foi possível escrever no arquivo de pontuação %s"
 
-#: src/serverside.c:2195
+#: src/serverside.c:2302
 msgid "(R.I.P.)"
 msgstr "(R.I.P.)"
 
-#: src/serverside.c:2257
+#: src/serverside.c:2364
 #, c-format
 msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
 msgstr "A moça próxima a você no metrô lhe diz,^ \"%s\"%s"
 
-#: src/serverside.c:2261
+#: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"
 msgstr "^    (ao menos, você -pensa- que foi o que ela disse)"
 
-#: src/serverside.c:2264
+#: src/serverside.c:2371
 #, c-format
 msgid "You hear someone playing %s"
 msgstr "Você escuta alguém tocando %s"
 
-#: src/serverside.c:2273 src/serverside.c:2282 src/serverside.c:2291
-#: src/serverside.c:2300
+#: src/serverside.c:2380 src/serverside.c:2389 src/serverside.c:2398
+#: src/serverside.c:2407
 #, c-format
 msgid "YN^Would you like to visit %tde?"
 msgstr "YN^Você gostaria de visitar %tde?"
 
-#: src/serverside.c:2313
+#: src/serverside.c:2420
 msgid "YN^^Would you like to hire a %tde for %P?"
 msgstr "YN^^Você gostaria de contratar %tde por %P?"
 
-#: src/serverside.c:2326
+#: src/serverside.c:2433
 #, c-format
 msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s está aqui!^Você Ataca, ou Evacua?"
 
-#: src/serverside.c:2393
+#: src/serverside.c:2500
 msgid "No Amirs or weapons!"
 msgstr "Nenhum policial ou armas!"
 
-#: src/serverside.c:2399
+#: src/serverside.c:2506
 msgid "Amirs cannot attack other amirs!"
 msgstr "Policiais não podem atacar outros policiais"
 
-#: src/serverside.c:2441
+#: src/serverside.c:2548
 msgid "Players are already in a fight!"
 msgstr "Jogadores já estão brigando!"
 
-#: src/serverside.c:2443
+#: src/serverside.c:2550
 msgid "Players are already in separate fights!"
 msgstr "Jogadores estão em lutas separadas!"
 
-#: src/serverside.c:2448
+#: src/serverside.c:2555
 msgid "Cannot start fight - no weapons to use!"
 msgstr "Não é possível começar briga - nenhuma arma para usar!"
 
-#: src/serverside.c:2677
+#: src/serverside.c:2784
 msgid "You're dead! The Angels carry you home. Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2908
+#: src/serverside.c:3015
 msgid "You're dead! Game over."
 msgstr "Você está morto! Jogo acabado."
 
-#: src/serverside.c:2917
+#: src/serverside.c:3024
 msgid "YN^Do you pay a doctor %P to sew you up?"
 msgstr ""
 
-#: src/serverside.c:2946
+#: src/serverside.c:3056
 msgid "You were mugged outside Holy Mass!"
 msgstr "Você foi massacrado no metrô!"
 
-#: src/serverside.c:2958
+#: src/serverside.c:3068
 #, c-format
 msgid "You meet a Christian friend! He gives you %d %tde."
 msgstr "Você encontrou um amigo! Ele lhe dá %d %tde."
 
-#: src/serverside.c:2964
+#: src/serverside.c:3074
 #, c-format
 msgid "You meet a Christian friend! You give him %d %tde."
 msgstr "Você encontrou um amigo! Você dá a ele %d %tde."
 
 #. Debugging message: we would normally have a random drug-related
 #. event here, but "Sanitized" mode is turned on
-#: src/serverside.c:2977
+#: src/serverside.c:3087
 msgid "Sanitized away a RandomOffer"
 msgstr "Sanitized away a RandomOffer"
 
-#: src/serverside.c:2982
+#: src/serverside.c:3092
 #, c-format
 msgid ""
 "Seljuk dogs chase you for %d streets! You dropped some %tde! That's a drag!"
@@ -3300,42 +3313,42 @@ msgstr ""
 "Cães policiais caçam você por %d blocos! Você largou algum %tde! Que droga, "
 "cara!"
 
-#: src/serverside.c:2999
+#: src/serverside.c:3109
 #, c-format
 msgid "You find %d %tde on a dead Seljuk Amir in the street!"
 msgstr "Você acha %d %tde em um cara morto no metrô!"
 
-#: src/serverside.c:3014
+#: src/serverside.c:3124
 #, c-format
 msgid "Your Priest made bread with some of your %tde! It was great!"
 msgstr "Sua mamãe fez comida com algumas de suas %tde! Ela estava ótima!"
 
-#: src/serverside.c:3024
+#: src/serverside.c:3134
 msgid ""
 "YN^There are some spices that smell like Amstelredamme here!^It looks good! "
 "Will you smoke it? "
 msgstr ""
 "YN^Tem uma maconha aqui que cheira muito bem!^Parece bom! Você irá fumar? "
 
-#: src/serverside.c:3031
+#: src/serverside.c:3141
 #, c-format
 msgid "You stopped to %s."
 msgstr "Você parou para %s."
 
-#: src/serverside.c:3056
+#: src/serverside.c:3166
 msgid "YN^Would you like to buy a bigger trenchcoat for %P?"
 msgstr "YN^Você gostaria de comprar um colete por %P?"
 
-#: src/serverside.c:3064
+#: src/serverside.c:3174
 msgid "YN^Hey trader! I'll help carry your %tde for a mere %P. Yes or no?"
 msgstr ""
 "YN^Ei carinha! Eu posso ajudar você carregar %tde por meros %P. Sim ou não?"
 
-#: src/serverside.c:3077
+#: src/serverside.c:3187
 msgid "YN^Would you like to buy a %tde for %P?"
 msgstr "YN^Você gostaria de comprar %tde por %P?"
 
-#: src/serverside.c:3262
+#: src/serverside.c:3378
 msgid ""
 "You hallucinated for three days from travel exhaustion!^Then you died "
 "because your brain disintegrated!"
@@ -3343,29 +3356,29 @@ msgstr ""
 "Você alucionou por três dias na viagem mais louca que você jamais imaginou!"
 "^Então você morreu porque seu cérebro desintegrou!"
 
-#: src/serverside.c:3288
+#: src/serverside.c:3404
 #, c-format
 msgid "Too late - %s has just left!"
 msgstr "Muito tarde - %s já saiu!"
 
-#: src/serverside.c:3362
+#: src/serverside.c:3479
 #, c-format
 msgid "The Amirs spot you dropping %tde!"
 msgstr ""
 
-#: src/serverside.c:3602
+#: src/serverside.c:3721
 msgid "Sending pending updates to the metaserver..."
 msgstr "Enviando atualizações pendentes ao metaservidor..."
 
-#: src/serverside.c:3607
+#: src/serverside.c:3726
 msgid "Sending reminder message to the metaserver..."
 msgstr ""
 
-#: src/serverside.c:3616
+#: src/serverside.c:3735
 msgid "Player removed due to idle timeout"
 msgstr "Jogador removido por ter ficado muito tempo parado"
 
-#: src/serverside.c:3629
+#: src/serverside.c:3748
 msgid "Player removed due to connect timeout"
 msgstr "Jogador removido por expiração da conexão"
 
@@ -3485,243 +3498,251 @@ msgstr ""
 msgid "Bad metaserver reply \"%s\""
 msgstr ""
 
-#: src/message.c:473
+#: src/message.c:486
 msgid "No servers listed on metaserver"
 msgstr "Nenhum servidor listado no metaservidor"
 
-#: src/message.c:1122
+#: src/message.c:989
+#, fuzzy, c-format
+msgid "Cannot initialize networking (%s)!"
+msgstr "Não foi possível instalar o sinal de pipe!"
+
+#: src/message.c:1169
 msgid "Do you run?"
 msgstr "Você corre?"
 
-#: src/message.c:1125
+#: src/message.c:1172
 msgid "Do you run, or fight?"
 msgstr "Você corre, ou luta?"
 
-#: src/message.c:1321
+#: src/message.c:1368
 msgid "pitifully armed"
 msgstr "muito pouco armado"
 
-#: src/message.c:1322
+#: src/message.c:1369
 msgid "lightly armed"
 msgstr "pouco armado"
 
-#: src/message.c:1323
+#: src/message.c:1370
 msgid "moderately well armed"
 msgstr "moderamente bem armado"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "heavily armed"
 msgstr "pesadamente armado"
 
-#: src/message.c:1324
+#: src/message.c:1371
 msgid "armed to the 3rd heavens"
 msgstr "armado até os dentes"
 
-#: src/message.c:1328
+#: src/message.c:1375
 #, c-format
 msgid "%s - %s - is chasing you!"
 msgstr "%s - %s - está te perseguindo, cara!"
 
-#: src/message.c:1332
+#: src/message.c:1379
 #, c-format
 msgid "%s and %d %tde - %s - are chasing you!"
 msgstr "%s e %d %tde - %s - estão te perseguindo, cara!"
 
-#: src/message.c:1336
+#: src/message.c:1383
 #, c-format
 msgid "%s arrives with %d %tde, %s!"
 msgstr "%s chega com %d %tde, %s!"
 
-#: src/message.c:1343
+#: src/message.c:1390
 #, c-format
 msgid "%s stands and takes it"
 msgstr "%s fica e pega"
 
-#: src/message.c:1345
+#: src/message.c:1392
 msgid "You stand there like a dummy."
 msgstr "Você fica parado como um panaca."
 
-#: src/message.c:1350
+#: src/message.c:1397
 #, c-format
 msgid "%s tries to get away, but fails."
 msgstr "%s tenta escapar, mas falha."
 
-#: src/message.c:1353
+#: src/message.c:1400
 msgid "Panic! You can't get away!"
 msgstr "Pânico! Você não consegue escapar!"
 
-#: src/message.c:1362
+#: src/message.c:1409
 #, c-format
 msgid "%s has got away to %tde!"
 msgstr "%s fugiu para %tde!"
 
-#: src/message.c:1365
+#: src/message.c:1412
 #, c-format
 msgid "%s has got away!"
 msgstr "%s fugiu!"
 
-#: src/message.c:1368
+#: src/message.c:1415
 msgid "You got away!"
 msgstr "Você fugiu!"
 
-#: src/message.c:1374
+#: src/message.c:1421
 msgid "Weapons readied..."
 msgstr "Armas recarregadas..."
 
-#: src/message.c:1379
+#: src/message.c:1426
 #, c-format
 msgid "%s attacks %s... and fails!"
 msgstr "%s atira em %s... e erra!"
 
-#: src/message.c:1382
+#: src/message.c:1429
 #, c-format
 msgid "%s swings at you... and misses!"
 msgstr "%s atira em você... e erra!"
 
-#: src/message.c:1385
+#: src/message.c:1432
 #, c-format
 msgid "You missed %s!"
 msgstr "Você errou em %s!"
 
-#: src/message.c:1391
+#: src/message.c:1438
 #, c-format
 msgid "%s charges %s to death."
 msgstr "%s mata %s."
 
-#: src/message.c:1394
+#: src/message.c:1441
 #, c-format
 msgid "%s attacks at %s and kills a %tde!"
 msgstr "%s atira em %s e mata uma %tde!"
 
-#: src/message.c:1397
+#: src/message.c:1444
 #, c-format
 msgid "%s attacks %s."
 msgstr "%s é %s"
 
-#: src/message.c:1402
+#: src/message.c:1449
 #, c-format
 msgid "%s killed you! The Angels carry you home."
 msgstr ""
 
-#: src/message.c:1406
+#: src/message.c:1453
 #, c-format
 msgid "%s charges at you... and kills a %tde!"
 msgstr "%s atirou em você... e matou uma %tde!"
 
-#: src/message.c:1409
+#: src/message.c:1456
 #, c-format
 msgid "%s hits you!"
 msgstr "%s acertou você, carinha!"
 
-#: src/message.c:1413
+#: src/message.c:1460
 #, c-format
 msgid "You killed %s!"
 msgstr "Você matou %s!"
 
-#: src/message.c:1415
+#: src/message.c:1462
 #, c-format
 msgid "You hit %s, and killed a %tde!"
 msgstr "Você acertou %s, e matou uma %tde!"
 
-#: src/message.c:1418
+#: src/message.c:1465
 #, c-format
 msgid "You hit %s!"
 msgstr "Você acertou %s!"
 
-#: src/message.c:1421
+#: src/message.c:1468
 msgid " You find %P on the body!"
 msgstr "Você achou %P no corpo!"
 
-#: src/message.c:1423
+#: src/message.c:1470
 msgid " You prayerfully loot the body!"
 msgstr " Você roubou o corpo!"
 
-#: src/network.c:90
-#, c-format
-msgid "Cannot initialize WinSock (%s)!"
-msgstr ""
-
 #. SOCKS version 5 error messages
-#: src/network.c:400
+#: src/network.c:402
 msgid "SOCKS server general failure"
 msgstr ""
 
-#: src/network.c:401
+#: src/network.c:403
 msgid "Connection denied by SOCKS ruleset"
 msgstr ""
 
-#: src/network.c:402
+#: src/network.c:404
 msgid "SOCKS: Network unreachable"
 msgstr ""
 
-#: src/network.c:403
+#: src/network.c:405
 msgid "SOCKS: Host unreachable"
 msgstr ""
 
-#: src/network.c:404
+#: src/network.c:406
 msgid "SOCKS: Connection refused"
 msgstr ""
 
-#: src/network.c:405
+#: src/network.c:407
 msgid "SOCKS: TTL expired"
 msgstr ""
 
-#: src/network.c:406
+#: src/network.c:408
 msgid "SOCKS: Command not supported"
 msgstr ""
 
-#: src/network.c:407
+#: src/network.c:409
 msgid "SOCKS: Address type not supported"
 msgstr ""
 
-#: src/network.c:408
+#: src/network.c:410
 msgid "SOCKS server rejected all offered methods"
 msgstr ""
 
-#: src/network.c:409
+#: src/network.c:411
 msgid "Unknown SOCKS address type returned"
 msgstr ""
 
-#: src/network.c:410
+#: src/network.c:412
 msgid "SOCKS authentication failed"
 msgstr ""
 
-#: src/network.c:411
+#: src/network.c:413
 msgid "SOCKS authentication canceled by user"
 msgstr ""
 
 #. SOCKS version 4 error messages
-#: src/network.c:414
+#: src/network.c:416
 msgid "SOCKS: Request rejected or failed"
 msgstr ""
 
-#: src/network.c:415
+#: src/network.c:417
 msgid "SOCKS: Rejected - unable to contact identd"
 msgstr ""
 
-#: src/network.c:417
+#: src/network.c:419
 msgid "SOCKS: Rejected - identd reports different user-id"
 msgstr ""
 
 #. SOCKS errors due to protocol violations
-#: src/network.c:420
+#: src/network.c:422
 msgid "Unknown SOCKS reply code"
 msgstr ""
 
-#: src/network.c:421
+#: src/network.c:423
 msgid "Unknown SOCKS reply version code"
 msgstr ""
 
-#: src/network.c:422
+#: src/network.c:424
 msgid "Unknown SOCKS server version"
 msgstr ""
 
-#: src/network.c:428
+#: src/network.c:430
 #, c-format
 msgid "SOCKS error code %d"
 msgstr ""
 
-#: src/network.c:1308
+#: src/network.c:1220
+msgid "curl_multi_init failed"
+msgstr ""
+
+#: src/network.c:1228
+msgid "curl_easy_init failed"
+msgstr ""
+
+#: src/network.c:1417
 msgid "Could not init curl"
 msgstr ""
 
@@ -3740,22 +3761,31 @@ msgstr ""
 "Conexão estabelecida; use Ctrl-D para fechar sua sessão.\n"
 "\n"
 
-#: src/configfile.c:177 src/configfile.c:232 src/configfile.c:240
-#: src/configfile.c:265
+#: src/configfile.c:219 src/configfile.c:296 src/configfile.c:303
+#: src/configfile.c:328
 #, fuzzy, c-format
 msgid "Could not write to config file: %s"
 msgstr "Não foi possível abrir o arquivo %s: %s"
 
-#: src/configfile.c:225
+#: src/configfile.c:236
+#, fuzzy, c-format
+msgid "Could not stat config file: %s"
+msgstr "Não foi possível abrir o arquivo %s: %s"
+
+#: src/configfile.c:242 src/configfile.c:276
+msgid "Config file too large"
+msgstr ""
+
+#: src/configfile.c:289
 #, fuzzy, c-format
 msgid "Could not truncate config file: %s"
 msgstr "Não foi possível abrir o arquivo %s: %s"
 
-#: src/configfile.c:306
+#: src/configfile.c:369
 msgid "Could not determine local config file to write to"
 msgstr ""
 
-#: src/configfile.c:318
+#: src/configfile.c:381
 #, c-format
 msgid "Could not open file %s: %s"
 msgstr "Não foi possível abrir o arquivo %s: %s"
@@ -3794,116 +3824,121 @@ msgid ""
 "Using Socks.Auth.User and Socks.Auth.Password for SOCKS5 authentication\n"
 msgstr ""
 
-#: src/AIPlayer.c:153
+#: src/AIPlayer.c:154
 #, c-format
 msgid "AI Player started; attempting to contact server at %s:%d..."
 msgstr "Jogador com IA iniciado; tentando contactar servidor em %s:%d..."
 
-#: src/AIPlayer.c:214
+#: src/AIPlayer.c:166
+#, fuzzy
+msgid "Failed to connect to server; cleaning up."
+msgstr "Falha ao conectar com metaservidor em %s (%s)"
+
+#: src/AIPlayer.c:220
 msgid "AI Player terminated OK.\n"
 msgstr "Jogador com IA terminado OK\n"
 
-#: src/AIPlayer.c:219
+#: src/AIPlayer.c:225
 msgid "Connection to server lost!\n"
 msgstr "Conexão com o servidor perdida!\n"
 
-#: src/AIPlayer.c:244
+#: src/AIPlayer.c:253
 #, c-format
 msgid "Using name %s\n"
 msgstr "Usando o nome %s\n"
 
-#: src/AIPlayer.c:326
+#: src/AIPlayer.c:335
 msgid "Players in this game:-\n"
 msgstr "Jogadores neste jogo:-\n"
 
-#: src/AIPlayer.c:345
+#: src/AIPlayer.c:354
 #, c-format
 msgid "%s joins the game.\n"
 msgstr "%s entra no jogo.\n"
 
-#: src/AIPlayer.c:349
+#: src/AIPlayer.c:358
 #, c-format
 msgid "%s has left the game.\n"
 msgstr "%s sai do jogo.\n"
 
-#: src/AIPlayer.c:353
+#: src/AIPlayer.c:362
 msgid "Travelling to %tde with %P cash and %P debt\n"
 msgstr "Indo para %tde com %P de dinheiro e %P de débito\n"
 
-#: src/AIPlayer.c:377
+#: src/AIPlayer.c:386
 msgid "AI Player killed. Terminating normally.\n"
 msgstr "Jogador com IA morto. Terminando normalmente.\n"
 
-#: src/AIPlayer.c:398
+#: src/AIPlayer.c:407
 msgid "Game time is up. Leaving game.\n"
 msgstr "Tempo de jogo esgotando. Saindo do jogo.\n"
 
-#: src/AIPlayer.c:401
+#: src/AIPlayer.c:410
 msgid "AI Player pushed from the server.\n"
 msgstr "Jogador com IA retirado do servidor.\n"
 
-#: src/AIPlayer.c:404
+#: src/AIPlayer.c:413
 msgid "The server has terminated.\n"
 msgstr "O servidor foi acabado.\n"
 
-#: src/AIPlayer.c:473
+#: src/AIPlayer.c:482
 msgid "Selling %d %tde at %P\n"
 msgstr "Vendendo %d %tde por %P\n"
 
-#: src/AIPlayer.c:488
+#: src/AIPlayer.c:497
 msgid "Buying %d %tde at %P\n"
 msgstr "Comprando %d %tde por %P\n"
 
-#: src/AIPlayer.c:521
+#: src/AIPlayer.c:530
 msgid "Buying a %tde for %P at the Hall of Arms\n"
 msgstr "Comprando um %tde por %P na loja de armas\n"
 
-#: src/AIPlayer.c:576
+#: src/AIPlayer.c:587
 msgid "Debt of %P paid off to loan collector\n"
 msgstr "Débito de %P pago ao agiota\n"
 
-#: src/AIPlayer.c:608
+#: src/AIPlayer.c:619
 #, c-format
 msgid "Loan collector located at %s\n"
 msgstr "Agiota localizado em %s\n"
 
-#: src/AIPlayer.c:616
+#: src/AIPlayer.c:627
 #, c-format
 msgid "Gun shop located at %s\n"
 msgstr "Loja de armas localizada em %s\n"
 
-#: src/AIPlayer.c:624
+#: src/AIPlayer.c:635
 #, c-format
 msgid "Pub located at %s\n"
 msgstr "Bordel localizado em %s\n"
 
-#: src/AIPlayer.c:639
+#: src/AIPlayer.c:650
 #, c-format
 msgid "Bank located at %s\n"
 msgstr "Banco localizado em %s\n"
 
 #. Random messages to send from the AI player to other players
-#: src/AIPlayer.c:668
+#: src/AIPlayer.c:679
 msgid "Call yourselves Trader-Saints?"
 msgstr "Vocês se acham traficantes de drogas?"
 
-#: src/AIPlayer.c:669
+#: src/AIPlayer.c:680
 msgid "A trained monkey could do better..."
 msgstr "Um macaco treinado pode até fazer melhor..."
 
-#: src/AIPlayer.c:670
+#: src/AIPlayer.c:681
 msgid "Think you're wise enough to deal with the likes of me?"
 msgstr "Acham que vocês são duros o bastante para lidar com gente como eu?"
 
-#: src/AIPlayer.c:671
+#: src/AIPlayer.c:682
 msgid "Zzzzz... are you trading in pennies or what?"
 msgstr "Zzzzz... vocês estão traficando doces ou o que?"
 
-#: src/AIPlayer.c:672
+#: src/AIPlayer.c:683
 msgid "Reckon I'll just have to kill you for your own good."
 msgstr "Droga eu vou ter que simplesmente atirar em você pro seu próprio bem."
 
-#: src/AIPlayer.c:685
+#: src/AIPlayer.c:699
 msgid ""
 "This binary has been compiled without networking support, and thus cannot "
 "act as an AI player.\n"
@@ -3913,19 +3948,27 @@ msgstr ""
 "como um jogador com IA.\n"
 "Recompile passando a opção --enable-networking para o script configure."
 
-#: src/sound.c:220
-#, c-format
-msgid "Failed to open sound driver \"%s\"."
-msgstr "Não foi possível abrir o arquivo %s"
+#~ msgid "Cannot get metaserver details"
+#~ msgstr "Não foi possível obter detalhes do metaservidor"
 
-#: src/sound.c:229
+#, fuzzy
+#~ msgid "Could not start multiplayer Church Wars"
+#~ msgstr "Não foi possível iniciar o Church Wars em multiplayer"
+
+#~ msgid "connection to server failed"
+#~ msgstr "a conexão com o servidor falhou"
+
 #, c-format
-msgid ""
-"Invalid plugin \"%s\" selected.\n"
-"(%s available; now using \"%s\".)"
-msgstr ""
-"Plugin inválido \"%s\" selecionado.\n"
-"(%s disponível; agora usando \"%s\".)"
+#~ msgid "Failed to open sound driver \"%s\"."
+#~ msgstr "Não foi possível abrir o arquivo %s"
+
+#, c-format
+#~ msgid ""
+#~ "Invalid plugin \"%s\" selected.\n"
+#~ "(%s available; now using \"%s\".)"
+#~ msgstr ""
+#~ "Plugin inválido \"%s\" selecionado.\n"
+#~ "(%s disponível; agora usando \"%s\".)"
 
 #~ msgid "The command used to start your web browser"
 #~ msgstr "O comando usado para iniciar seu navegador"

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -763,8 +763,8 @@ struct LOCATION DefaultLocation[] = {
 
 struct DRUGS Drugs = { NULL, NULL, 0, 0 };
 struct DRUGS DefaultDrugs = {
-  /* Messages displayed for drug busts, etc. */
-  N_("Seljuk Amirs made a big %tde bust! Prices are outrageous!"),
+  /* Messages displayed for drug raids, etc. */
+  N_("Seljuk Amirs pulled off a big %tde raid! Prices are outrageous!"),
   N_("Traders are buying %tde at ridiculous prices!"),
   4, 4
 };

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -745,7 +745,7 @@ void CompleteHighScoreDialog(gboolean AtEnd)
 
 /* 
  * Prints an information message in the display area of the GTK+ client.
- * This area is used for displaying drug busts, messages from other
+ * This area is used for displaying drug raids, messages from other
  * players, etc. The message is passed in as the string "text".
  */
 void PrintMessage(char *text, char *tagname)

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -3199,7 +3199,7 @@ enum DealType {
 };
 
 /* 
- * Generates drug prices and drug busts etc. for player "To"
+ * Generates drug prices and drug raids etc. for player "To"
  * "Deal" is an array of size NumDrug.
  */
 static void GenerateDrugsHere(Player *To, enum DealType *Deal)
@@ -3260,7 +3260,7 @@ static void GenerateDrugsHere(Player *To, enum DealType *Deal)
 /* 
  * Sends details of drug prices to player "To". If "DisplayBusts"
  * is TRUE, also regenerates drug prices and sends details of
- * special events such as drug busts.
+ * special events such as drug raids.
  */
 void SendDrugsHere(Player *To, gboolean DisplayBusts)
 {


### PR DESCRIPTION
## Summary
- Update event message to "Seljuk Amirs pulled off a big %tde raid!" and adjust related comments
- Document `Drugs.ExpensiveStr1` example using "raid" wording
- Regenerate translation templates and update locale files with new msgid

## Testing
- `msgfmt -c *.po`
- `strings /tmp/en_GB.gmo | rg 'Seljuk Amirs'`

------
https://chatgpt.com/codex/tasks/task_e_689ed2ba8ea0832694c017f9e1422abb