### PR TITLE
Handle AddPlayer allocation failures

### DIFF
--- a/src/curses_client/curses_client.c
+++ b/src/curses_client/curses_client.c
@@ -2771,7 +2771,23 @@ void CursesLoop(struct CMDLINE *cmdline)
   display_intro();
 
   Play = g_new(Player, 1);
-  FirstClient = AddPlayer(0, Play, FirstClient);
+  {
+    GSList *tmp_list = AddPlayer(0, Play, FirstClient);
+    if (!tmp_list) {
+      g_warning(_("Unable to allocate memory for new player"));
+      g_free(Play->Guns);
+      g_free(Play->Drugs);
+      g_free(Play->Name);
+      g_free(Play);
+      end_curses();
+#ifdef NETWORKING
+      if (MetaConn.h && MetaConn.multi)
+        CurlCleanup(&MetaConn);
+#endif
+      return;
+    }
+    FirstClient = tmp_list;
+  }
   do {
     ok = Curses_DoGame(Play);
     if (ok)

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -906,17 +906,12 @@ GSList *AddPlayer(int fd, Player *NewPlayer, GSList *First)
   NewPlayer->Guns = (Inventory *)g_try_malloc0(NumGun * sizeof(Inventory));
   if (!NewPlayer->Guns) {
     g_warning("Unable to allocate guns for new player");
-    g_free(NewPlayer->Name);
-    g_free(NewPlayer);
-    return First;
+    return NULL;
   }
   NewPlayer->Drugs = (Inventory *)g_try_malloc0(NumDrug * sizeof(Inventory));
   if (!NewPlayer->Drugs) {
     g_warning("Unable to allocate drugs for new player");
-    g_free(NewPlayer->Name);
-    g_free(NewPlayer->Guns);
-    g_free(NewPlayer);
-    return First;
+    return NULL;
   }
   NewPlayer->Turn = 1;
   NewPlayer->date =

--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2200,7 +2200,18 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   /* Create the main player */
   ClientData.Play = g_new(Player, 1);
-  FirstClient = AddPlayer(0, ClientData.Play, FirstClient);
+  {
+    GSList *tmp_list = AddPlayer(0, ClientData.Play, FirstClient);
+    if (!tmp_list) {
+      g_warning(_("Unable to allocate memory for new player"));
+      g_free(ClientData.Play->Guns);
+      g_free(ClientData.Play->Drugs);
+      g_free(ClientData.Play->Name);
+      g_free(ClientData.Play);
+      return TRUE;
+    }
+    FirstClient = tmp_list;
+  }
   if (PlayerName && PlayerName[0]) {
     SetPlayerName(ClientData.Play, PlayerName);
   }


### PR DESCRIPTION
## Summary
- Return NULL on player allocation failures instead of freeing the player
- Abort curses and GTK client setup when player allocation fails

## Testing
- `pytest` *(fails: SystemExit 0 during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689fb3f582888326a2251bd7d50d0c61