### PR TITLE
Log queuing failures for player messages

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -390,15 +390,24 @@ gboolean ReadPlayerDataFromWire(Player *Play)
   return ReadDataFromWire(&Play->NetBuf);
 }
 
-void QueuePlayerMessageForSend(Player *Play, gchar *data)
+gboolean QueuePlayerMessageForSend(Player *Play, gchar *data)
 {
+  gboolean ok;
+
   if (Conv_Needed(netconv)) {
     gchar *conv = Conv_ToExternal(netconv, data, -1);
-    QueueMessageForSend(&Play->NetBuf, conv);
+    ok = QueueMessageForSend(&Play->NetBuf, conv);
     g_free(conv);
   } else {
-    QueueMessageForSend(&Play->NetBuf, data);
+    ok = QueueMessageForSend(&Play->NetBuf, data);
   }
+
+  if (!ok) {
+    g_warning("Failed to queue message for player %s",
+              Play ? GetPlayerName(Play) : "(unknown)");
+  }
+
+  return ok;
 }
 
 gboolean WritePlayerDataToWire(Player *Play)

--- a/src/message.h
+++ b/src/message.h
@@ -90,7 +90,7 @@ gboolean PlayerHandleNetwork(Player *Play, gboolean ReadReady,
                              gboolean WriteReady, gboolean ErrorReady,
                              gboolean *DoneOK);
 gboolean ReadPlayerDataFromWire(Player *Play);
-void QueuePlayerMessageForSend(Player *Play, gchar *data);
+gboolean QueuePlayerMessageForSend(Player *Play, gchar *data);
 gboolean WritePlayerDataToWire(Player *Play);
 gchar *GetWaitingPlayerMessage(Player *Play);
 


### PR DESCRIPTION
## Summary
- return a boolean from QueuePlayerMessageForSend and log failures so message queuing problems surface

## Testing
- `pytest` *(fails: SystemExit: 0)*
- `gcc -c src/message.c -I./src` *(fails: glib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fb27a37ec83269a880179f18ffe6c