### PR TITLE
Replace missing slot text

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2399,7 +2399,7 @@ void display_intro(GtkWidget *widget, gpointer data)
                           "travels to survive and build a fortune for the Kingdom.\n"
                           "\n"
                           "Clerics in the Hagia Sophia add 20 space to\n"
-                          "your starting 40, grant one Missing Pauline Letter slot, and\n"
+                          "your starting 40, grant one weapon slot, and\n"
                           "take damage for you in fights. The Hall of Arms,\n"
                           "also there, prepares you for battle. The Merchant\n"
                           "Bank in Jerusalem keeps your gold safe.\n"


### PR DESCRIPTION
## Summary
- clarify introductory message: 'Missing Pauline Letter slot' changed to 'weapon slot'

## Testing
- `pytest` *(fails: SystemExit: 0 in tests/test_gun_balance.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f913817348326a1b2da8e4b3dcc09