### PR TITLE
Update reload message

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1418,7 +1418,7 @@ void FormatFightMessage(Player *To, GString *text, Player *Attacker,
     break;
   case F_RELOAD:
     if (!AttackName[0]) {
-      g_string_append(text, _("Missing Pauline Letters readied..."));
+      g_string_append(text, _("Weapons readied..."));
     }
     break;
   case F_MISS:


### PR DESCRIPTION
## Summary
- replace "Missing Pauline Letters readied..." with "Weapons readied..." in reload text

## Testing
- `make check` (fails: No rule to make target 'check')
- `pytest` (fails: SystemExit in tests)


------
https://chatgpt.com/codex/tasks/task_e_689f9124c8b08326876cf9d096d80080