### PR TITLE
Zero Unix socket address struct before use

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -57,6 +57,7 @@ static int OpenSocket(void)
     exit(EXIT_FAILURE);
   }
 
+  memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
   if (g_strlcpy(addr.sun_path, sockname, sizeof(addr.sun_path)) >
       sizeof(addr.sun_path) - 1) {


### PR DESCRIPTION
## Summary
- Zero the Unix domain socket address structure before initializing fields

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make check` *(fails: No rule to make target 'check')*
- `pytest` *(fails: SystemExit: 0)*

------
https://chatgpt.com/codex/tasks/task_e_689fb2823a7c8326bd0a85251b6bb6e2