### PR TITLE
Adjust cleric pricing and scaling

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -569,14 +569,16 @@ current game turn.</dd>
 <dd>Sets the price to pay a cleric to tip off the cops to another player to be
 <i>$1,500</i>.</dd>
 
-<dt><b>Cleric.MinPrice=<i>2500</i></b></dt>
-<dd>Sets the minimum price for a cleric at the Rough Pub to be <i>$2,500</i>.
-Note that prices for clerics "on the street" (i.e. those that are offered
+<dt><b>Cleric.MinPrice=<i>10000</i></b></dt>
+<dd>Sets the minimum price for a cleric at the Rough Pub to be <i>$10,000</i>.
+Prices for clerics increase by ten percent for each cleric you already
+employ. Prices for clerics "on the street" (i.e. those that are offered
 by random events) are produced by dividing the normal cleric price
-distribution by 3, i.e. about one-third of the shop price range (~$800–$1,700 by default).</dd>
+distribution by 3, i.e. about one-third of the shop price range
+(~$3,300–$6,600 by default).</dd>
 
-<dt><b>Cleric.MaxPrice=<i>5000</i></b></dt>
-<dd>Sets the maximum price for a cleric to <i>$5,000</i>.</dd>
+<dt><b>Cleric.MaxPrice=<i>20000</i></b></dt>
+<dd>Sets the maximum price for a cleric to <i>$20,000</i>.</dd>
 
 <dt><b>SubwaySaying= <i>{ "First saying", "Second saying",
 "Third saying" }</i></b></dt>

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -227,9 +227,10 @@ struct PRICES Prices = {
 };
 
 /* Default price range for hiring clerics.  Renamed from the old "Bitch"
- * terminology to reflect the updated in-game nomenclature. */
+ * terminology to reflect the updated in-game nomenclature. Lowered to make
+ * hiring a cleric feasible earlier in the game. */
 struct CLERIC Cleric = {
-  20000, 40000
+  10000, 20000
 };
 
 #ifdef NETWORKING

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2413,8 +2413,11 @@ void SendEvent(Player *To)
       break;
     case E_HIREBITCH:
       if (To->IsAt + 1 == RoughPubLoc) {
-        /* Random pub price for a cleric, defaults to 40k-120k */
-        To->Bitches.Price = prandom(Cleric.MinPrice, Cleric.MaxPrice);
+        /* Random pub price for a cleric, defaults to 10k-20k. Prices
+         * increase by 10% for each cleric already carried. */
+        price_t base_price = prandom(Cleric.MinPrice, Cleric.MaxPrice);
+        To->Bitches.Price = base_price +
+            (base_price * To->Bitches.Carried) / (price_t)10;
         text =
             dpg_strdup_printf(_
                               ("YN^^Would you like to hire a %tde for %P?"),
@@ -3016,7 +3019,7 @@ void WithdrawFromCombat(Player *Play)
       } else if (CanRunHere(Defend)
                  && brandom(0, 100) > Location[Defend->IsAt].PolicePresence) {
         Defend->EventNum = E_DOCTOR;
-        /* Doctor price scales from the cleric price range (40k-120k by default) */
+        /* Doctor price scales from the cleric price range (10k-20k by default) */
         Defend->DocPrice = prandom(Cleric.MinPrice, Cleric.MaxPrice) *
             Defend->Health / 500;
         text =
@@ -3166,9 +3169,12 @@ int OfferObject(Player *To, gboolean ForceBitch)
       text = dpg_strdup_printf(_("YN^Would you like to buy a bigger "
                                  "trenchcoat for %P?"), To->Bitches.Price);
     } else {
-/* Street price is one-third of the shop price range (~13k–40k by default). */
-      To->Bitches.Price =
+/* Street price is one-third of the shop price range (~3.3k–6.6k by default).
+ * Prices increase by 10% per cleric already carried. */
+      price_t base_price =
           prandom(Cleric.MinPrice, Cleric.MaxPrice) / (price_t)3;
+      To->Bitches.Price = base_price +
+          (base_price * To->Bitches.Carried) / (price_t)10;
       text =
           dpg_strdup_printf(_
                             ("YN^Hey trader! I'll help carry your %tde for a "


### PR DESCRIPTION
## Summary
- Lower default cleric price range from 20k–40k to 10k–20k
- Scale cleric offer prices by 10% for each cleric already owned
- Document new cleric cost defaults and scaling behavior

## Testing
- `./autogen.sh` *(fails: You must have automake installed)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_689eea9a565c8326a3e8c43717a3ab2e