### PR TITLE
Revert weapon messages to weapon terminology

### DIFF
--- a/po/churchwars.pot
+++ b/po/churchwars.pot
@@ -3110,7 +3110,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3126,7 +3126,7 @@ msgid "Players are already in separate fights!"
 msgstr ""
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3433,7 +3433,7 @@ msgid "You got away!"
 msgstr ""
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/de.po
+++ b/po/de.po
@@ -3259,7 +3259,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s ist schon hier!^Willst du angreifen, oder dich verdrücken?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3275,7 +3275,7 @@ msgid "Players are already in separate fights!"
 msgstr "Spieler kämpfen bereits in verschieden Kämpfen!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3590,7 +3590,7 @@ msgid "You got away!"
 msgstr "Du entkommst!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -3110,7 +3110,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3126,7 +3126,7 @@ msgid "Players are already in separate fights!"
 msgstr ""
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3433,7 +3433,7 @@ msgid "You got away!"
 msgstr ""
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3181,7 +3181,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr ""
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3197,7 +3197,7 @@ msgid "Players are already in separate fights!"
 msgstr ""
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3504,7 +3504,7 @@ msgid "You got away!"
 msgstr ""
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/es.po
+++ b/po/es.po
@@ -3343,7 +3343,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quiere Atacar o Huir?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3359,7 +3359,7 @@ msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3674,7 +3674,7 @@ msgid "You got away!"
 msgstr "¡Ha conseguido escapar!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -3338,7 +3338,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^¡%s ya está aquí!^¿Quieres Atacar o Huir?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3354,7 +3354,7 @@ msgid "Players are already in separate fights!"
 msgstr "¡Los jugadores ya están en sus propias peleas!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3669,7 +3669,7 @@ msgid "You got away!"
 msgstr "¡Has conseguido escapar!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/fr.po
+++ b/po/fr.po
@@ -3234,7 +3234,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est deja la!^Tu Attaque, or t'Evade?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3250,7 +3250,7 @@ msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont deja dans des bastons separees!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3563,7 +3563,7 @@ msgid "You got away!"
 msgstr "Tu t'est echappe!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -3309,7 +3309,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s est déjà là!^Tu Attaque, or t'Evade?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3325,7 +3325,7 @@ msgid "Players are already in separate fights!"
 msgstr "Les joueurs sont déjà dans des batailles séparées!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3641,7 +3641,7 @@ msgid "You got away!"
 msgstr "Tu t'es échappé!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/nn.po
+++ b/po/nn.po
@@ -3300,7 +3300,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s er alt her!^Vil du gå til Angrep, eller Stikka av?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3316,7 +3316,7 @@ msgid "Players are already in separate fights!"
 msgstr "Spelarane er alt i kvar sine kampar!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3628,7 +3628,7 @@ msgid "You got away!"
 msgstr "Du kom deg unna!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/pl.po
+++ b/po/pl.po
@@ -3215,7 +3215,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s już tu jest!^A>takujesz czy E>wakuujesz się?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3231,7 +3231,7 @@ msgid "Players are already in separate fights!"
 msgstr ""
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3544,7 +3544,7 @@ msgid "You got away!"
 msgstr ""
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3254,7 +3254,7 @@ msgid "%s^%s is already here!^Do you Attack, or Evade?"
 msgstr "%s^%s está aqui!^Você Ataca, ou Evacua?"
 
 #: src/serverside.c:2500
-msgid "No Amirs or Missing Pauline Letters!"
+msgid "No Amirs or weapons!"
 msgstr ""
 
 #: src/serverside.c:2506
@@ -3270,7 +3270,7 @@ msgid "Players are already in separate fights!"
 msgstr "Jogadores estão em lutas separadas!"
 
 #: src/serverside.c:2555
-msgid "Cannot start fight - no Missing Pauline Letters to use!"
+msgid "Cannot start fight - no weapons to use!"
 msgstr ""
 
 #: src/serverside.c:2784
@@ -3583,7 +3583,7 @@ msgid "You got away!"
 msgstr "Você fugiu!"
 
 #: src/message.c:1421
-msgid "Missing Pauline Letters readied..."
+msgid "Weapons readied..."
 msgstr ""
 
 #: src/message.c:1426

--- a/src/message.c
+++ b/src/message.c
@@ -1418,7 +1418,7 @@ void FormatFightMessage(Player *To, GString *text, Player *Attacker,
     break;
   case F_RELOAD:
     if (!AttackName[0]) {
-      g_string_append(text, _("Missing Pauline Letters readied..."));
+      g_string_append(text, _("Weapons readied..."));
     }
     break;
   case F_MISS:

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2528,7 +2528,7 @@ void CopsAttackPlayer(Player *Play)
   gint CopIndex, NumDeputy, GunIndex;
 
   if (NumCop == 0 || NumGun == 0) {
-    g_warning(_("No Amirs or Missing Pauline Letters!"));
+    g_warning(_("No Amirs or weapons!"));
     return;
   }
 
@@ -2583,7 +2583,7 @@ void AttackPlayer(Player *Play, Player *Attacked)
     return;
   }
   if (NumGun == 0) {
-    g_error(_("Cannot start fight - no Missing Pauline Letters to use!"));
+    g_error(_("Cannot start fight - no weapons to use!"));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Restore "Weapons readied..." and other weapon-related messages in game logic.
- Update translation template and language files to use weapon terminology and keep "Missing Pauline Letters" only for the commodity.

## Testing
- ⚠️ `intltool-update --pot` (command not found)
- ⚠️ `make check` (no rule to make target)


------
https://chatgpt.com/codex/tasks/task_e_689f9142181083269567fc70062c989f