### PR TITLE
Show profit or loss on drug sales in GTK client

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -1567,6 +1567,24 @@ static void DealOKCallback(GtkWidget *widget, gpointer data)
   text = g_strdup_printf("drug^%d^%d", DealDialog.DrugInd,
                          data == BT_BUY ? amount : -amount);
 
+  if (data != BT_BUY && HaveAbility(ClientData.Play, A_DRUGVALUE)) {
+    Player *Play = ClientData.Play;
+    gint ind = DealDialog.DrugInd;
+    price_t avg = 0;
+    price_t sale_price = Play->Drugs[ind].Price;
+
+    if (Play->Drugs[ind].Carried > 0)
+      avg = Play->Drugs[ind].TotalValue / Play->Drugs[ind].Carried;
+
+    price_t profit = (price_t)amount * (sale_price - avg);
+    char *pstr = FormatPrice(profit >= 0 ? profit : -profit);
+    gchar *msg =
+        g_strdup_printf(profit >= 0 ? _("Profit: %s") : _("Loss: %s"), pstr);
+    PrintMessage(msg, NULL);
+    g_free(msg);
+    g_free(pstr);
+  }
+
   gtk_widget_destroy(DealDialog.dialog);
 
   SendClientMessage(ClientData.Play, C_NONE, C_BUYOBJECT, NULL, text);


### PR DESCRIPTION
## Summary
- Compute and display profit or loss when selling drugs if the player has drug-value tracking enabled.
- Continue to send the existing `C_BUYOBJECT` message after closing the dialog.

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*
- `make` *(fails: No targets specified and no makefile found)*
- `make -C src` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689efd6cb78c8326b49ae649df43958c