### PR TITLE
Replace 'drug busts' with 'drug raids' in config docs

### DIFF
--- a/doc/configfile.html
+++ b/doc/configfile.html
@@ -306,7 +306,7 @@ the game.</dd>
 
 <dt><b>Drug[<i>6</i>].MinPrice=<i>1500</i></b></dt>
 <dd>Sets the usual minimum price of the <i>6th</i> drug (in the absence of
-"special events" such as drug busts) to be <i>$1,500</i>.</dd>
+"special events" such as drug raids) to be <i>$1,500</i>.</dd>
 
 <dt><b>Drug[<i>6</i>].MaxPrice=<i>4400</i></b></dt>
 <dd>Sets the usual maximum price of drug number <i>6</i> to be


### PR DESCRIPTION
## Summary
- Clarify config file documentation by replacing "drug busts" with "drug raids"

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `pytest` *(fails: SystemExit: 0; no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689eec0d313c83268efa40905e397883