### PR TITLE
Adjust Food price range for balance

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -739,7 +739,7 @@ struct DRUG DefaultDrug[] = {
   {N_("Weapons"), 1500, 4400, FALSE, FALSE, ""},
   {N_("Horses"), 540, 1250, FALSE, TRUE, ""},
   {N_("True Cross splinters"), 1000, 2500, FALSE, FALSE, ""},
-  {N_("Food"), 220, 700, FALSE, FALSE, ""},
+  {N_("Food"), 40, 120, FALSE, FALSE, ""},
   {N_("Silk"), 630, 1300, FALSE, FALSE, ""},
   {N_("Gold"), 800, 1600, FALSE, TRUE, ""},
   {N_("Holy Scriptures"), 315, 890, TRUE, FALSE,


### PR DESCRIPTION
## Summary
- Reduce Food commodity default price range from 220–700 to 40–120

## Testing
- `python3 tests/test_gun_balance.py`
- Attempted `gcc tests/test_sell_items.c -Isrc \`pkg-config --cflags --libs glib-2.0\`` (missing glib-2.0)
- Attempted `apt-get update` to install build dependencies (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689eea93940483268cf35ad118660008