### PR TITLE
Handle strftime failure in high score timestamp

### DIFF
--- a/src/serverside.c
+++ b/src/serverside.c
@@ -2253,10 +2253,17 @@ void SendHighScores(Player *Play, gboolean EndGame, char *Message)
 #else
     timep = gmtime(&tim);
 #endif
-    Score.Time = g_new(char, 80);       /* Yuck! */
+    size_t tlen;
+    Score.Time = g_new0(char, 80);      /* Yuck! */
 
-    strftime(Score.Time, 80, "%d-%m-%Y", timep);
-    Score.Time[79] = '\0';
+    tlen = strftime(Score.Time, 80, "%d-%m-%Y", timep);
+    if (tlen == 0) {
+      /* Skip recording the date if conversion failed */
+      Score.Time[0] = '\0';
+    } else {
+      /* Ensure the string is explicitly NUL terminated */
+      Score.Time[tlen] = '\0';
+    }
     for (i = 0; i < NUMHISCORE; i++) {
       if (InList == -1 && (Score.Money > HiScore[i].Money ||
                            !HiScore[i].Time || HiScore[i].Time[0] == 0)) {


### PR DESCRIPTION
## Summary
- Capture strftime result when logging high score dates
- Skip recording the date if strftime fails and ensure timestamp is null-terminated

## Testing
- `./autogen.sh` *(fails: automake not installed)*
- `gcc -c src/serverside.c -o /tmp/serverside.o` *(fails: glib.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a03ce7f48326abf8246ac9f31b5b