### PR TITLE
Handle fflush errors when writing high scores

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2193,8 +2193,15 @@ gboolean HighScoreWrite(FILE *fp, struct HISCORE *MultiScore,
       ReleaseLock(fp);
       return FALSE;
     }
+    if (fflush(fp) != 0) {
+      gchar *errmsg = ErrStrFromErrno(errno);
+      g_log(NULL, G_LOG_LEVEL_CRITICAL,
+            _("Cannot flush high score file: %s."), errmsg);
+      g_free(errmsg);
+      ReleaseLock(fp);
+      return FALSE;
+    }
     ReleaseLock(fp);
-    fflush(fp);
   } else
     return FALSE;
   return TRUE;


### PR DESCRIPTION
## Summary
- Check and handle `fflush` failures when saving high scores to avoid corruption

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `python -m pytest` *(fails: SystemExit: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a034abd48326bac8bbf7b4d0455b