### PR TITLE
Expand inventory window and inventory list height

### DIFF
--- a/src/gui_client/gtk_client.c
+++ b/src/gui_client/gtk_client.c
@@ -48,7 +48,7 @@
 #define BT_DROP (GINT_TO_POINTER(3))
 
 /* Minimum height for inventory lists to avoid excessive scrolling */
-#define INVENTORY_MIN_HEIGHT 220
+#define INVENTORY_MIN_HEIGHT 300
 
 struct InventoryWidgets {
   GtkWidget *HereList, *CarriedList;
@@ -315,7 +315,7 @@ void ListInventory(GtkWidget *widget, gpointer data)
   if (IsShowingInventory)
     return;
   window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  gtk_window_set_default_size(GTK_WINDOW(window), 550, 120);
+  gtk_window_set_default_size(GTK_WINDOW(window), 500, 320);
   accel_group = gtk_accel_group_new();
   gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
 


### PR DESCRIPTION
## Summary
- increase `INVENTORY_MIN_HEIGHT` to 300 for taller inventory lists
- adjust `ListInventory` default window size to 500x320

## Testing
- ⚠️ `./autogen.sh` *(missing automake)*
- ⚠️ `sudo apt-get update` *(403: repository is not signed)*
- ⚠️ `make` *(no makefile found)*
- ⚠️ `gcc -c src/gui_client/gtk_client.c -o /tmp/gtk_client.o` *(missing header configfile.h)*

------
https://chatgpt.com/codex/tasks/task_e_68a09d8239c483269cc4dd76c28cd09b