### PR TITLE
Clamp network buffer size before expansion

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -199,6 +199,12 @@ static void FreeConnBuf(ConnBuf *buf)
   InitConnBuf(buf);
 }
 
+static void ClampConnBuf(ConnBuf *buf)
+{
+  if (buf->DataPresent < 0)
+    buf->DataPresent = 0;
+}
+
 /* 
  * Initializes the passed network buffer, ready for use. Messages sent
  * or received on the buffered connection will be terminated by the
@@ -747,6 +753,7 @@ gint CountWaitingMessages(NetworkBuffer *NetBuf)
     return 0;
 
   conn = &NetBuf->ReadBuf;
+  ClampConnBuf(conn);
 
   if (conn->Data)
     for (i = 0; i < conn->DataPresent; i++) {
@@ -767,6 +774,7 @@ gchar *PeekWaitingData(NetworkBuffer *NetBuf, size_t numbytes)
   }
 
   conn = &NetBuf->ReadBuf;
+  ClampConnBuf(conn);
   if (!conn->Data || (size_t)conn->DataPresent < numbytes)
     return NULL;
   else
@@ -785,6 +793,7 @@ gchar *GetWaitingData(NetworkBuffer *NetBuf, size_t numbytes)
   }
 
   conn = &NetBuf->ReadBuf;
+  ClampConnBuf(conn);
   if (!conn->Data || (size_t)conn->DataPresent < numbytes)
     return NULL;
 
@@ -813,6 +822,7 @@ gchar *GetWaitingMessage(NetworkBuffer *NetBuf)
   gchar *NewMessage;
 
   conn = &NetBuf->ReadBuf;
+  ClampConnBuf(conn);
   if (!conn->Data || !conn->DataPresent || NetBuf->status != NBS_CONNECTED) {
     return NULL;
   }
@@ -898,6 +908,7 @@ gchar *ExpandWriteBuffer(ConnBuf *conn, size_t numbytes, LastError **error)
 {
   size_t newlen;
 
+  ClampConnBuf(conn);
   newlen = (size_t)conn->DataPresent + numbytes;
   if (newlen > MAXWRITEBUF) {
     if (error)
@@ -1093,6 +1104,7 @@ static gboolean WriteBufToWire(NetworkBuffer *NetBuf, ConnBuf *conn)
 {
   int CurrentPosition, BytesSent;
 
+  ClampConnBuf(conn);
   if (!conn->Data || !conn->DataPresent)
     return TRUE;
   if (conn->Length == MAXWRITEBUF) {

--- a/tests/test_conn_buf.c
+++ b/tests/test_conn_buf.c
@@ -1,0 +1,36 @@
+#include "network.h"
+#include <assert.h>
+#include <string.h>
+
+static void reset_connbuf(ConnBuf *buf) {
+  if (buf->Data) g_free(buf->Data);
+  buf->Data = NULL;
+  buf->Length = 0;
+  buf->DataPresent = 0;
+}
+
+int main(void) {
+  ConnBuf buf;
+  reset_connbuf(&buf);
+
+  /* Negative DataPresent should be clamped to zero */
+  buf.DataPresent = -5;
+  gchar *ptr = ExpandWriteBuffer(&buf, 16, NULL);
+  assert(ptr != NULL);
+  assert(buf.DataPresent == 0);
+  reset_connbuf(&buf);
+
+  /* Boundary: allow growth up to MAXWRITEBUF */
+  const size_t max = 65536; /* MAXWRITEBUF in network.c */
+  buf.Data = g_malloc(max);
+  buf.Length = max;
+  buf.DataPresent = max - 8;
+  ptr = ExpandWriteBuffer(&buf, 8, NULL);
+  assert(ptr == buf.Data + (max - 8));
+
+  /* Exceeding MAXWRITEBUF should fail */
+  assert(ExpandWriteBuffer(&buf, 9, NULL) == NULL);
+
+  reset_connbuf(&buf);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- prevent negative DataPresent values in connection buffers via new `ClampConnBuf`
- validate and clamp before expanding write buffers and other buffer operations
- add unit test for buffer growth limits and negative DataPresent handling

## Testing
- `python3 tests/test_gun_balance.py`
- `gcc -DNETWORKING tests/test_conn_buf.c src/network.c src/error.c -Isrc $(pkg-config --cflags --libs glib-2.0 libcurl) -o tests/test_conn_buf` *(fails: glib.h: No such file or directory)*
- `gcc -DNETWORKING tests/test_socks5.c src/network.c src/error.c -Isrc $(pkg-config --cflags --libs glib-2.0 libcurl) -o tests/test_socks5` *(fails: glib.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689f75dd75708326a0946bef4613430f