### PR TITLE
Fix overlapping copy and guard network writes

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -941,24 +941,33 @@ void CommitWriteBuffer(NetworkBuffer *NetBuf, ConnBuf *conn,
 gboolean QueueMessageForSend(NetworkBuffer *NetBuf, gchar *data)
 {
   gchar *addpt;
-  size_t addlen;
+  size_t msglen;
   ConnBuf *conn;
 
   conn = &NetBuf->WriteBuf;
 
   if (!data)
     return FALSE;
-  addlen = strlen(data) + 1;
-  addpt = ExpandWriteBuffer(conn, addlen, &NetBuf->error);
+
+  msglen = strlen(data);
+  /* Refuse excessively large messages which would overflow the
+   * write buffer or wrap around the size calculations. */
+  if (msglen >= MAXWRITEBUF ||
+      (size_t)conn->DataPresent + msglen + 1 > MAXWRITEBUF) {
+    SetError(&NetBuf->error, ET_CUSTOM, E_FULLBUF, NULL);
+    return FALSE;
+  }
+
+  addpt = ExpandWriteBuffer(conn, msglen + 1, &NetBuf->error);
   if (!addpt) {
     g_warning("Failed to expand write buffer for outgoing message");
     return FALSE;
   }
 
-  memcpy(addpt, data, addlen);
-  addpt[addlen - 1] = NetBuf->Terminator;
+  memcpy(addpt, data, msglen);
+  addpt[msglen] = NetBuf->Terminator;
 
-  CommitWriteBuffer(NetBuf, conn, addpt, addlen);
+  CommitWriteBuffer(NetBuf, conn, addpt, msglen + 1);
   return TRUE;
 }
 

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2253,7 +2253,11 @@ void SendHighScores(Player *Play, gboolean EndGame, char *Message)
         g_free(HiScore[NUMHISCORE - 1].Name);
         g_free(HiScore[NUMHISCORE - 1].Time);
         for (j = NUMHISCORE - 1; j > i; j--) {
-          memcpy(&HiScore[j], &HiScore[j - 1], sizeof(struct HISCORE));
+          /* The source and destination ranges overlap when shifting
+           * existing scores down the table.  Use memmove rather than
+           * memcpy to avoid undefined behaviour and potential memory
+           * corruption under heavy load. */
+          memmove(&HiScore[j], &HiScore[j - 1], sizeof(struct HISCORE));
         }
         memcpy(&HiScore[i], &Score, sizeof(struct HISCORE));
         break;

--- a/tests/test_writebuf.c
+++ b/tests/test_writebuf.c
@@ -1,0 +1,33 @@
+#include "network.h"
+#include <assert.h>
+#include <string.h>
+
+static void dummy_cb(NetworkBuffer *NetBuf, gboolean Read, gboolean Write,
+                     gboolean Exception, gboolean CallNow) {
+  (void)NetBuf; (void)Read; (void)Write; (void)Exception; (void)CallNow;
+}
+
+int main(void) {
+  NetworkBuffer nb;
+  InitNetworkBuffer(&nb, '\n', '\0', NULL);
+  SetNetworkBufferCallBack(&nb, dummy_cb, NULL);
+
+  char *longmsg = g_malloc(MAXWRITEBUF + 1);
+  memset(longmsg, 'x', MAXWRITEBUF);
+  longmsg[MAXWRITEBUF] = '\0';
+  gboolean ok = QueueMessageForSend(&nb, longmsg);
+  assert(ok == FALSE);
+  assert(nb.WriteBuf.DataPresent == 0);
+  g_free(longmsg);
+
+  char chunk[1024];
+  memset(chunk, 'y', sizeof(chunk)-1);
+  chunk[sizeof(chunk)-1] = '\0';
+  for (int i = 0; i < 50; i++) {
+    ok = QueueMessageForSend(&nb, chunk);
+    assert(ok == TRUE);
+  }
+  assert(nb.WriteBuf.DataPresent < MAXWRITEBUF);
+  g_free(nb.WriteBuf.Data);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- prevent overlapped high-score shifts from corrupting memory by switching to `memmove`
- add strict bounds checks when queuing outbound messages to the network buffer
- add regression test exercising write-buffer limits

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc -fsanitize=address -I./src tests/test_writebuf.c src/network.c src/error.c -DNETWORKING -o tests/test_writebuf -lcurl -lglib-2.0` *(fails: fatal error: glib.h: No such file or directory)*
- `gcc -fsanitize=address -I./src tests/test_socks5.c src/network.c src/error.c -DNETWORKING -o tests/test_socks5 -lcurl -lglib-2.0` *(fails: fatal error: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f75f4257c83269b5f40c105b85a4f