### PR TITLE
Handle high score read failures

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# Unreleased
+- Server checks for high score read failures and sends an empty score list if the
+  high score file cannot be read. The file is created automatically if it is
+  missing.
+
 # 1.6.2 - 2022-06-26
 - The text-mode client should now support Unicode input when in UTF-8
   locales, e.g. allowing player names containing accented characters
@@ -113,7 +118,7 @@
   shortcuts; now fixed.
 - configure should now work properly if GLib 2.0 is installed but
   GTK2.0 is not
-- Norwegian Nynorsk translation added by Åsmund
+- Norwegian Nynorsk translation added by smund
 - If dopewars is run setuid/setgid, it will now only use this privilege
   to open the default (hard-coded) high score file; it will not open
   a user-specified high score file with privilege

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Once you're done, you can safely delete the RPM, tarball and churchwars
 directory. The churchwars binary is all you need!
 
 Church Wars stores its high score files by default in `/usr/local/var/churchwars.sco`.
-This will be created by `make install` or by RPM installation. Use the `-f`
-command-line option to specify an alternative score file.
+The server creates this file automatically if it is missing and sends an empty
+high score list if it cannot be read. Use the `-f` command-line option to
+specify an alternative score file.
 
 ## Windows installation
 

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2207,8 +2207,18 @@ void SendHighScores(Player *Play, gboolean EndGame, char *Message)
   int i, j, InList = -1;
 
   text = g_string_new("");
+  ensure_scorefile_ready(HiScoreFile);
   if (!HighScoreRead(ScoreFP, MultiScore, AntiqueScore, TRUE)) {
     g_warning(_("Unable to read high score file %s"), HiScoreFile);
+    if (EndGame && Message)
+      SendPrintMessage(NULL, C_NONE, Play, Message);
+    SendServerMessage(NULL, C_NONE, C_STARTHISCORE, Play, NULL);
+    SendServerMessage(NULL, C_NONE, C_ENDHISCORE, Play,
+                      EndGame ? "end" : NULL);
+    if (!EndGame)
+      SendDrugsHere(Play, FALSE);
+    g_string_free(text, TRUE);
+    return;
   }
   if (Message) {
     g_string_assign(text, Message);


### PR DESCRIPTION
## Summary
- create the high score file if missing and bail out cleanly when reading fails
- document automatic high-score file creation and failure behavior

## Testing
- `pytest -q` *(fails: SystemExit in tests/test_gun_balance.py)*
- `python tests/test_gun_balance.py`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689f1a1bedbc8326aa5e81985dbab976