### PR TITLE
Verify SetBlocking results in network and server startup

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -265,7 +265,14 @@ void BindNetworkBufferToSocket(NetworkBuffer *NetBuf, int fd)
   NetBuf->ioch = g_io_channel_unix_new(fd);
 #endif
 
-  SetBlocking(fd, FALSE);       /* We only deal with non-blocking sockets */
+  if (!SetBlocking(fd, FALSE)) {
+    CloseSocket(fd);
+    g_io_channel_unref(NetBuf->ioch);
+    NetBuf->ioch = NULL;
+    NetBuf->fd = -1;
+    return;
+  }
+
   NetBuf->status = NBS_CONNECTED;       /* Assume the socket is connected */
 }
 
@@ -1631,7 +1638,12 @@ static gboolean StartConnect(int *fd, const gchar *bindaddr, gchar *RemoteHost,
       continue;
     }
 
-    SetBlocking(*fd, FALSE);
+    if (!SetBlocking(*fd, FALSE)) {
+      SetNetworkError(error);
+      CloseSocket(*fd);
+      *fd = -1;
+      continue;
+    }
 
     if (connect(*fd, rp->ai_addr, rp->ai_addrlen) == SOCKET_ERROR) {
 #ifdef CYGWIN

--- a/src/serverside.c
+++ b/src/serverside.c
@@ -774,7 +774,21 @@ static gboolean StartServer(void)
   }
 #endif
 
-  SetBlocking(ListenSock, FALSE);
+  if (!SetBlocking(ListenSock, FALSE)) {
+#ifdef CYGWIN
+    SetError(&sockerr, ET_WINSOCK, WSAGetLastError(), NULL);
+#else
+    SetError(&sockerr, ET_ERRNO, errno, NULL);
+#endif
+    errstr = g_string_new("");
+    g_string_assign_error(errstr, sockerr);
+    g_log(NULL, G_LOG_LEVEL_CRITICAL,
+          _("Cannot set listening socket non-blocking (%s)"), errstr->str);
+    g_string_free(errstr, TRUE);
+    FreeError(sockerr);
+    CloseSocket(ListenSock);
+    return FALSE;
+  }
 
   if (!BindTCPSocket(ListenSock, BindAddress, Port, &sockerr)) {
     errstr = g_string_new("");
@@ -1050,7 +1064,11 @@ static int SetupLocalSocket(void)
   if (sock == -1)
     goto cleanup;
 
-  SetBlocking(sock, FALSE);
+  if (!SetBlocking(sock, FALSE)) {
+    g_warning(_("Cannot set local socket non-blocking (%s)"),
+              g_strerror(errno));
+    goto cleanup;
+  }
 
   sockname = GetLocalSocket();
   sockdir = GetLocalSockDir();


### PR DESCRIPTION
## Summary
- Close sockets when BindNetworkBufferToSocket cannot set non-blocking mode
- Report errors if SetBlocking fails during StartConnect
- Abort server initialization when SetBlocking fails on listening or local admin sockets

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `./autogen.sh` *(fails: automake not found)*
- `./runindent.sh src/network.c src/serverside.c` *(fails: indent not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb2739e148326893e0a37d821681b