### PR TITLE
Handle allocation failures in ReadDataFromWire

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -872,7 +872,18 @@ gboolean ReadDataFromWire(NetworkBuffer *NetBuf)
         conn->Length *= 2;
       if (conn->Length > MAXREADBUF)
         conn->Length = MAXREADBUF;
-      conn->Data = g_realloc(conn->Data, conn->Length);
+      {
+        gchar *tmp;
+
+        tmp = g_try_realloc(conn->Data, conn->Length);
+        if (!tmp) {
+          SetError(&NetBuf->error, ET_ERRNO, ENOMEM, NULL);
+          CloseSocket(NetBuf->fd);
+          NetBuf->fd = -1;
+          return FALSE;
+        }
+        conn->Data = tmp;
+      }
     }
     BytesRead = recv(NetBuf->fd, &conn->Data[CurrentPosition],
                      conn->Length - CurrentPosition, 0);


### PR DESCRIPTION
## Summary
- ensure ReadDataFromWire handles memory allocation failures gracefully

## Testing
- `./autogen.sh` *(fails: You must have automake installed to compile dopewars)*
- `./configure` *(fails: No such file or directory)*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68a0a032d7208326a84bcc69087578e7