### PR TITLE
Handle invalid player dates

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2555,6 +2555,21 @@ void GetDateString(GString *str, Player *Play)
     return;
   }
 
+  if (!Play->date || !g_date_valid(Play->date)) {
+    if (g_date_valid_dmy(StartDate.day, StartDate.month, StartDate.year)) {
+      if (Play->date == NULL) {
+        Play->date =
+            g_date_new_dmy(StartDate.day, StartDate.month, StartDate.year);
+      } else {
+        g_date_set_dmy(Play->date, StartDate.day, StartDate.month,
+                       StartDate.year);
+      }
+    } else {
+      g_string_printf(str, "Turn %d", Play->Turn);
+      return;
+    }
+  }
+
   turn = g_strdup_printf("%d", Play->Turn);
   g_string_assign(str, Names.Date);
   while ((pt = strstr(str->str, "%T")) != NULL) {


### PR DESCRIPTION
## Summary
- Guard `GetDateString` against NULL or invalid `Player->date`
- Fallback to start date or turn string when date is unusable

## Testing
- `pytest -q` *(fails: SystemExit in tests/test_gun_balance.py)*
- `gcc -Isrc tests/test_turn_progress.c src/dopewars.c -Dmain=dopewars_main $(pkg-config --cflags --libs glib-2.0) -o /tmp/test_turn_progress` *(fails: Package glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb3f72d08832688d90528d08afdb9