### PR TITLE
Adjust GTK default window size for goods list

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -2212,7 +2212,7 @@ gboolean GtkLoop(int *argc, char **argv[],
 
   /* Title of main window in GTK+ client */
   gtk_window_set_title(GTK_WINDOW(window), _("Church Wars"));
-  gtk_window_set_default_size(GTK_WINDOW(window), 700, 450);
+  gtk_window_set_default_size(GTK_WINDOW(window), 600, 550);
 
   g_signal_connect(G_OBJECT(window), "delete_event",
                    G_CALLBACK(MainDelete), NULL);


### PR DESCRIPTION
## Summary
- Set GTK client main window default size to 600x550 for better goods list display

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09d7ee5ac83268502b9bc7a5c10d0