### PR TITLE
Rename Missing Pauline Letters list to Guns

### DIFF
--- a/src/gui_client/optdialog.c
+++ b/src/gui_client/optdialog.c
@@ -942,9 +942,9 @@ void OptDialog(GtkWidget *widget, gpointer data)
   label = gtk_label_new(_("Goods"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook), vbox2, label);
 
-  hbox = CreateList("Missing Pauline Letter", gunmembers);
+  hbox = CreateList("Gun", gunmembers);
   gtk_container_set_border_width(GTK_CONTAINER(hbox), 7);
-  label = gtk_label_new(_("Missing Pauline Letters"));
+  label = gtk_label_new(_("Weapons"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook), hbox, label);
 
   hbox = CreateList("Cop", copmembers);


### PR DESCRIPTION
## Summary
- update options dialog to create and label gun list instead of missing Pauline letters

## Testing
- `python3 tests/test_combat_disconnect.py`
- `python3 tests/test_gun_balance.py`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689f91317f3c8326947d941599e9e9e1