### PR TITLE
Balance crossbow damage with other weapons

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -733,7 +733,7 @@ struct COP DefaultCop[] = {
 struct GUN DefaultGun[] = {
   /* The names of the default guns */
   {N_("Mace"), 3000, 4, 5},
-  {N_("Crossbow"), 5400, 6, 9},
+  {N_("Crossbow"), 5400, 6, 8},
   {N_("Spear"), 2400, 3, 4},
   {N_("Battle Axe"), 4200, 5, 7}
 };


### PR DESCRIPTION
## Summary
- Reduce crossbow damage to 8 so its damage-to-space ratio aligns with other default weapons.

## Testing
- `python3 tests/test_gun_balance.py`
- `python3 tests/test_combat_disconnect.py`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689fad20e71483269e236837c40b0dc5