### PR TITLE
Replace 'drug busts' with 'drug raids' in docs

### DIFF
--- a/doc/help/drugs.html
+++ b/doc/help/drugs.html
@@ -24,7 +24,7 @@ sections in this window to be filled in.<p /></li>
 <p /></li>
 
 <li><b>Minimum normal price</b>: Sets the lowest price that this drug can
-be offered at, under normal circumstances (i.e. there have been no drug busts
+be offered at, under normal circumstances (i.e. there have been no drug raids
 or other special events on this day).<p /></li>
 
 <li><b>Maximum normal price</b>: Sets the highest price that this drug can


### PR DESCRIPTION
## Summary
- clarify drug pricing help text by referring to 'drug raids' instead of 'drug busts'

## Testing
- `python tests/test_gun_balance.py`
- `pytest -q` *(fails: SystemExit 0 internal error)*
- `make check` *(fails: No rule to make target 'check')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689eec11d01c8326b5c64654d67ebe88