### PR TITLE
Replace Holy Mass with The Crusader's Arms in translations

### DIFF
--- a/po/churchwars.pot
+++ b/po/churchwars.pot
@@ -3082,7 +3082,7 @@ msgstr ""
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
 msgstr ""
 
 #: src/serverside.c:2368

--- a/po/de.po
+++ b/po/de.po
@@ -3231,8 +3231,8 @@ msgstr "(R.I.P.)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "Die Lady neben dir in der U-Bahn sagte,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "Die Lady neben dir im Lokal \"Zum Kreuzritter\" sagte,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -3082,7 +3082,7 @@ msgstr ""
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
 msgstr ""
 
 #: src/serverside.c:2368

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3153,8 +3153,8 @@ msgstr ""
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr ""
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/es.po
+++ b/po/es.po
@@ -3315,8 +3315,8 @@ msgstr "(R.I.P.)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "La señorita que está junto a usted en el metro dice:^ «%s»%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "La señorita que está junto a usted en las Armas del Cruzado dice:^ «%s»%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -3310,8 +3310,8 @@ msgstr "(R.I.P.)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "La chavala que está junto a ti en el metro dice:^ «%s»%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "La chavala que está junto a ti en las Armas del Cruzado dice:^ «%s»%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3206,8 +3206,8 @@ msgstr "(Repose en Paix)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "La dame a cote de vous dans le metro dit,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "La dame à côté de vous aux Armes du Croisé dit,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -3281,8 +3281,8 @@ msgstr "(Repose en Paix)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "La madame à côté de toi dans le métro te dit,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "La madame à côté de toi aux Armes du Croisé te dit,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/nn.po
+++ b/po/nn.po
@@ -3272,8 +3272,8 @@ msgstr "(Kvil i fred.)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "Dama attmed deg på t-banen sa^ «%s»%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "Dama attmed deg på Korsfararens Våpen sa^ «%s»%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3187,8 +3187,8 @@ msgstr ""
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "Jakaś kobieta stojąca obok na dworcu powiedziała^\"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "Jakaś kobieta stojąca obok w Zbrojowni Krzyżowca powiedziała,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3226,8 +3226,8 @@ msgstr "(R.I.P.)"
 
 #: src/serverside.c:2364
 #, c-format
-msgid "The lady next to you in Holy Mass said,^ \"%s\"%s"
-msgstr "A moça próxima a você no metrô lhe diz,^ \"%s\"%s"
+msgid "The lady next to you in The Crusader's Arms said,^ \"%s\"%s"
+msgstr "A moça próxima a você nas Armas do Cruzado lhe diz,^ \"%s\"%s"
 
 #: src/serverside.c:2368
 msgid "^    (at least, you -think- that's what she said)"

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2361,7 +2361,7 @@ void SendEvent(Player *To)
         if (NumPlaying == 0)
           subwaychance = 100;
         if (brandom(0, 100) < subwaychance) {
-          text = g_strdup_printf(_("The lady next to you in Holy Mass "
+          text = g_strdup_printf(_("The lady next to you in The Crusader's Arms "
                                    "said,^ \"%s\"%s"),
                                  SubwaySaying[brandom(0, NumSubway)],
                                  brandom(0, 100) < 30 ?


### PR DESCRIPTION
## Summary
- Update subway encounter to mention The Crusader's Arms instead of Holy Mass
- Refresh translation templates and all locale catalogs with new phrasing and localized pub name

## Testing
- `for f in po/*.po; do lang=$(basename $f .po); msgfmt -c "$f" -o /tmp/$lang.mo; done`
- `make check` *(fails: No rule to make target 'check')*
- `pytest` *(internal error: SystemExit 0)*

------
https://chatgpt.com/codex/tasks/task_e_689ef211d7048326bfe5c3add3597e57