### PR TITLE
Refactor mkdir_p to handle long paths and add tests

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -48,18 +48,32 @@
 
 static int mkdir_p(const char *path) {
     if (!path || !*path) return 0;
-    char tmp[1024];
     size_t len = strlen(path);
-    if (len >= sizeof tmp) return -1;
-    strcpy(tmp, path);
-    for (char *p = tmp + 1; *p; ++p) {
+    gchar *tmp = g_malloc(len + 1);
+    if (!tmp) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (g_strlcpy(tmp, path, len + 1) >= len + 1) {
+        g_free(tmp);
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    for (gchar *p = tmp + 1; *p; ++p) {
         if (*p == '/') {
             *p = '\0';
-            if (mkdir(tmp, 0775) && errno != EEXIST) return -1;
+            if (mkdir(tmp, 0775) && errno != EEXIST) {
+                g_free(tmp);
+                return -1;
+            }
             *p = '/';
         }
     }
-    if (mkdir(tmp, 0775) && errno != EEXIST) return -1;
+    if (mkdir(tmp, 0775) && errno != EEXIST) {
+        g_free(tmp);
+        return -1;
+    }
+    g_free(tmp);
     return 0;
 }
 
@@ -67,12 +81,18 @@ int ensure_scorefile_ready(const char *path) {
     if (!path || !*path) return -1;
     const char *slash = strrchr(path, '/');
     if (slash) {
-        char dir[1024];
         size_t n = (size_t)(slash - path);
-        if (n >= sizeof dir) return -1;
-        memcpy(dir, path, n);
-        dir[n] = '\0';
-        if (mkdir_p(dir) != 0) return -1;
+        gchar *dir = g_malloc(n + 1);
+        if (!dir) {
+            errno = ENOMEM;
+            return -1;
+        }
+        g_strlcpy(dir, path, n + 1);
+        if (mkdir_p(dir) != 0) {
+            g_free(dir);
+            return -1;
+        }
+        g_free(dir);
     }
     FILE *f = fopen(path, "ab+");
     if (!f) return -1;

--- a/tests/test_long_paths.c
+++ b/tests/test_long_paths.c
@@ -1,0 +1,43 @@
+#include "configfile.h"
+#include <glib.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+int main(void) {
+    char templ[] = "/tmp/cwtestXXXXXX";
+    char *base = mkdtemp(templ);
+    assert(base);
+
+    gchar component[201];
+    memset(component, 'a', 200);
+    component[200] = '\0';
+
+    GString *path = g_string_new(base);
+    for (int i = 0; i < 10; i++) {
+        g_string_append_c(path, '/');
+        g_string_append(path, component);
+    }
+    g_string_append(path, "/score.sco");
+    assert(ensure_scorefile_ready(path->str) == 0);
+
+    GString *bad = g_string_new(base);
+    g_string_append_c(bad, '/');
+    for (int i = 0; i < 300; i++)
+        g_string_append_c(bad, 'b');
+    g_string_append(bad, "/score.sco");
+    errno = 0;
+    assert(ensure_scorefile_ready(bad->str) == -1);
+    assert(errno == ENAMETOOLONG);
+
+    GString *cmd = g_string_new(NULL);
+    g_string_printf(cmd, "rm -rf %s", base);
+    system(cmd->str);
+
+    g_string_free(cmd, TRUE);
+    g_string_free(bad, TRUE);
+    g_string_free(path, TRUE);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Dynamically allocate temporary buffers in `mkdir_p` and `ensure_scorefile_ready`
- Use `g_strlcpy` to avoid unchecked copies and return proper errors
- Add regression test for long directory names

## Testing
- `gcc -I src tests/test_long_paths.c src/configfile.c -o tests/test_long_paths $(pkg-config --cflags --libs glib-2.0) -ffunction-sections -fdata-sections -Wl,--gc-sections` *(fails: glib-2.0 not found)*
- `python3 tests/test_gun_balance.py`


------
https://chatgpt.com/codex/tasks/task_e_689f75e83b588326a76d5bec8aa7d85a