### PR TITLE
Replace Pauline letter references with weapon terminology in translations

### DIFF
--- a/po/churchwars.pot
+++ b/po/churchwars.pot
@@ -33,12 +33,12 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
+msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
+msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
@@ -470,19 +470,19 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
 msgstr ""
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
 msgstr ""
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
 msgstr ""
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
 msgstr ""
 
 #: src/dopewars.c:616
@@ -736,7 +736,7 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
+msgid "weapons"
 msgstr ""
 
 #: src/dopewars.c:740
@@ -2247,7 +2247,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -34,13 +34,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "Waffe"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "Waffen"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -477,20 +477,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplikationsfaktor bei extrem hohen Drogenpreisen"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Name jeder Waffe"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Preis jeder Waffe"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Platzbedarf jeder Waffe"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Schaden jeder Waffe"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -744,8 +744,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "Waffen"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2346,7 +2346,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -33,12 +33,12 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
+msgid "weapon"
 msgstr ""
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
+msgid "weapons"
 msgstr ""
 
 #. Word used for a single drug
@@ -470,19 +470,19 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
 msgstr ""
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
 msgstr ""
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
 msgstr ""
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
 msgstr ""
 
 #: src/dopewars.c:616
@@ -736,7 +736,7 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
+msgid "weapons"
 msgstr ""
 
 #: src/dopewars.c:740
@@ -2247,7 +2247,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -31,13 +31,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "weapon"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "weapons"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -468,20 +468,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr ""
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Name of each weapon"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Price of each weapon"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Space taken by each weapon"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Damage done by each weapon"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -734,8 +734,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "weapons"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2315,7 +2315,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -40,13 +40,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "arma"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -486,20 +486,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nombre de cada arma"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Precio de cada arma"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Espacio ocupado por cada arma"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Daño causado por cada arma"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -752,8 +752,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2397,7 +2397,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -40,13 +40,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "arma"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -483,20 +483,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para las drogas especialmente caras"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nombre de cada arma"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Precio de cada arma"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Espacio ocupado por cada arma"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Daño causado por cada arma"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -750,8 +750,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2392,7 +2392,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -31,13 +31,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "arme"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armes"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -469,20 +469,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicateur pour les drogues devenues cheres"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nom de chaque arme"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Prix de chaque arme"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Espace pris par chaque arme"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Dégâts infligés par chaque arme"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -735,8 +735,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armes"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2331,7 +2331,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -30,13 +30,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "arme"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armes"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -473,20 +473,20 @@ msgstr ""
 "exhorbitants"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nom de chaque arme"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Prix de chaque arme"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Espace pris par chaque arme"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Dégâts infligés par chaque arme"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -739,8 +739,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armes"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2374,7 +2374,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -45,13 +45,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "våpen"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "våpen"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -484,20 +484,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Tal som prisen på dopet skal gangast med når det er ekstra dyrt"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Namn på kvart våpen"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Pris på kvart våpen"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Plass teke av kvart våpen"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Skade gjort av kvart våpen"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -750,8 +750,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "våpen"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2367,7 +2367,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -31,13 +31,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "broń"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "bronie"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -468,20 +468,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Mnożnik dla szczególnie drogich dragów"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nazwa każdej broni"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Cena każdej broni"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Miejsce zajmowane przez każdą broń"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Obrażenia zadawane przez każdą broń"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -734,8 +734,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "bronie"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2322,7 +2322,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -32,13 +32,13 @@ msgstr ""
 
 #. Word used for a single gun
 #: src/dopewars.c:203
-msgid "Missing Pauline Letter"
-msgstr "Missing Pauline Letter"
+msgid "weapon"
+msgstr "arma"
 
 #. Word used for two or more guns
 #: src/dopewars.c:205
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #. Word used for a single drug
 #. Word used for two or more drugs
@@ -469,20 +469,20 @@ msgid "Multiplier for specially expensive drug prices"
 msgstr "Multiplicador para para os preços da droga especialmente cara"
 
 #: src/dopewars.c:600
-msgid "Name of each Missing Pauline Letter"
-msgstr "Name of each Missing Pauline Letter"
+msgid "Name of each weapon"
+msgstr "Nome de cada arma"
 
 #: src/dopewars.c:604
-msgid "Price of each Missing Pauline Letter"
-msgstr "Price of each Missing Pauline Letter"
+msgid "Price of each weapon"
+msgstr "Preço de cada arma"
 
 #: src/dopewars.c:608
-msgid "Space taken by each Missing Pauline Letter"
-msgstr "Space taken by each Missing Pauline Letter"
+msgid "Space taken by each weapon"
+msgstr "Espaço ocupado por cada arma"
 
 #: src/dopewars.c:612
-msgid "Damage done by each Missing Pauline Letter"
-msgstr "Damage done by each Missing Pauline Letter"
+msgid "Damage done by each weapon"
+msgstr "Dano causado por cada arma"
 
 #: src/dopewars.c:616
 msgid "Word used to denote a single \"cleric\""
@@ -735,8 +735,8 @@ msgid "Exiled alchemists are selling cheap medicines!"
 msgstr ""
 
 #: src/dopewars.c:739 src/gui_client/optdialog.c:947
-msgid "Missing Pauline Letters"
-msgstr "Missing Pauline Letters"
+msgid "weapons"
+msgstr "armas"
 
 #: src/dopewars.c:740
 msgid "Horses"
@@ -2351,7 +2351,7 @@ msgid ""
 "travels to survive and build a fortune for the Kingdom.\n"
 "\n"
 "Clerics in the Hagia Sophia add 20 space to\n"
-"your starting 40, grant one Missing Pauline Letter slot, and\n"
+"your starting 40, grant one weapon slot, and\n"
 "take damage for you in fights. The Hall of Arms,\n"
 "also there, prepares you for battle. The Merchant\n"
 "Bank in Jerusalem keeps your gold safe.\n"


### PR DESCRIPTION
## Summary
- Replace "Missing Pauline Letter" references with weapon terminology in translation templates and locale files
- Provide locale-specific translations for weapon-related strings
- Update narrative text to reference "weapon slots"

## Testing
- `msguniq --use-first $f | msgfmt -o ${f%.po}.gmo -`
- `python tests/test_gun_balance.py`
- `python tests/test_combat_disconnect.py`


------
https://chatgpt.com/codex/tasks/task_e_689f984f023c832695dc03bc558b854b